### PR TITLE
fix(deployer): prevent `add_hosts` from overwriting existing 127.0.0.1

### DIFF
--- a/src/environmentSetup/environmentSetup.sh
+++ b/src/environmentSetup/environmentSetup.sh
@@ -67,10 +67,17 @@ function add_hosts {
         
         MIFOSXHOSTS=( mifos.$DOMAIN )
         
-        ALLHOSTS=( "127.0.0.1" "localhost" "${MIFOSXHOSTS[@]}" "${PHEEHOSTS[@]}" "${VNEXTHOSTS[@]}" )
-        export ENDPOINTS=`echo ${ALLHOSTS[*]}`
-        perl -pi -e 's/^(127\.0\.0\.1\s+)(.*)/$1localhost/' /etc/hosts
-        perl -p -i.bak -e 's/127\.0\.0\.1.*localhost.*$/$ENV{ENDPOINTS} /' /etc/hosts
+        ALLHOSTS=( "${MIFOSXHOSTS[@]}" "${PHEEHOSTS[@]}" "${VNEXTHOSTS[@]}" )
+        
+        # Strip existing Gazelle block if present
+        perl -i.bak -ne 'print unless /# GAZELLE_START/ .. /# GAZELLE_END/' /etc/hosts
+        
+        # Append new Gazelle entries
+        echo "# GAZELLE_START added by mifos-gazelle" >> /etc/hosts
+        for host in "${ALLHOSTS[@]}"; do
+            echo "127.0.0.1 $host" >> /etc/hosts
+        done
+        echo "# GAZELLE_END added by mifos-gazelle" >> /etc/hosts
     else
         printf "==> Skipping /etc/hosts modification for remote cluster \n"
     fi


### PR DESCRIPTION
## Description
This PR fixes a critical issue in the `add_hosts` function where the script would completely overwrite the `127.0.0.1` line in `/etc/hosts`. This behavior was problematic as it erased any pre-existing custom local mappings the developer might have had (e.g., `127.0.0.1 my-local-dev-site`).

## Changes
- Modified `src/environmentSetup/environmentSetup.sh`.
- Replaced the regex-based `perl` replacement of the `127.0.0.1` line with a guarded sentinel block approach.
- The script now searches for a `# GAZELLE_START` to `# GAZELLE_END` block, removes it if it exists (for idempotency on re-deploys), and appends a fresh block at the end of the file.
- All Gazelle-specific hostnames are now added as individual `127.0.0.1 <hostname>` entries within this block, leaving the original `localhost` line untouched.