### PR TITLE
fix: replace Image and edit deployer

### DIFF
--- a/config/ph_values.yaml
+++ b/config/ph_values.yaml
@@ -38,14 +38,15 @@ ph-ee-engine:
   operations:
     mysql:
       enabled: true
-    resources:
-      requests:
-        cpu: 1
-        memory: 100Mi
-      limits:
-        cpu: 2
-        memory: 300Mi
-    
+      image:
+        # repository: bitnamilegacy/mysql
+        tag: "5.7"
+        debug: false
+  
+  redis:
+    image:
+      repository: bitnamilegacy/redis
+
   camunda-platform:
     global:
       elasticsearch:

--- a/src/deployer/deployer.sh
+++ b/src/deployer/deployer.sh
@@ -345,11 +345,12 @@ function checkPHEEDependencies() {
   printf "    Installing Prometheus " 
   # Install Prometheus Operator if needed as it is a PHEE dependency
   local deployment_name="prometheus-operator"
-  deployment_available=$(kubectl get deployment "$deployment_name" -n "default" -o jsonpath='{.status.conditions[?(@.type=="Available")].status}' > /dev/null 2>&1)
+  # deployment_available=$(kubectl get deployment "$deployment_name" -n "default" -o jsonpath='{.status.conditions[?(@.type=="Available")].status}' > /dev/null 2>&1)
+  deployment_available=$(kubectl get deployment "$deployment_name" -n "default" -o jsonpath='{.status.conditions[?(@.type=="Available")].status}' 2>/dev/null)
   if [[ "$deployment_available" == "True" ]]; then
     echo -e "${RED} prometheus already installed -skipping install. ${RESET}" 
     return 0
-  fi 
+  fi
   LATEST=$(curl -s https://api.github.com/repos/prometheus-operator/prometheus-operator/releases/latest | jq -cr .tag_name)
   su - $k8s_user -c "curl -sL https://github.com/prometheus-operator/prometheus-operator/releases/download/${LATEST}/bundle.yaml | kubectl create -f - " >/dev/null 2>&1
   if [ $? -eq 0 ]; then

--- a/src/deployer/helm/infra/values.yaml
+++ b/src/deployer/helm/infra/values.yaml
@@ -224,6 +224,8 @@ mongo-express:
 ## Reference: https://github.com/bitnami/charts/blob/main/bitnami/redis/values.yaml
 redis:
   enabled: true
+  image:
+    repository: bitnamilegacy/redis
   fullnameOverride: redis
   architecture: standalone
   auth:
@@ -236,6 +238,15 @@ redis:
 ############### Elasticsearch and Kibana  ####################
 elasticsearch:
   enabled: true
+  image:
+    registry: docker.io
+    repository: bitnamilegacy/elasticsearch
+    tag: 8.10.4-debian-11-r0
+  sysctlImage:
+    registry: docker.io
+    repository: bitnamilegacy/os-shell
+    tag: 11-debian-11-r90
+
   #fullnameOverride: "fredelastic"
 
   security:
@@ -312,6 +323,7 @@ mysql:
     # rootPassword: "ethieTieCh8ahv"
   image:
     tag: "5.7"
+    repository: bitnamilegacy/mysql
     debug: false
   initdbScripts:
     setup.sql: |-


### PR DESCRIPTION
### Change 1
Here, I have replaced the Bitnami images with `bitnamilegacy` images for Elasticsearch, Redis and MySQL.

### Change 2
and in the deployer.sh I have replace `> /dev/null > 2>&1` to `2>/dev/null`

Previously, the output was directed to `/dev/null`, which printed the message: 'Failed to install prometheus'. Despite Prometheus being up and running.

Now, this will only move forward if the variable `deployment_available=True`

Meaning, we can now redeploy `phee` without using `-m cleanapps`.