### PR TITLE
(GAZ-64) Added OS check bypass using -o tag and manual customization with LINUX_OS_LIST

### DIFF
--- a/src/commandline/commandline.sh
+++ b/src/commandline/commandline.sh
@@ -21,6 +21,7 @@ Example 2 : sudo $0 -m cleanapps -u \$USER -d true  # delete apps, leave environ
 Example 3 : sudo $0 -m cleanall -u \$USER           # delete all apps, all Kubernetes artifacts, and server
 Example 4 : sudo $0 -m deploy -u \$USER -a phee     # install PHEE only, user \$USER
 Example 5 : sudo $0 -m deploy -u \$USER -a all      # install all apps (vNext, PHEE, and MifosX) with user \$USER
+Example 6 : sudo $0 -m deploy -u \$USER -o true     # install with OS check bypassed for non-Ubuntu distributions
 
 Options:
   -m mode ................ deploy|cleanapps|cleanall  (required)
@@ -29,6 +30,7 @@ Options:
   -e environment ......... currently, 'local' is the only value supported and is the default (optional)
   -d debug ............... enable debug mode (true|false) (optional default=false)
   -r redeploy ............ force redeployment of apps (true|false) (optional, default=true)
+  -o os_check ............. skip OS validation (true|false) (optional, default=false)
   -h|H ................... display this message
 "
 }
@@ -68,16 +70,23 @@ function validateInputs {
         showUsage
         exit 1
     fi
+    
+    if [[ -n "$os_check" && "$os_check" != "true" && "$os_check" != "false" ]]; then
+        echo "Error: Invalid value for os_check. Use 'true' or 'false'."
+        showUsage
+        exit 1
+    fi
 
     # Set default values
     environment="${environment:-local}"
     debug="${debug:-false}"
     redeploy="${redeploy:-true}"
+    os_check="${os_check:-false}"
 }
 
 
 function getOptions {
-    while getopts "m:k:d:a:e:v:u:r:hH" OPTION ; do
+    while getopts "m:k:d:a:e:v:u:r:o:hH" OPTION ; do
         case "${OPTION}" in
             m) mode="${OPTARG}" ;;
             k) k8s_distro="${OPTARG}" ;;
@@ -86,6 +95,7 @@ function getOptions {
             v) k8s_user_version="${OPTARG}" ;;
             u) k8s_user="${OPTARG}" ;;
             r) redeploy="${OPTARG}" ;;
+            o) os_check="${OPTARG}" ;;
             h|H) showUsage
                  exit 0 ;;
             *) echo "Unknown option: -${OPTION}"
