### PR TITLE
[GAZ-20] removed cloning of ph-ee-env-labs from scripts and config.ini file

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -90,16 +90,10 @@ VNEXT_REPO_LINK = https://github.com/mojaloop/platform-shared-tools.git
 [phee]
 # Enable or disable Payment Hub EE deployment.
 enabled = true
-# Branch of the Payment Hub EE repository to use.
-PHBRANCH = master
-# Directory for Payment Hub EE repository.
-PHREPO_DIR = phlabs
 # Namespace for Payment Hub EE components.
 PH_NAMESPACE = paymenthub
 # Helm release name for Payment Hub EE.
 PH_RELEASE_NAME = phee
-# URL of the Payment Hub EE repository.
-PH_REPO_LINK = https://github.com/openMF/ph-ee-env-labs.git
 # URL of the Payment Hub EE environment template repository.
 PH_EE_ENV_TEMPLATE_REPO_LINK = https://github.com/openMF/ph-ee-env-template.git
 # Branch of the Payment Hub EE environment template repository.

--- a/src/deployer/core.sh
+++ b/src/deployer/core.sh
@@ -189,26 +189,20 @@ EOF
 #------------------------------------------------------------------------------
 # Function : manageElasticSecrets
 # Description: Creates or deletes Elasticsearch related Kubernetes secrets.
+#              On create, generates a self-signed certificate and packages it
+#              as a PKCS12 file using only openssl — no external repo required.
 # Parameters:
 #   $1 - Action: "create" or "delete"
 #   $2 - Namespace where the secrets are managed
