### PR TITLE
Fixes Dependency Dashboard #3: chore: bump redis to 20.0.0 and console to 0.7.1

### DIFF
--- a/src/deployer/helm/infra/Chart.lock
+++ b/src/deployer/helm/infra/Chart.lock
@@ -1,0 +1,24 @@
+dependencies:
+- name: kafka
+  repository: https://charts.bitnami.com/bitnami
+  version: 19.0.2
+- name: console
+  repository: https://charts.redpanda.com
+  version: 0.7.1
+- name: mongodb
+  repository: https://charts.bitnami.com/bitnami
+  version: 13.3.1
+- name: mongo-express
+  repository: https://cowboysysop.github.io/charts/
+  version: 6.5.2
+- name: redis
+  repository: https://charts.bitnami.com/bitnami
+  version: 20.0.0
+- name: elasticsearch
+  repository: https://charts.bitnami.com/bitnami
+  version: 19.9.2
+- name: mysql
+  repository: https://charts.bitnami.com/bitnami
+  version: 9.4.5
+digest: sha256:6b681c5bc95674faffa177246e9d5cb1cc0f28a76ac6f9c8852c04d72cee8ad9
+generated: "2025-04-14T13:48:37.24791+05:30"

--- a/src/deployer/helm/infra/Chart.yaml
+++ b/src/deployer/helm/infra/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-description: Helm chart formifos-gazelle infrastructure services
+description: Helm chart for mifos-gazelle infrastructure services
 name: gazelle-infra
 version: 0.1.0
-appVersion: "kafka: 19.0.2; console: 0.6.6; mongodb: 13.3.1; mongo-express: 1.0.2; elasticsearch:19.9.2; redis: 17.11.6"
+appVersion: "kafka: 19.0.2; console: 0.7.1; mongodb: 13.3.1; mongo-express: 1.0.2; elasticsearch: 19.9.2; redis: 20.0.0"
 home: https://github.com/openMF/mifos-gazelle
 #icon: 
 sources:
@@ -23,6 +23,7 @@ dependencies:
   - dependency
   - kafka
   version: 19.0.2
+
 ## redpanda kafka console 
 - name: console
   alias: redpanda-console
@@ -33,7 +34,8 @@ dependencies:
   - dependency
   - kafka
   - redpanda
-  version: 0.6.6
+  version: 0.7.1
+
 ## MongoDB
 - name: mongodb
   alias: mongodb
@@ -44,6 +46,7 @@ dependencies:
   - dependency
   - mongodb
   version: 13.3.1
+
 ## Mongo-express
 - name: mongo-express
   alias: mongo-express
@@ -54,6 +57,7 @@ dependencies:
   - dependency
   - mongodb
   version: 6.5.2
+
 ## redis 
 - name: redis
   alias: redis 
@@ -63,7 +67,8 @@ dependencies:
   - gazelle
   - dependency
   - mongodb
-  version: 17.11.6
+  version: 20.0.0
+
 ## Elastic Search Kibana 
 - name: elasticsearch
   alias: elasticsearch
@@ -74,6 +79,7 @@ dependencies:
   - dependency
   - elasticsearch
   version: 19.9.2
+
 ## MySQL
 - name: mysql
   alias: mysql


### PR DESCRIPTION
Updates Helm chart dependencies for Redis (v20.0.0) and Console (v0.7.1).
Fixes issue #3 by updating the Helm chart versions.