### PR TITLE
add stability check

### DIFF
--- a/src/deployer/mifosx.sh
+++ b/src/deployer/mifosx.sh
@@ -18,6 +18,8 @@ function DeployMifosXfromYaml() {
         return
       fi
     fi 
+    run_as_user "kubectl wait --for=condition=ready pod --all -n $PH_NAMESPACE --timeout=600s"
+    wait_for_pods_ready "$PH_NAMESPACE"
     # We are deploying or redeploying => make sure things are cleaned up first
     printf "    Redeploying MifosX : Deleting existing resources in namespace %s\n" "$MIFOSX_NAMESPACE"
     deleteResourcesInNamespaceMatchingPattern "$MIFOSX_NAMESPACE"

--- a/src/deployer/phee.sh
+++ b/src/deployer/phee.sh
@@ -20,6 +20,8 @@ function deployPH(){
   printf "    Redeploying paymenthub : Deleting existing resources in namespace %s\n" "$PH_NAMESPACE"
   deleteResourcesInNamespaceMatchingPattern "$PH_NAMESPACE"
   manageElasticSecrets delete "$INFRA_NAMESPACE" "$APPS_DIR/$PHREPO_DIR/helm/es-secret"
+  run_as_user "kubectl wait --for=condition=ready pod --all -n $VNEXT_NAMESPACE --timeout=600s"
+  wait_for_pods_ready "$VNEXT_NAMESPACE"
   echo "==> Deploying PaymentHub EE"
   createNamespace "$PH_NAMESPACE"
   #checkPHEEDependencies

--- a/src/deployer/vnext.sh
+++ b/src/deployer/vnext.sh
@@ -43,8 +43,9 @@ function deployvNext() {
     applyKubeManifests "$folder" "$VNEXT_NAMESPACE" #>/dev/null 2>&1
     if [ "$index" -eq 0 ]; then
       echo -e "${BLUE}    Waiting for vnext cross cutting concerns to come up${RESET}"
-      sleep 10
-      echo -e "    Proceeding ..."
+      # run_as_user "kubectl wait --for=condition=ready pod --all -n infra --timeout=1000s"
+      wait_for_pods_ready "$INFRA_NAMESPACE"
+      echo -e "    Infra is up & running proceeding ..."
     fi
   done
 


### PR DESCRIPTION
In this PR, I have added stability checks(again!).

* I tried to use/call is_app_running function earlier to avoid adding a stability check specifically.
* But, then after I created a function wait_for_pods_ready function which does stability check.

It do need improvement

### Todo:
* **Right now:**
* When redeploying a particular component (phee per say). The vnext goes through the stability check, which it shouldn't.
* Condition to add: if we're seeing the message "vnext is stable moving ahead!" the stability check for vnext is not necessary.
* So, I am yet to work on this.