-#   $3 - Directory containing the .p12 certificate file
 #------------------------------------------------------------------------------
 function manageElasticSecrets {
     local action="$1"
     local namespace="$2"
-    local certdir="$3" # location of the .p12 and .pem files 
     local password="XVYgwycNuEygEEEI0hQF"
 
     # Verify input parameters
-    if [ -z "$action" ] || [ -z "$namespace" ] || [ -z "$certdir" ]; then
-        log_error "Missing required parameters (action, namespace, certdir)"
-        return 1
-    fi
-
-    # Verify certdir exists and is readable
-    if [ ! -d "$certdir" ] || [ ! -r "$certdir/elastic-certificates.p12" ]; then
-        log_error "certdir $certdir does not exist or elastic-certificates.p12 is not readable"
+    if [ -z "$action" ] || [ -z "$namespace" ]; then
+        log_error "Missing required parameters (action, namespace)"
         return 1
     fi
 
@@ -218,18 +212,31 @@ function manageElasticSecrets {
     chown "$k8s_user":"$k8s_user" "$temp_dir" || { log_error "Failed to change ownership of $temp_dir"; rm -rf "$temp_dir"; return 1; }
     chmod 700 "$temp_dir" || { log_error "Failed to set permissions on $temp_dir"; rm -rf "$temp_dir"; return 1; }
 
-    # Check if k8s_user can access certdir
-    if ! su - "$k8s_user" -c "test -r '$certdir/elastic-certificates.p12'" 2>/dev/null; then
-        # Copy certificates to temp_dir
-        cp "$certdir/elastic-certificates.p12" "$temp_dir/elastic-certificates.p12" || { log_error "Failed to copy certificates"; rm -rf "$temp_dir"; return 1; }
-        chown "$k8s_user":"$k8s_user" "$temp_dir/elastic-certificates.p12" || { log_error "Failed to change ownership of copied certificates"; rm -rf "$temp_dir"; return 1; }
-        chmod 600 "$temp_dir/elastic-certificates.p12" || { log_error "Failed to set permissions on copied certificates"; rm -rf "$temp_dir"; return 1; }
-        certdir="$temp_dir"
-    fi
-
     if [ "$action" = "create" ]; then
+        # Generate a self-signed CA certificate and package as PKCS12
+        if ! openssl req -x509 -newkey rsa:2048 \
+                -keyout "$temp_dir/key.pem" \
+                -out "$temp_dir/cert.pem" \
+                -days 3650 -nodes \
+                -subj "/CN=elastic-ca" >/dev/null 2>&1; then
+            log_error "Failed to generate self-signed certificate"
+            rm -rf "$temp_dir"
+            return 1
+        fi
+        if ! openssl pkcs12 -export \
+                -out "$temp_dir/elastic-certificates.p12" \
+                -inkey "$temp_dir/key.pem" \
+                -in "$temp_dir/cert.pem" \
+                -passout pass: >/dev/null 2>&1; then
+            log_error "Failed to create elastic-certificates.p12"
+            rm -rf "$temp_dir"
+            return 1
+        fi
+        chown "$k8s_user":"$k8s_user" "$temp_dir/elastic-certificates.p12" "$temp_dir/key.pem" "$temp_dir/cert.pem" || { log_error "Failed to set ownership on generated cert files"; rm -rf "$temp_dir"; return 1; }
+        chmod 600 "$temp_dir/elastic-certificates.p12" "$temp_dir/key.pem" "$temp_dir/cert.pem" || { log_error "Failed to set permissions on generated cert files"; rm -rf "$temp_dir"; return 1; }
+
         # Convert certificates
-        if ! openssl pkcs12 -nodes -passin pass:'' -in "$certdir/elastic-certificates.p12" -out "$temp_dir/elastic-certificate.pem" >/dev/null 2>&1; then
+        if ! openssl pkcs12 -nodes -passin pass:'' -in "$temp_dir/elastic-certificates.p12" -out "$temp_dir/elastic-certificate.pem" >/dev/null 2>&1; then
             log_error "Failed to convert p12 to pem"
             rm -rf "$temp_dir"
             return 1
@@ -261,7 +268,7 @@ function manageElasticSecrets {
 
         # Create secrets
         local secret_output
-        secret_output=$(run_as_user "kubectl create secret generic elastic-certificates --namespace=\"$namespace\" --from-file=\"$certdir/elastic-certificates.p12\"" 2>&1)
+        secret_output=$(run_as_user "kubectl create secret generic elastic-certificates --namespace=\"$namespace\" --from-file=\"$temp_dir/elastic-certificates.p12\"" 2>&1)
         if [ $? -ne 0 ]; then
             log_error "Failed to create elastic-certificates secret: $secret_output"
             rm -rf "$temp_dir"

--- a/src/deployer/phee.sh
+++ b/src/deployer/phee.sh
@@ -25,7 +25,7 @@ function deployPH(){
 
   log_step "Removing existing Payment Hub resources"
   deleteResourcesInNamespaceMatchingPattern "$PH_NAMESPACE"
-  manageElasticSecrets delete "$INFRA_NAMESPACE" "$APPS_DIR/$PHREPO_DIR/helm/es-secret"
+  manageElasticSecrets delete "$INFRA_NAMESPACE"
   log_ok
 
   run_as_user "kubectl wait --for=condition=ready pod --all -n $VNEXT_NAMESPACE --timeout=600s" > /dev/null 2>&1
@@ -37,9 +37,9 @@ function deployPH(){
   prepare_payment_hub_chart
 
   log_step "Creating elastic secrets"
-  manageElasticSecrets delete "$INFRA_NAMESPACE" "$APPS_DIR/$PHREPO_DIR/helm/es-secret"
-  manageElasticSecrets create "$PH_NAMESPACE" "$APPS_DIR/$PHREPO_DIR/helm/es-secret"
-  manageElasticSecrets create "$INFRA_NAMESPACE" "$APPS_DIR/$PHREPO_DIR/helm/es-secret"
+  manageElasticSecrets delete "$INFRA_NAMESPACE"
+  manageElasticSecrets create "$PH_NAMESPACE"
+  manageElasticSecrets create "$INFRA_NAMESPACE"
   log_ok
 
   createIngressSecret "$PH_NAMESPACE" \
@@ -67,7 +67,6 @@ function deployPH(){
 #------------------------------------------------------------------------------
 function prepare_payment_hub_chart() {
   # Clone the repositories
-  cloneRepo "$PHBRANCH" "$PH_REPO_LINK" "$APPS_DIR" "$PHREPO_DIR"  # needed for kibana and elastic secrets only 
   cloneRepo "$PH_EE_ENV_TEMPLATE_REPO_BRANCH" "$PH_EE_ENV_TEMPLATE_REPO_LINK" "$APPS_DIR" "$PH_EE_ENV_TEMPLATE_REPO_DIR"
   
   log_step "Updating FQDNs in Helm chart values and manifests"


### PR DESCRIPTION
**Stop cloning ph-ee-env-labs**

GAZ-20 say update BPMN handling and stop cloning.  The updated BPMN handling was done a long time ago with BPMNs being put into Mifos Gazelle and maintained there (for the moment) , this PR and commit removes any dependence on certificates which were held in ph-ee-env-labs but now the mifos-gazelle scripys generate them with openssl as it does the rest of the certs (for now).


