### PR TITLE
Remove unconditional DEBUG statements in commandline.sh

### DIFF
--- a/src/commandline/commandline.sh
+++ b/src/commandline/commandline.sh
@@ -248,7 +248,6 @@ function validateInputs {
 
         local current_apps_array
         IFS=' ' read -r -a current_apps_array <<< "$apps"
-        echo "DEBUG TODO -> current_apps_array: ${current_apps_array[*]}"
 
 
         local found_all_keyword="false"
@@ -284,7 +283,6 @@ function validateInputs {
             logWithLevel "$INFO" "Expanded 'all' keyword to: $apps"
         fi
 
-        echo "DEBUG : Apps to process: $apps"
         if [[ " $apps " =~ " infra " ]]; then
             if [[ "$mode" == "deploy" ]]; then
                 # for mode = deploy ensure 'infra' is first app if present
@@ -296,7 +294,6 @@ function validateInputs {
                     apps=$(echo $apps | xargs) # trim any extra spaces
             fi  
         fi
-        echo "DEBUG Final apps to process order: $apps"
     fi
 
     if [[ -n "$debug" && "$debug" != "true" && "$debug" != "false" ]]; then


### PR DESCRIPTION
## Problem
When running `./run.sh`, users would always see debug output like:

DEBUG TODO -> current_apps_array: all
DEBUG : Apps to process: infra vnext phee mifosx
DEBUG Final apps to process order: infra vnext phee mifosx

These messages printed every time regardless of whether the `-d true` (debug) flag was set, making the console output noisy for regular users.

## Solution
Removed the three unconditional debug echo statements from `src/commandline/commandline.sh`:
- Line 251: `echo "DEBUG TODO -> current_apps_array: ${current_apps_array[*]}"`
- Line 287: `echo "DEBUG : Apps to process: $apps"`
- Line 299: `echo "DEBUG Final apps to process order: $apps"`

## Result
The deployment script now runs with clean output. Users no longer see debug information unless they explicitly enable verbose mode.y.