### PR TITLE
Implement DNS cache flush for chart deployment

### DIFF
--- a/src/deployer/core.sh
+++ b/src/deployer/core.sh
@@ -415,6 +415,11 @@ function ensure_helm_dependencies() {
   local chartName=$(basename "$chartPath")
   
   echo "    ensuring dependencies for $chartName chart"
+
+  # This prevents stale DNS entries from blocking repository access
+  if command -v resolvectl &> /dev/null; then
+    resolvectl flush-caches 2>/dev/null || true
+  fi
   
   if [[ -f "$chartPath/Chart.lock" && -s "$chartPath/Chart.lock" ]]; then
     # Count entries in Chart.lock and compare with .tgz files in charts/


### PR DESCRIPTION
I was facing an issue in the PI.
where I encountered negative DNS caching -> DNS cached that(like redpanda and groundhog2k does not exist) -> these ([charts.redpanda.com](http://charts.redpanda.com/), [groundhog2k.github.io](http://groundhog2k.github.io/) and a few more) do not exist. So, I flushed the cached domains using sudo resolvectl flush-caches, and it worked.

All DPGs deployed.

working on PI.