### PR TITLE
Fix: Appended 's' suffix to helm timeout duration(GAZ-284)

### DIFF
--- a/src/deployer/deployer.sh
+++ b/src/deployer/deployer.sh
@@ -116,7 +116,7 @@ function deployHelmChartFromDir() {
   fi
 
   # Build helm install command
-  local helm_cmd="helm install --wait --timeout $startup_timeout $release_name $chart_dir -n $namespace"
+  local helm_cmd="helm install --wait --timeout ${startup_timeout}s $release_name $chart_dir -n $namespace"
   if [ -n "$values_file" ]; then
       helm_cmd="$helm_cmd -f $values_file"
   fi


### PR DESCRIPTION
## Problem
helm `--timeout` requires a duration string (e.g. `600s`) not only a integer. 
The timeout value was passed as `$startup_timeout` which evaluates to `600` 
with no unit, causing helm to reject it and fail silently with `Deployment failed `
and no useful error message in the TUI logs.
<img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/936589a2-afee-44ff-b510-87f845ce1a8c" />


## Solution
Added `s` to `$startup_timeout` so helm receives a valid duration string `600s`.

## Changes
Updated `deployer.sh` line 119 from `--timeout $startup_timeout`  to `--timeout ${startup_timeout}s`

## Testing
Tested full TUI deployment. All components deployed successfully:
•Infrastructure 
•Payment Hub EE 
•vNext 
•MifosX 
•Mifos Gazelle Ready 
<img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/69a3bcfa-53d0-4801-8848-92a70fef608c" />