@@ -134,7 +144,7 @@ function main {
     echo -e "The deployment made by this script is currently recommended for demo, test and educational purposes "
     echo -e "======================================================================================================"
     echo -e "${RESET}"
-    envSetupMain "$mode" "k3s" "1.30" "$environment"
+    envSetupMain "$mode" "k3s" "1.30" "$environment" "$os_check"
     deployApps "$mifosx_instances" "$apps" "$redeploy" 
   elif [ $mode == "cleanapps" ]; then  
     logWithVerboseCheck $debug info "Cleaning up Mifos Gazelle applications only"
@@ -142,7 +152,7 @@ function main {
   elif [ $mode == "cleanall" ]; then
     logWithVerboseCheck $debug info "Cleaning up all traces of Mifos Gazelle "
     deleteApps "$mifosx_instances" "all"
-    envSetupMain "$mode" "k3s" "1.30" "$environment"
+    envSetupMain "$mode" "k3s" "1.30" "$environment" "$os_check"
   else
     showUsage
   fi

--- a/src/environmentSetup/environmentSetup.sh
+++ b/src/environmentSetup/environmentSetup.sh
@@ -59,31 +59,41 @@ function k8s_already_installed {
     return 1
 }
 
-function set_linux_os_distro {
-
+function check_linux_os_distro {
     LINUX_VERSION="Unknown"
     if [ -x "/usr/bin/lsb_release" ]; then
-        LINUX_OS=`lsb_release --d | perl -ne 'print  if s/^.*Ubuntu.*(\d+).(\d+).*$/Ubuntu/' `
-        LINUX_VERSION=`/usr/bin/lsb_release --d | perl -ne 'print $&  if m/(\d+)/' `
-    else
-        LINUX_OS="Untested"
+        LINUX_OS=$(/usr/bin/lsb_release -si | tr '[:upper:]' '[:lower:]')
+        LINUX_VERSION=$(/usr/bin/lsb_release -sr | cut -d. -f1)
     fi
-    printf "\r==> Linux OS is [%s] " "$LINUX_OS"
+
+    if [[ " ${LINUX_OS_LIST[@]} " =~ " ${LINUX_OS} " ]]; then
+        OS_CHECK="true"
+        printf "\r==> Linux OS [%s] version [%s] is supported.\n" "$LINUX_OS" "$LINUX_VERSION"
+    else
+        OS_CHECK="false"
+        printf "\r==> Linux OS [%s] version [%s] is not supported.\n" "$LINUX_OS" "$LINUX_VERSION"
+    fi
 }
 
 function check_os_ok {
     printf "\r==> checking OS and kubernetes distro is tested with mifos-gazelle scripts\n"
-    set_linux_os_distro
+    
+    if [[ "$OS_CHECK" == "true" ]]; then
+        printf "** OS validation check skipped as requested by user **\n"
+        return
+    fi
+    
+    check_linux_os_distro
 
-    if [[ ! $LINUX_OS == "Ubuntu" ]]; then
-        printf "** Error , Mifos Gazelle is only tested with Ubuntu OS at this time   **\n"
+    if [[ ! "$OS_CHECK" == "true" ]]; then
+        printf "** Error , Mifos Gazelle is only tested with Ubuntu OS at this time, you can either pass -o true tag or add your os in LINUX_OS_LIST **\n"
         exit 1
     fi
 }
 
 function install_prerequisites {
     printf "\n\r==> Install any OS prerequisites , tools &  updates  ...\n"
-    if [[ $LINUX_OS == "Ubuntu" ]]; then
+    if [[ "$OS_CHECK" == "true" ]]; then
         printf "\rapt update \n"
         apt update > /dev/null 2>&1
 
@@ -547,7 +557,6 @@ function envSetupMain {
     K8S_VERSION=""
 
     HELM_VERSION="3.12.0"  # Feb 2023
-    OS_VERSIONS_LIST=( 20 22 )
     K8S_CURRENT_RELEASE_LIST=( "1.29" "1.30" )
     CURRENT_RELEASE="false"
     k8s_user_home=""
@@ -555,8 +564,8 @@ function envSetupMain {
     # Set the minimum amount of RAM in GB
     MIN_RAM=4
     MIN_FREE_SPACE=30
-    LINUX_OS_LIST=( "Ubuntu" )
-    UBUNTU_OK_VERSIONS_LIST=(20 22)
+    LINUX_OS_LIST=( "Ubuntu", "linuxmint" )
+    OS_VERSIONS_LIST=( 20 22 )
 
     # ensure we are running as root
     if [ "$EUID" -ne 0 ]
@@ -576,6 +585,7 @@ function envSetupMain {
     k8s_distro="$2"
     k8s_user_version="$3"
     environment="$4"
+    OS_CHECK="${5:-false}"
 
     check_arch_ok
     set_user

--- a/src/environmentSetup/environmentSetup.sh
+++ b/src/environmentSetup/environmentSetup.sh
@@ -564,7 +564,7 @@ function envSetupMain {
     # Set the minimum amount of RAM in GB
     MIN_RAM=4
     MIN_FREE_SPACE=30
-    LINUX_OS_LIST=( "Ubuntu", "linuxmint" )
+    LINUX_OS_LIST=( "ubuntu" "linuxmint" ) # values should be lower case with no spaces
     OS_VERSIONS_LIST=( 20 22 )
 
     # ensure we are running as root


### PR DESCRIPTION
This pull request introduces a new feature to bypass the OS check for non-Ubuntu distributions in the deployment script. The changes include updates to the command-line options, input validation, and environment setup functions.

Key changes:

### Command-line options and usage:

* Added a new option `-o os_check` to skip OS validation with a default value of `false` (`src/commandline/commandline.sh`).
* Updated the usage examples to include the new `-o` option for bypassing the OS check (`src/commandline/commandline.sh`).

### Input validation:

* Added validation for the new `os_check` option to ensure it accepts only `true` or `false` (`src/commandline/commandline.sh`).

### Environment setup:

* Modified the `envSetupMain` function to accept the `os_check` parameter and pass it to the relevant functions (`src/commandline/commandline.sh`, `src/environmentSetup/environmentSetup.sh`) [[1]](diffhunk://#diff-14273ea4f2c773d20525672cfd3875374d73ae7204d2c607a96d41cdebf85a3aL137-R155) [[2]](diffhunk://#diff-3b0f2e1d65bfcac6808d30f41a59e845f0f96916218aa9a0ff4ac564960c2144R588).
* Updated the `check_os_ok` function to respect the `os_check` parameter and skip OS validation if requested (`src/environmentSetup/environmentSetup.sh`).

### OS detection:

* Refactored the `set_linux_os_distro` function to `check_linux_os_distro` and improved the detection and validation of supported Linux distributions (`src/environmentSetup/environmentSetup.sh`).