### PR TITLE
optimizing memory usage of pods

### DIFF
--- a/config/ph_values.yaml
+++ b/config/ph_values.yaml
@@ -138,10 +138,18 @@ ph-ee-engine:
           ROOT: INFO
           io.camunda.operate: DEBUG
 
+      deployment:
+      extraEnv:
+        - name: JAVA_TOOL_OPTIONS
+          value: "-Xms64m -Xmx256m -XX:+UseG1GC -XX:+ExitOnOutOfMemoryError"
+          
       resources:
         requests:
-          cpu: 300m
-          memory: 400Mi
+          cpu: 200m
+          memory: 300Mi
+        limits:
+          cpu: 1
+          memory: 800Mi
 
       affinity: {}
 
@@ -327,7 +335,7 @@ ph-ee-engine:
         - minio.mifos.gazelle.test
     resources:
       requests:
-        memory: 128k
+        memory: 128Mi
     consoleIngress:
       enabled: true 
       ingressClassName: nginx 

--- a/config/ph_values.yaml
+++ b/config/ph_values.yaml
@@ -325,7 +325,9 @@ ph-ee-engine:
     ingress:
       hosts:
         - minio.mifos.gazelle.test
-
+    resources:
+      requests:
+        memory: 128k
     consoleIngress:
       enabled: true 
       ingressClassName: nginx 

--- a/src/deployer/deployer.sh
+++ b/src/deployer/deployer.sh
@@ -366,7 +366,7 @@ function deployPhHelmChartFromDir(){
   local chartDir="$2"      # Directory containing the Helm chart
   local valuesFile="$3"    # Values file for the Helm chart
   local releaseName="$PH_RELEASE_NAME"
-  local timeout="600s"
+  local timeout="1200s"
 
   # Construct install command
   local helm_cmd="helm install $releaseName $chartDir -n $namespace --wait --timeout $timeout"


### PR DESCRIPTION
Here, I am trying to optimise the pods that are utilising more space than they are supposed to.
Pods such as,
* MySQL
* Kafka
* Minio - Optimised at some point
* phee-operate - Optimised it from using ~500MiB to ~300MiB
