### PR TITLE
tom-reorg-fix2

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -6,7 +6,7 @@
 # Deployment mode: 'deploy' to set up the environment, 'cleanall' to remove it.
 mode = deploy
 # Domain used for Mifos Gazelle services (e.g., *.mifos.gazelle.test).
-GAZELLE_DOMAIN = mifos.gazelle.localhost
+GAZELLE_DOMAIN = mifos.gazelle.test
 # Version of Mifos Gazelle being deployed.
 GAZELLE_VERSION = 1.1.0
 
@@ -19,8 +19,6 @@ k8s_user = $USER
 k8s_version = 1.33
 # Path to the kubeconfig file. Defaults to ~/.kube/config if not specified.
 kubeconfig_path = ~/.kube/config
-# Helm version to install (e.g., '3.18.4').
-helm_version = 3.18.4
 # Minimum RAM required in GB.
 min_ram = 6
 # Minimum free disk space required in GB.

--- a/src/deployer/deployer.sh
+++ b/src/deployer/deployer.sh
@@ -336,7 +336,7 @@ function deleteApps() {
       "infra")
         printf "    deleting infrastructure  "
         deleteResourcesInNamespaceMatchingPattern "$INFRA_NAMESPACE"
-        printf "                               [ok]\n"
+        printf "                       [ok]\n"
 
         ;;
       *)

--- a/src/deployer/mifosx.sh
+++ b/src/deployer/mifosx.sh
@@ -27,6 +27,7 @@ function DeployMifosXfromYaml() {
     
     # Update FQDNs in values file and manifests
     echo "    Updating MifosX FQDNs manifest(s) to use domain $GAZELLE_DOMAIN"
+    update_fqdn "$MIFOSX_MANIFESTS_DIR/web-app-deployment.yaml" "mifos.gazelle.test" "$GAZELLE_DOMAIN" 
     update_fqdn "$MIFOSX_MANIFESTS_DIR/web-app-ingress.yaml" "mifos.gazelle.test" "$GAZELLE_DOMAIN" 
 
     # Restore the database dump before starting MifosX
@@ -70,11 +71,11 @@ function generateMifosXandVNextData {
     
     if [[ $result_vnext -eq 0 ]] && [[ $result_mifosx -eq 0 ]]; then
       echo -e "${BLUE}    Generating MifosX clients and accounts & registering associations with vNext Oracle ...${RESET}"
-      $RUN_DIR/src/utils/data-loading/generate-mifos-vnext-data.py > /dev/null 2>&1
+      run_as_user "$RUN_DIR/src/utils/data-loading/generate-mifos-vnext-data.py -c \"$CONFIG_FILE_PATH\" " #> /dev/null 2>&1
       
       if [[ "$?" -ne 0 ]]; then
         echo -e "${RED}Error generating vNext clients and accounts ${RESET}"
-        echo " run $RUN_DIR/src/utils/data-loading/generate-mifos-vnext-data.py to investigate"
+        echo " run $RUN_DIR/src/utils/data-loading/generate-mifos-vnext-data.py -c $CONFIG_FILE_PATH to investigate"
         return 1 
       fi
       

--- a/src/environmentSetup/environmentSetup.sh
+++ b/src/environmentSetup/environmentSetup.sh
@@ -219,7 +219,7 @@ function env_setup_local_cluster {
             install_nginx_local_cluster
             $UTILS_DIR/install-k9s.sh > /dev/null 2>&1
         fi
-        printf "\r==> local kubernetes v%s configured sucessfully for [%s]\n" \
+        printf "\r==> local kubernetes v%s configured  for %s \n" \
                   "$k8s_version" "$k8s_user"
         print_end_message
     elif [[ "$mode" == "cleanapps" ]]; then


### PR DESCRIPTION
fixes to scripts such as make-payment.sh and src/utils/data-loading/generate-mifos-vnext-data.py for when user specifies a config file using the -f flag to run.sh.  The the DNS domain for deployment and tooling such as these scripts needs to be set from this config file not the default config/config.ini

Note: also the GAZELLE_DOMAIN is now returned to the correct default of mifos.gazelle.test in the config/config.ini file 

Note for Gazelle developers , config/config.ini needs to be he gold standard so please get used to using ./runs.sh -f <your config.ini file> thus preventing future non-default changes to the default config.ini