### PR TITLE
fix: anchor grep pattern in deleteResourcesInNamespaceMatchingPattern

### DIFF
--- a/src/deployer/deployer.sh
+++ b/src/deployer/deployer.sh
@@ -69,7 +69,7 @@ function deleteResourcesInNamespaceMatchingPattern() {
     
     # Filter the output for namespaces matching the pattern, stripping the "namespace/" prefix
     # grep returns 1 if no matches, but we want to continue, hence || true
-    matching_namespaces=$(echo "$all_namespaces_output" | grep -E "$pattern" | sed 's/^namespace\///' || true)
+    matching_namespaces=$(echo "$all_namespaces_output" | grep -E "^namespace/${pattern}$" | sed 's/^namespace\///' || true)
 
     if [ -z "$matching_namespaces" ]; then
         # printf "      namespaces %s not found    [skipping] \n"  $pattern


### PR DESCRIPTION
## Summary

I fixed unsafe namespace matching in `deleteResourcesInNamespaceMatchingPattern()` by changing it from a substring match to an exact match.

Previously, using `infra` could also match namespaces like `infra-monitoring` or `infrastructure`, which could lead to unintended deletions during cleanup on shared clusters.

I updated the grep check to anchor against the full `namespace/<name>` format, so only the exact configured namespace is matched.

## Impact

* Prevents accidental deletion of similarly named namespaces
* Keeps existing behavior unchanged for valid namespace names
* Low-risk, minimal change limited to delete filtering logic
