### PR TITLE
[GAZ-281][PHEE-359] Mastercard Test and help Integrate solution into GovStack Sandbox Env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Deployment state (local only)
+config/.last_applied_domain
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/config/ph_values.yaml
+++ b/config/ph_values.yaml
@@ -86,14 +86,15 @@ ph-ee-engine:
         kubernetes.io/ingress.class: nginx
         nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
         nginx.ingress.kubernetes.io/enable-cors: "true"
-        nginx.ingress.kubernetes.io/cors-allow-origin: "https://ops.mifos.gazelle.localhost"
+        nginx.ingress.kubernetes.io/cors-allow-origin: "https://ops.mifos.gazelle.localhost,https://cross-border.mifos.gazelle.localhost"
         nginx.ingress.kubernetes.io/cors-allow-methods: "PUT, GET, POST, OPTIONS, DELETE, PATCH"
-        nginx.ingress.kubernetes.io/cors-allow-headers: "DNT,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization,Platform-TenantId,platform-tenantid,purpose,type,x-callback-url,x-correlationid,x-correlation-id,X-Correlation-ID,x-program-id,x-registering-institution-id,x-signature,Sec-Fetch-Dest,Sec-Fetch-Mode,Sec-Fetch-Site,Sec-GPC,Pragma"
+        nginx.ingress.kubernetes.io/cors-allow-headers: "DNT,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization,Platform-TenantId,platform-tenantid,purpose,type,x-callback-url,x-correlationid,x-correlation-id,X-Correlation-ID,x-program-id,x-registering-institution-id,x-signature,privateKey,privatekey,Sec-Fetch-Dest,Sec-Fetch-Mode,Sec-Fetch-Site,Sec-GPC,Pragma"
         nginx.ingress.kubernetes.io/cors-expose-headers: "Content-Length,Content-Range,X-Correlation-ID,x-correlation-id"
         nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
         nginx.ingress.kubernetes.io/cors-max-age: "86400"
         nginx.ingress.kubernetes.io/enable-access-log: "true"
         nginx.ingress.kubernetes.io/log-format: '$remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" "$http_x_forwarded_for" $request_uri'
+        cert-manager.io/cluster-issuer: "letsencrypt-http"
       tls:
       - hosts:
         - ops-bk.mifos.gazelle.localhost
@@ -106,7 +107,7 @@ ph-ee-engine:
               service:
                 name: ph-ee-operations-app
                 port:
-                  number: 80  
+                  number: 80
 
   operations:
     mysql:
@@ -376,14 +377,15 @@ ph-ee-engine:
       annotations:
         nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
         nginx.ingress.kubernetes.io/enable-cors: "true"
-        nginx.ingress.kubernetes.io/cors-allow-origin: "https://ops.mifos.gazelle.localhost"
+        nginx.ingress.kubernetes.io/cors-allow-origin: "https://ops.mifos.gazelle.localhost,https://cross-border.mifos.gazelle.localhost"
         nginx.ingress.kubernetes.io/cors-allow-methods: "PUT, GET, POST, OPTIONS, DELETE, PATCH"
-        nginx.ingress.kubernetes.io/cors-allow-headers: "DNT,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization,Platform-TenantId,platform-tenantid,purpose,type,x-callback-url,x-correlationid,x-correlation-id,X-Correlation-ID,x-program-id,x-registering-institution-id,x-signature,Sec-Fetch-Dest,Sec-Fetch-Mode,Sec-Fetch-Site,Sec-GPC,Pragma"
+        nginx.ingress.kubernetes.io/cors-allow-headers: "DNT,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization,Platform-TenantId,platform-tenantid,purpose,type,x-callback-url,x-correlationid,x-correlation-id,X-Correlation-ID,x-program-id,x-registering-institution-id,x-signature,privateKey,privatekey,Sec-Fetch-Dest,Sec-Fetch-Mode,Sec-Fetch-Site,Sec-GPC,Pragma"
         nginx.ingress.kubernetes.io/cors-expose-headers: "Content-Length,Content-Range,X-Correlation-ID,x-correlation-id"
         nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
         nginx.ingress.kubernetes.io/cors-max-age: "86400"
         nginx.ingress.kubernetes.io/enable-access-log: "true"
         nginx.ingress.kubernetes.io/log-format: '$remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" "$http_x_forwarded_for" $request_uri'
+        cert-manager.io/cluster-issuer: "letsencrypt-http"
       tls:
         - secretName: sandbox-secret
       hosts:
@@ -394,7 +396,7 @@ ph-ee-engine:
               service:
                 name: ph-ee-operations-app
                 port:
-                  number: 80  
+                  number: 80
 
   ph_ee_bulk_processor:
     enabled: true
@@ -461,14 +463,15 @@ ph-ee-engine:
         nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"  # End-to-end TLS
         nginx.ingress.kubernetes.io/backend-protocol-ssl-verify: "false"  # Self-signed cert in backend
         nginx.ingress.kubernetes.io/enable-cors: "true"
-        nginx.ingress.kubernetes.io/cors-allow-origin: "https://ops.mifos.gazelle.localhost"
+        nginx.ingress.kubernetes.io/cors-allow-origin: "https://ops.mifos.gazelle.localhost,https://cross-border.mifos.gazelle.localhost"
         nginx.ingress.kubernetes.io/cors-allow-methods: "PUT, GET, POST, OPTIONS, DELETE, PATCH"
-        nginx.ingress.kubernetes.io/cors-allow-headers: "DNT,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization,Platform-TenantId,platform-tenantid,purpose,type,x-callback-url,x-correlationid,x-correlation-id,X-Correlation-ID,x-program-id,x-registering-institution-id,x-signature,Sec-Fetch-Dest,Sec-Fetch-Mode,Sec-Fetch-Site,Sec-GPC,Pragma"
+        nginx.ingress.kubernetes.io/cors-allow-headers: "DNT,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization,Platform-TenantId,platform-tenantid,purpose,Purpose,type,filename,x-callback-url,x-callbackurl,X-CallbackURL,x-correlationid,x-correlation-id,X-Correlation-ID,x-program-id,x-registering-institution-id,x-signature,privateKey,privatekey,Sec-Fetch-Dest,Sec-Fetch-Mode,Sec-Fetch-Site,Sec-GPC,Pragma"
         nginx.ingress.kubernetes.io/cors-expose-headers: "Content-Length,Content-Range,X-Correlation-ID,x-correlation-id"
         nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
         nginx.ingress.kubernetes.io/cors-max-age: "86400"
         nginx.ingress.kubernetes.io/enable-access-log: "true"
         nginx.ingress.kubernetes.io/log-format: '$remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" "$http_x_forwarded_for" $request_uri'
+        cert-manager.io/cluster-issuer: "letsencrypt-http"
       tls:
       - hosts:
         - bulk-processor.mifos.gazelle.localhost
@@ -523,8 +526,8 @@ ph-ee-engine:
         - channel.mifos.gazelle.localhost
         secretName: sandbox-secret
       hosts:
-        - host: channel.mifos.gazelle.localhost          
-          paths: 
+        - host: channel.mifos.gazelle.localhost
+          paths:
           - path: /
             backend:
               service:
@@ -598,13 +601,12 @@ ph-ee-engine:
   importer_rdbms:
     enabled: true
     image: docker.io/openmf/ph-ee-importer-rdbms:dev-latest
-    resources:
-      requests:
-        cpu: 50m
-        memory: 192Mi
-      limits:
-        cpu: 300m
-        memory: 256Mi
+    requests:
+      cpu: 50m
+      memory: 192Mi
+    limits:
+      cpu: 300m
+      memory: 256Mi
     extraEnvs:
       - name: JAVA_TOOL_OPTIONS
         value: |

--- a/docs/mastercard/MASTERCARD.md
+++ b/docs/mastercard/MASTERCARD.md
@@ -32,10 +32,10 @@ Without it, Payment Hub EE can route bulk G2P disbursements either through the *
 ```
 
 The connector sits alongside the existing Mojaloop and closedloop connectors. It shares the same infrastructure:
-- **Same BPMN pipeline**: bulk-processor → connector-bulk → connector-channel → `MastercardFundTransfer-{dfspid}` workflow
-- **Same identity-account-mapper**: for payee MSISDN lookups
-- **Same tenants**: `greenbank` (or any payer tenant) can use `MASTERCARD_CBS` payment mode
-- **Additional data requirement**: a `mastercard_cbs_supplementary_data` table holds the regulatory/KYC data that Mastercard CBS requires per payee (country, bank details, etc.) — this is loaded automatically during deployment
+- **Same BPMN pipeline**: bulk-processor → connector-bulk → `MastercardFundTransfer-{dfspid}` workflow
+- **Same identity-account-mapper**: for payee MSISDN lookups and de-bulking by destination bank
+- **Same tenants**: `greenbank` (or any payer tenant) submits with `--govstack` and `MASTERCARD_CBS` payment mode
+- **Additional data requirement**: a `mastercard_cbs_supplementary_data` table holds the regulatory/KYC data that Mastercard CBS requires per payee (country, bank details, SWIFT code) — this is populated from the identity mapper during `setup-data`
 
 The connector itself (`ph-ee-connector-mccbs`) is a Java Spring Boot service deployed via a **Kubernetes Operator** — meaning you declare the desired state in a `MastercardCBSConnector` Custom Resource and the operator manages the pod lifecycle, secrets, and data loading automatically.
 
@@ -43,9 +43,10 @@ The connector itself (`ph-ee-connector-mccbs`) is a Java Spring Boot service dep
 
 ## Prerequisites
 
-- Payment Hub EE deployed and running (`sudo ./run.sh -u $USER -m deploy -a phee`)
-- A Mastercard Developers portal account with a sandbox or production app (for real payments; demo mode works without valid credentials)
-- `~/ph-ee-connector-mccbs` present on the server (the connector source / Docker image)
+- Payment Hub EE deployed and running
+- **`setup-data` must run after `mastercard-demo`** — it populates the identity-account-mapper and then loads Mastercard supplementary data. See the deployment steps below.
+- A Mastercard Developers portal account with a sandbox or production app (for real payments; demo mode works without fully encrypted payload)
+- `~/ph-ee-connector-mccbs` present on the server (the connector source)
 
 ---
 
@@ -59,44 +60,144 @@ enabled = true
 MASTERCARD_CBS_HOME = ~/ph-ee-connector-mccbs
 MASTERCARD_API_URL  = https://sandbox.api.mastercard.com
 # For real payments — get these from developer.mastercard.com:
-MASTERCARD_PARTNER_ID          = <partner-id>
-MASTERCARD_CONSUMER_KEY        = <consumer-key>
-MASTERCARD_SIGNING_KEY_ALIAS   = <alias>
+MASTERCARD_PARTNER_ID           = <partner-id>
+MASTERCARD_CONSUMER_KEY         = <consumer-key>
+MASTERCARD_SIGNING_KEY_ALIAS    = <alias>
 MASTERCARD_SIGNING_KEY_PASSWORD = <password>
-MASTERCARD_SIGNING_KEY_PATH    = /path/to/signing.p12
+MASTERCARD_SIGNING_KEY_PATH     = /path/to/signing.p12
+# For local development with hostPath JAR mount:
+MASTERCARD_LOCALDEV_ENABLED     = true
 ```
 
 ### 2. Deploy
 
-```bash
-# Deploy Mastercard connector alongside everything else
-sudo ./run.sh -u $USER -m deploy -a all
+**Option A — all in one step** (recommended): with `enabled = true` in `config/config.ini`, a single `run.sh` call deploys everything in the correct order, ending with `setup-data` which populates the identity mapper and loads Mastercard supplementary data:
 
-# Or add it to an existing running Gazelle deployment
-sudo ./run.sh -u $USER -m deploy -a mastercard-demo
+```bash
+sudo ./run.sh
 ```
 
-This deploys the CRD, operator, connector pod, BPMN workflows, and loads supplementary data. A sample 6-row CSV is generated at `src/utils/data-loading/bulk-gazelle-mastercard-6.csv`.
+**Option B — add to an existing deployment**: deploy the connector first, then run `setup-data` last to populate the identity mapper and load supplementary data:
 
-### 3. Test a payment
+```bash
+# Deploy the Mastercard connector, operator, and BPMN workflows
+sudo ./run.sh -a mastercard-demo
+
+# Load all data: Fineract clients, identity mapper, and Mastercard supplementary data
+sudo ./run.sh -a setup-data
+```
+
+> **`setup-data` must run after `mastercard-demo`**, not before. The supplementary data
+> loader reads payee MSISDNs from the identity-account-mapper, which is populated by
+> `setup-data`. Running them in this order ensures both tables are populated correctly.
+>
+> If you need to reload supplementary data manually (e.g. after regenerating data):
+> ```bash
+> bash src/utils/mastercard/load-mastercard-supplementary-data.sh
+> ```
+
+### 3. Submit a test batch
+
+Mastercard CBS **requires `--govstack`**. This triggers the `bulk_processor_account_lookup-{tenant}` BPMN, which validates payees via the identity-account-mapper and de-bulks the batch by destination bank before handing off to the connector. Without it, the account lookup step is skipped and the connector cannot determine the payee's bank routing details.
 
 ```bash
 cd src/utils/batch
 ./submit-batch.py \
-  -c ~/config/config.ini \
   -f ../data-loading/bulk-gazelle-mastercard-6.csv \
-  --tenant greenbank
+  --tenant greenbank \
+  --govstack \
+  --debug
 ```
 
-Monitor the connector:
-```bash
-kubectl logs -n mastercard-demo -l app=ph-ee-connector-mastercard-cbs -f
+Expected output:
+```
+✓ Identity mapper: 6 beneficiaries found for 'greenbank'
+
+WORKFLOW DETAILS
+──────────────────────────────────────────────────
+  Bulk-processor workflow : bulk_processor_account_lookup-greenbank
+  Payment mode(s) in CSV  : MASTERCARD_CBS
+  Submission mode         : GovStack — identity validation + de-bulking by payee FSP
+──────────────────────────────────────────────────
+
+Response Status: 202
+✓ Batch submitted successfully!
 ```
 
 ### 4. Remove
 
 ```bash
-sudo ./run.sh -u $USER -m cleanapps -a mastercard-demo
+sudo ./run.sh -m cleanapps -a mastercard-demo
+```
+
+---
+
+## Verifying Successful Payments
+
+### Operations Web UI
+
+Partial batch and transfer details are available in the Payment Hub operations web UI at:
+
+```
+http://ops.<GAZELLE_DOMAIN>
+```
+
+where `GAZELLE_DOMAIN` is set in your `config/config.ini` (e.g. `http://ops.mifos.gazelle.test`). Note that transfer-level detail (Mastercard Payment IDs, SWIFT codes) is only visible via the connector logs and database queries below — the UI shows batch status and per-transfer status/amounts but not CBS-specific fields.
+
+### Connector logs
+
+```bash
+kubectl logs -n mastercard-demo -l app=ph-ee-connector-mastercard-cbs --tail=100
+```
+
+A successful payment looks like:
+```
+✓ MASTERCARD CBS PAYMENT SUCCESS (XML Unencrypted)
+  Transaction Reference : 408f5e43-5004-4c33-b979-e79a3fe9501f
+  Mastercard Payment ID : rem_NgDyY0qkCvMJZwi-6XE0tq75Paw
+  Status                : SUCCESS
+  Amount                : 10.0 USD
+  Beneficiary           : Scarlett Taylor
+```
+
+Each successful transfer has a real `Mastercard Payment ID` (`rem_...`) returned from the CBS API.
+
+### Transfer records
+
+```bash
+MYSQL_PW=$(kubectl get secret -n paymenthub operationsmysql \
+  -o jsonpath='{.data.mysql-root-password}' | base64 -d)
+
+kubectl exec -n paymenthub operationsmysql-0 -- \
+  env MYSQL_PWD="$MYSQL_PW" mysql -uroot \
+  -e "SELECT transaction_id, status, status_detail, payee_party_id, amount, currency \
+      FROM greenbank.transfers ORDER BY id DESC LIMIT 6\G"
+```
+
+Expected: `status: COMPLETED`, `status_detail: SUCCESS | Mastercard Payment ID: rem_...`
+
+### Batch summary
+
+```bash
+MYSQL_PW=$(kubectl get secret -n paymenthub operationsmysql \
+  -o jsonpath='{.data.mysql-root-password}' | base64 -d)
+
+kubectl exec -n paymenthub operationsmysql-0 -- \
+  env MYSQL_PWD="$MYSQL_PW" mysql -uroot greenbank \
+  -e "SELECT batch_id, total_transactions, completed, failed, status \
+      FROM batches ORDER BY id DESC LIMIT 3\G"
+```
+
+### Supplementary data check
+
+```bash
+MYSQL_PW=$(kubectl get secret -n paymenthub operationsmysql \
+  -o jsonpath='{.data.mysql-root-password}' | base64 -d)
+
+kubectl exec -n paymenthub operationsmysql-0 -- \
+  env MYSQL_PWD="$MYSQL_PW" mysql -uroot \
+  -e "SELECT account_number, beneficiary_name, bank_name, bank_swift_code, country \
+      FROM operations.mastercard_cbs_supplementary_data"
 ```
 
 ---
@@ -119,16 +220,16 @@ payment-modes:
 
 ## Data Loading
 
-**Supplementary data** (Mastercard regulatory/KYC fields per payee) is loaded automatically during deployment. To reload manually:
+**Supplementary data** (Mastercard regulatory/KYC fields per payee) is loaded automatically as part of `setup-data`. To reload manually after data has been regenerated:
 
 ```bash
-bash src/utils/mastercard/load-mastercard-supplementary-data.sh -c config/config.ini
+bash src/utils/mastercard/load-mastercard-supplementary-data.sh
 ```
 
 **Sample CSV** generation:
 ```bash
 python3 src/utils/data-loading/generate-example-csv-files.py \
-  -c config/config.ini --mode mastercard --num-rows 6 \
+  --mode mastercard --num-rows 6 \
   --output-dir src/utils/data-loading
 ```
 
@@ -141,6 +242,7 @@ python3 src/utils/data-loading/generate-example-csv-files.py \
 | **Switch** | None | Mojaloop vNext | Mastercard CBS API |
 | **Scope** | Same PH instance | Inter-FSP domestic | Cross-border |
 | **Payee lookup** | identity-account-mapper | vNext oracle | identity-account-mapper + supplementary data |
+| **`--govstack` required** | Optional | Optional | **Yes** |
 | **Credentials needed** | None | None | Mastercard developer account |
 | **Typical use** | Testing | Domestic G2P | Cross-border G2P |
 

--- a/orchestration/feel/MastercardFundTransfer-DFSPID.bpmn
+++ b/orchestration/feel/MastercardFundTransfer-DFSPID.bpmn
@@ -1,0 +1,185 @@
+<?xml version='1.0' encoding='utf-8'?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:ns1="http://camunda.org/schema/modeler/1.0" xmlns:ns4="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:ns5="http://www.omg.org/spec/DD/20100524/DC" xmlns:ns6="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_MastercardTransfer" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0" ns1:executionPlatform="Camunda Cloud" ns1:executionPlatformVersion="8.0.0">
+  <bpmn:process id="MastercardFundTransfer-DFSPID" name="Mastercard CBS Fund Transfer" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_InitTransfer" name="Transfer&#10;Initiation">
+      <bpmn:outgoing>Flow_start_to_lookup</bpmn:outgoing>
+    </bpmn:startEvent>
+
+    
+    <bpmn:serviceTask id="Task_LookupSupplementalData" name="Lookup Supplemental Data">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="mastercard-lookup-supplemental-data-DFSPID" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_start_to_lookup</bpmn:incoming>
+      <bpmn:outgoing>Flow_lookup_to_gateway</bpmn:outgoing>
+    </bpmn:serviceTask>
+
+    
+    <bpmn:exclusiveGateway id="Gateway_DataFound" name="Data Found?" default="Flow_data_not_found">
+      <bpmn:incoming>Flow_lookup_to_gateway</bpmn:incoming>
+      <bpmn:outgoing>Flow_data_found</bpmn:outgoing>
+      <bpmn:outgoing>Flow_data_not_found</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+
+    
+    <bpmn:serviceTask id="Task_MergeData" name="Merge Transfer and Supplemental Data">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="mastercard-merge-data-DFSPID" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_data_found</bpmn:incoming>
+      <bpmn:outgoing>Flow_merge_to_initiate</bpmn:outgoing>
+    </bpmn:serviceTask>
+
+    
+    <bpmn:serviceTask id="Task_InitiateCBSPayment" name="Initiate Mastercard CBS Payment">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="mastercard-initiate-payment-DFSPID" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_merge_to_initiate</bpmn:incoming>
+      <bpmn:outgoing>Flow_initiate_to_gateway</bpmn:outgoing>
+    </bpmn:serviceTask>
+
+    
+    <bpmn:exclusiveGateway id="Gateway_PaymentSuccess" name="Payment&#10;Submitted?" default="Flow_payment_failed">
+      <bpmn:incoming>Flow_initiate_to_gateway</bpmn:incoming>
+      <bpmn:outgoing>Flow_payment_success</bpmn:outgoing>
+      <bpmn:outgoing>Flow_payment_failed</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+
+    
+    <bpmn:serviceTask id="Task_UpdateOperationsSuccess" name="Update Operations DB (Success)">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="mastercard-update-operations-DFSPID" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_payment_success</bpmn:incoming>
+      <bpmn:outgoing>Flow_success_to_end</bpmn:outgoing>
+    </bpmn:serviceTask>
+
+    
+    <bpmn:serviceTask id="Task_UpdateOperationsFailure" name="Update Operations DB (Failure)">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="mastercard-update-operations-DFSPID" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_payment_failed</bpmn:incoming>
+      <bpmn:incoming>Flow_data_not_found</bpmn:incoming>
+      <bpmn:outgoing>Flow_failure_to_end</bpmn:outgoing>
+    </bpmn:serviceTask>
+
+    
+    <bpmn:endEvent id="EndEvent_Success" name="Transfer&#10;Completed">
+      <bpmn:incoming>Flow_success_to_end</bpmn:incoming>
+    </bpmn:endEvent>
+
+    
+    <bpmn:endEvent id="EndEvent_Failure" name="Transfer&#10;Failed">
+      <bpmn:incoming>Flow_failure_to_end</bpmn:incoming>
+    </bpmn:endEvent>
+
+    
+    <bpmn:sequenceFlow id="Flow_start_to_lookup" sourceRef="StartEvent_InitTransfer" targetRef="Task_LookupSupplementalData" />
+    <bpmn:sequenceFlow id="Flow_lookup_to_gateway" sourceRef="Task_LookupSupplementalData" targetRef="Gateway_DataFound" />
+    <bpmn:sequenceFlow id="Flow_data_found" name="Yes" sourceRef="Gateway_DataFound" targetRef="Task_MergeData">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=supplementalDataFound = true</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_data_not_found" name="No" sourceRef="Gateway_DataFound" targetRef="Task_UpdateOperationsFailure" />
+    <bpmn:sequenceFlow id="Flow_merge_to_initiate" sourceRef="Task_MergeData" targetRef="Task_InitiateCBSPayment" />
+    <bpmn:sequenceFlow id="Flow_initiate_to_gateway" sourceRef="Task_InitiateCBSPayment" targetRef="Gateway_PaymentSuccess" />
+    <bpmn:sequenceFlow id="Flow_payment_success" name="Yes" sourceRef="Gateway_PaymentSuccess" targetRef="Task_UpdateOperationsSuccess">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=paymentSuccess = true</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_payment_failed" name="No" sourceRef="Gateway_PaymentSuccess" targetRef="Task_UpdateOperationsFailure" />
+    <bpmn:sequenceFlow id="Flow_success_to_end" sourceRef="Task_UpdateOperationsSuccess" targetRef="EndEvent_Success" />
+    <bpmn:sequenceFlow id="Flow_failure_to_end" sourceRef="Task_UpdateOperationsFailure" targetRef="EndEvent_Failure" />
+  </bpmn:process>
+
+  
+  <ns4:BPMNDiagram id="BPMNDiagram_1">
+    <ns4:BPMNPlane id="BPMNPlane_1" bpmnElement="MastercardFundTransfer-DFSPID">
+      <ns4:BPMNShape id="StartEvent_InitTransfer_di" bpmnElement="StartEvent_InitTransfer">
+        <ns5:Bounds x="152" y="102" width="36" height="36" />
+      </ns4:BPMNShape>
+      <ns4:BPMNShape id="Task_LookupSupplementalData_di" bpmnElement="Task_LookupSupplementalData">
+        <ns5:Bounds x="240" y="80" width="100" height="80" />
+      </ns4:BPMNShape>
+      <ns4:BPMNShape id="Gateway_DataFound_di" bpmnElement="Gateway_DataFound" isMarkerVisible="true">
+        <ns5:Bounds x="395" y="95" width="50" height="50" />
+      </ns4:BPMNShape>
+      <ns4:BPMNShape id="Task_MergeData_di" bpmnElement="Task_MergeData">
+        <ns5:Bounds x="500" y="80" width="100" height="80" />
+      </ns4:BPMNShape>
+      <ns4:BPMNShape id="Task_InitiateCBSPayment_di" bpmnElement="Task_InitiateCBSPayment">
+        <ns5:Bounds x="660" y="80" width="100" height="80" />
+      </ns4:BPMNShape>
+      <ns4:BPMNShape id="Gateway_PaymentSuccess_di" bpmnElement="Gateway_PaymentSuccess" isMarkerVisible="true">
+        <ns5:Bounds x="815" y="95" width="50" height="50" />
+      </ns4:BPMNShape>
+      <ns4:BPMNShape id="Task_UpdateOperationsSuccess_di" bpmnElement="Task_UpdateOperationsSuccess">
+        <ns5:Bounds x="920" y="80" width="100" height="80" />
+      </ns4:BPMNShape>
+      <ns4:BPMNShape id="Task_UpdateOperationsFailure_di" bpmnElement="Task_UpdateOperationsFailure">
+        <ns5:Bounds x="920" y="200" width="100" height="80" />
+      </ns4:BPMNShape>
+      <ns4:BPMNShape id="EndEvent_Success_di" bpmnElement="EndEvent_Success">
+        <ns5:Bounds x="1082" y="102" width="36" height="36" />
+      </ns4:BPMNShape>
+      <ns4:BPMNShape id="EndEvent_Failure_di" bpmnElement="EndEvent_Failure">
+        <ns5:Bounds x="1082" y="222" width="36" height="36" />
+      </ns4:BPMNShape>
+      
+      <ns4:BPMNEdge id="Flow_start_to_lookup_di" bpmnElement="Flow_start_to_lookup">
+        <ns6:waypoint x="188" y="120" />
+        <ns6:waypoint x="240" y="120" />
+      </ns4:BPMNEdge>
+      <ns4:BPMNEdge id="Flow_lookup_to_gateway_di" bpmnElement="Flow_lookup_to_gateway">
+        <ns6:waypoint x="340" y="120" />
+        <ns6:waypoint x="395" y="120" />
+      </ns4:BPMNEdge>
+      <ns4:BPMNEdge id="Flow_data_found_di" bpmnElement="Flow_data_found">
+        <ns6:waypoint x="445" y="120" />
+        <ns6:waypoint x="500" y="120" />
+        <ns4:BPMNLabel>
+          <ns5:Bounds x="460" y="102" width="25" height="14" />
+        </ns4:BPMNLabel>
+      </ns4:BPMNEdge>
+      <ns4:BPMNEdge id="Flow_data_not_found_di" bpmnElement="Flow_data_not_found">
+        <ns6:waypoint x="420" y="145" />
+        <ns6:waypoint x="420" y="240" />
+        <ns6:waypoint x="920" y="240" />
+        <ns4:BPMNLabel>
+          <ns5:Bounds x="428" y="190" width="15" height="14" />
+        </ns4:BPMNLabel>
+      </ns4:BPMNEdge>
+      <ns4:BPMNEdge id="Flow_merge_to_initiate_di" bpmnElement="Flow_merge_to_initiate">
+        <ns6:waypoint x="600" y="120" />
+        <ns6:waypoint x="660" y="120" />
+      </ns4:BPMNEdge>
+      <ns4:BPMNEdge id="Flow_initiate_to_gateway_di" bpmnElement="Flow_initiate_to_gateway">
+        <ns6:waypoint x="760" y="120" />
+        <ns6:waypoint x="815" y="120" />
+      </ns4:BPMNEdge>
+      <ns4:BPMNEdge id="Flow_payment_success_di" bpmnElement="Flow_payment_success">
+        <ns6:waypoint x="865" y="120" />
+        <ns6:waypoint x="920" y="120" />
+        <ns4:BPMNLabel>
+          <ns5:Bounds x="880" y="102" width="25" height="14" />
+        </ns4:BPMNLabel>
+      </ns4:BPMNEdge>
+      <ns4:BPMNEdge id="Flow_payment_failed_di" bpmnElement="Flow_payment_failed">
+        <ns6:waypoint x="840" y="145" />
+        <ns6:waypoint x="840" y="240" />
+        <ns6:waypoint x="920" y="240" />
+        <ns4:BPMNLabel>
+          <ns5:Bounds x="848" y="190" width="15" height="14" />
+        </ns4:BPMNLabel>
+      </ns4:BPMNEdge>
+      <ns4:BPMNEdge id="Flow_success_to_end_di" bpmnElement="Flow_success_to_end">
+        <ns6:waypoint x="1020" y="120" />
+        <ns6:waypoint x="1082" y="120" />
+      </ns4:BPMNEdge>
+      <ns4:BPMNEdge id="Flow_failure_to_end_di" bpmnElement="Flow_failure_to_end">
+        <ns6:waypoint x="1020" y="240" />
+        <ns6:waypoint x="1082" y="240" />
+      </ns4:BPMNEdge>
+    </ns4:BPMNPlane>
+  </ns4:BPMNDiagram>
+</bpmn:definitions>

--- a/src/deployer/core.sh
+++ b/src/deployer/core.sh
@@ -397,12 +397,69 @@ update_fqdn_batch() {
     local directory="$1"
     local old_fqdn="$2"
     local new_fqdn="$3"
-    
+
     find "$directory" -type f \( -name "*.yaml" -o -name "*.yml" \) | while read -r file; do
         #echo "Processing: $file"
         update_fqdn "$file" "$old_fqdn" "$new_fqdn"
         #echo "---"
     done
+}
+
+#------------------------------------------------------------------------------
+# Domain state tracking — ensures FQDN substitution is idempotent across runs
+# even when GAZELLE_DOMAIN changes between deployments.
+#
+# The last successfully applied domain is stored in config/.last_applied_domain.
+# On each run both the canonical baselines AND the previously applied domain are
+# replaced, so files already patched with a prior domain are correctly updated.
+#------------------------------------------------------------------------------
+_domain_state_file() {
+    echo "${RUN_DIR:-$HOME/mifos-gazelle}/config/.last_applied_domain"
+}
+
+get_last_applied_domain() {
+    local f
+    f=$(_domain_state_file)
+    [ -f "$f" ] && cat "$f"
+}
+
+save_applied_domain() {
+    echo "$GAZELLE_DOMAIN" > "$(_domain_state_file)"
+}
+
+# Replace canonical baselines AND the previously applied domain in a single file.
+# Usage: apply_domain_to_file <file> <new_domain>
+apply_domain_to_file() {
+    local file="$1"
+    local new_domain="$2"
+    local prev_domain
+    prev_domain=$(get_last_applied_domain)
+
+    update_fqdn "$file" "mifos.gazelle.test" "$new_domain"
+    update_fqdn "$file" "mifos.gazelle.localhost" "$new_domain"
+    if [ -n "$prev_domain" ] && [ "$prev_domain" != "$new_domain" ]; then
+        logWithVerboseCheck "$debug" "$DEBUG" "Also replacing previous domain '$prev_domain' → '$new_domain' in $(basename "$file")"
+        update_fqdn "$file" "$prev_domain" "$new_domain"
+    fi
+}
+
+# Replace canonical baselines AND the previously applied domain across a directory tree.
+# Usage: apply_domain_to_dir <directory> <new_domain> [extra_old_fqdn]
+#   extra_old_fqdn: additional baseline to replace first (e.g. "local" for vNext manifests)
+apply_domain_to_dir() {
+    local directory="$1"
+    local new_domain="$2"
+    local extra_old_fqdn="${3:-}"
+    local prev_domain
+    prev_domain=$(get_last_applied_domain)
+
+    [ -n "$extra_old_fqdn" ] && update_fqdn_batch "$directory" "$extra_old_fqdn" "$new_domain"
+    update_fqdn_batch "$directory" "mifos.gazelle.test" "$new_domain"
+    update_fqdn_batch "$directory" "mifos.gazelle.localhost" "$new_domain"
+    if [ -n "$prev_domain" ] && [ "$prev_domain" != "$new_domain" ]; then
+        logWithVerboseCheck "$debug" "$DEBUG" "Also replacing previous domain '$prev_domain' → '$new_domain' in $directory"
+        update_fqdn_batch "$directory" "$prev_domain" "$new_domain"
+    fi
 }
 
 #------------------------------------------------------------------------------

--- a/src/deployer/core.sh
+++ b/src/deployer/core.sh
@@ -123,22 +123,22 @@ function createIngressSecret {
     chown "$k8s_user":"$k8s_user" "$key_dir/$primary_domain.key"
     chmod 600 "$key_dir/$primary_domain.key"
 
-    # Generate certificate with SANs
-    openssl req -x509 -new -nodes \
-        -key "$key_dir/$primary_domain.key" \
-        -sha256 -days 365 \
-        -out "$key_dir/$primary_domain.crt" \
-        -subj "/CN=$primary_domain" \
-        -extensions v3_req \
-        -config <(
-            cat <<EOF
+    # X.509 CN field is limited to 64 characters; truncate if needed.
+    # SANs handle actual hostname matching — CN is informational only.
+    local cn="${primary_domain:0:64}"
+
+    # Write OpenSSL config to a temp file (process substitution is non-seekable;
+    # openssl reads the config multiple times and fails silently with <(...))
+    local config_file
+    config_file=$(mktemp /tmp/openssl-san-XXXXXX.conf)
+    cat > "$config_file" <<EOF
 [req]
 distinguished_name=req_distinguished_name
 x509_extensions=v3_req
 prompt=no
 
 [req_distinguished_name]
-CN=$primary_domain
+CN=$cn
 
 [v3_req]
 subjectAltName=@alt_names
@@ -148,7 +148,17 @@ extendedKeyUsage=serverAuth
 [alt_names]
 ${san_config}
 EOF
-        ) >/dev/null 2>&1
+
+    # Generate certificate with SANs
+    openssl req -x509 -new -nodes \
+        -key "$key_dir/$primary_domain.key" \
+        -sha256 -days 365 \
+        -out "$key_dir/$primary_domain.crt" \
+        -subj "/CN=$cn" \
+        -extensions v3_req \
+        -config "$config_file" >/dev/null 2>&1
+
+    rm -f "$config_file"
 
     # Set proper ownership and permissions on the certificate
     chown "$k8s_user":"$k8s_user" "$key_dir/$primary_domain.crt"

--- a/src/deployer/cross-border-mifos.sh
+++ b/src/deployer/cross-border-mifos.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# cross-border-mifos.sh -- Deploy the Mifos fork of the GovStack cross-border payment web app
+
+set -euo pipefail
+
+CROSS_BORDER_REPO="${CROSS_BORDER_REPO:-$HOME/sandbox-usecase-cross-border-payment}"
+MANIFEST_DIR="$CROSS_BORDER_REPO/k8s"
+
+if [[ ! -d "$MANIFEST_DIR" ]]; then
+  echo "ERROR: manifest directory not found: $MANIFEST_DIR"
+  echo "       Clone the repo or set CROSS_BORDER_REPO to its location."
+  exit 1
+fi
+
+echo "Deploying cross-border-mifos from $MANIFEST_DIR"
+
+kubectl apply -f "$MANIFEST_DIR/namespace.yaml"
+kubectl apply -f "$MANIFEST_DIR/deployment.yaml"
+kubectl apply -f "$MANIFEST_DIR/service.yaml"
+kubectl apply -f "$MANIFEST_DIR/ingress.yaml"
+
+kubectl rollout restart deployment/cross-border-mifos -n cross-border-mifos
+kubectl rollout status deployment/cross-border-mifos -n cross-border-mifos
+
+echo "Done — https://cross-border.mifos.sandbox.govstack.global"

--- a/src/deployer/deployer.sh
+++ b/src/deployer/deployer.sh
@@ -186,8 +186,7 @@ function deployInfrastructure() {
   log_ok
 
   log_step "Updating FQDNs"
-  update_fqdn "$INFRA_CHART_DIR/values.yaml" "mifos.gazelle.test" "$GAZELLE_DOMAIN"
-  update_fqdn "$INFRA_CHART_DIR/values.yaml" "mifos.gazelle.localhost" "$GAZELLE_DOMAIN"
+  apply_domain_to_file "$INFRA_CHART_DIR/values.yaml" "$GAZELLE_DOMAIN"
   log_ok
 
   ensure_helm_dependencies "$INFRA_CHART_DIR"
@@ -404,5 +403,6 @@ function deployApps() {
     esac
   done
 
+  save_applied_domain
   print_deployment_end_message "$data_gen_failed"
 }

--- a/src/deployer/mastercard.sh
+++ b/src/deployer/mastercard.sh
@@ -164,8 +164,8 @@ deploy_connector() {
     local api_url="$MASTERCARD_API_URL"
 
     # Determine image settings
-    local image_repo="ph-ee-connector-mastercard-cbs"
-    local image_tag="1.0.0"
+    local sample_cr="$RUN_DIR/src/deployer/operators/mastercard/config/samples/mastercard-cbs-default.yaml"
+    local image_repo image_tag
     local localdev_section=""
 
     if [ "${MASTERCARD_LOCALDEV_ENABLED:-false}" == "true" ]; then
@@ -176,6 +176,13 @@ deploy_connector() {
     enabled: true
     hostPath: \"${MASTERCARD_CBS_HOME}\"
     jarPath: \"/app/build/libs/ph-ee-connector-mastercard-cbs-1.0.0-SNAPSHOT.jar\""
+    else
+        # Read image from sample CR as source of truth
+        image_repo=$(grep 'repository:' "$sample_cr" 2>/dev/null | head -1 | sed 's/.*repository:[[:space:]]*//' | tr -d '"')
+        image_tag=$(grep '[[:space:]]tag:' "$sample_cr" 2>/dev/null | head -1 | sed 's/.*tag:[[:space:]]*//' | tr -d '"')
+        image_repo="${image_repo:-ph-ee-connector-mastercard-cbs}"
+        image_tag="${image_tag:-1.0.0}"
+        logWithVerboseCheck "$debug" "$INFO" "Connector image: ${image_repo}:${image_tag}"
     fi
 
     local cr_file="/tmp/mastercard-cbs-cr.yaml"

--- a/src/deployer/mastercard.sh
+++ b/src/deployer/mastercard.sh
@@ -223,7 +223,7 @@ ${localdev_section}
       cpu: "500m"
       memory: "512Mi"
     requests:
-      cpu: "250m"
+      cpu: "50m"
       memory: "256Mi"
 EOF
     chmod 644 "$cr_file"
@@ -415,10 +415,6 @@ deploy_mastercard() {
     log_ok
 
     wait_for_deployment
-
-    log_step "Deploying BPMN workflow"
-    deploy_bpmn_workflow
-    log_ok
 
     log_step "Loading supplementary data"
     load_supplementary_data

--- a/src/deployer/mastercard.sh
+++ b/src/deployer/mastercard.sh
@@ -55,10 +55,12 @@ check_prerequisites() {
         exit 1
     fi
 
-    if [ ! -d "$MASTERCARD_CBS_HOME" ]; then
+    if [ "${MASTERCARD_LOCALDEV_ENABLED:-false}" == "true" ] && [ ! -d "$MASTERCARD_CBS_HOME" ]; then
         log_error "Mastercard CBS directory not found: $MASTERCARD_CBS_HOME"
         log_error "Set MASTERCARD_CBS_HOME or ensure ~/ph-ee-connector-mccbs exists"
         exit 1
+    elif [ "${MASTERCARD_LOCALDEV_ENABLED:-false}" != "true" ] && [ ! -d "$MASTERCARD_CBS_HOME" ]; then
+        logWithVerboseCheck "$debug" "$WARNING" "MASTERCARD_CBS_HOME not found ($MASTERCARD_CBS_HOME) - BPMN workflow deploy will be skipped (Docker image deployment)"
     fi
 
     if ! run_as_user "kubectl get namespace \"$PAYMENTHUB_NAMESPACE\"" &> /dev/null; then
@@ -257,7 +259,7 @@ wait_for_deployment() {
 }
 
 deploy_bpmn_workflow() {
-    local workflow_file="$MASTERCARD_CBS_HOME/orchestration/MastercardFundTransfer-DFSPID.bpmn"
+    local workflow_file="$RUN_DIR/orchestration/feel/MastercardFundTransfer-DFSPID.bpmn"
     local deploy_script="$RUN_DIR/src/utils/deployBpmn-gazelle.sh"
 
     if [ ! -f "$workflow_file" ]; then

--- a/src/deployer/mifosx.sh
+++ b/src/deployer/mifosx.sh
@@ -34,10 +34,8 @@ function DeployMifosXfromYaml() {
     cloneRepo "$MIFOSX_BRANCH" "$MIFOSX_REPO_LINK" "$APPS_DIR" "$MIFOSX_REPO_DIR"
 
     log_step "Updating FQDNs in manifests"
-    update_fqdn "$MIFOSX_MANIFESTS_DIR/web-app-deployment.yaml" "mifos.gazelle.test" "$GAZELLE_DOMAIN"
-    update_fqdn "$MIFOSX_MANIFESTS_DIR/web-app-ingress.yaml" "mifos.gazelle.test" "$GAZELLE_DOMAIN"
-    update_fqdn "$MIFOSX_MANIFESTS_DIR/web-app-deployment.yaml" "mifos.gazelle.localhost" "$GAZELLE_DOMAIN"
-    update_fqdn "$MIFOSX_MANIFESTS_DIR/web-app-ingress.yaml" "mifos.gazelle.localhost" "$GAZELLE_DOMAIN"
+    apply_domain_to_file "$MIFOSX_MANIFESTS_DIR/web-app-deployment.yaml" "$GAZELLE_DOMAIN"
+    apply_domain_to_file "$MIFOSX_MANIFESTS_DIR/web-app-ingress.yaml" "$GAZELLE_DOMAIN"
     log_ok
 
     log_step "Restoring MifosX database dump"

--- a/src/deployer/operators/mastercard/config/samples/mastercard-cbs-default.yaml
+++ b/src/deployer/operators/mastercard/config/samples/mastercard-cbs-default.yaml
@@ -12,8 +12,8 @@ spec:
 
   # Connector image
   image:
-    repository: ph-ee-connector-mastercard-cbs
-    tag: "1.0.0"
+    repository: openmf/ph-ee-connector-mccbs
+    tag: "dev-443a7dd"
     pullPolicy: IfNotPresent
 
   # Mastercard API configuration

--- a/src/deployer/operators/mastercard/config/samples/mastercard-cbs-default.yaml
+++ b/src/deployer/operators/mastercard/config/samples/mastercard-cbs-default.yaml
@@ -13,7 +13,7 @@ spec:
   # Connector image
   image:
     repository: openmf/ph-ee-connector-mccbs
-    tag: "dev-443a7dd"
+    tag: "phee-359-ec98e64"
     pullPolicy: IfNotPresent
 
   # Mastercard API configuration

--- a/src/deployer/operators/mastercard/controllers/reconcile.sh
+++ b/src/deployer/operators/mastercard/controllers/reconcile.sh
@@ -372,11 +372,9 @@ deploy_workflow() {
 
     log_info "Deploying BPMN workflows to Zeebe for all tenants..."
 
-    # Read MASTERCARD_CBS_HOME from config (defaults to connector repo location)
-    local mastercard_cbs_home=$(read_config_value "MASTERCARD_CBS_HOME" "$HOME/ph-ee-connector-mccbs" "$config_file")
     local mifos_gazelle_home=$(read_config_value "MIFOS_GAZELLE_HOME" "$HOME/mifos-gazelle" "$config_file")
 
-    local workflow_template="$mastercard_cbs_home/orchestration/MastercardFundTransfer-DFSPID.bpmn"
+    local workflow_template="$mifos_gazelle_home/orchestration/feel/MastercardFundTransfer-DFSPID.bpmn"
     local deploy_script="$mifos_gazelle_home/src/utils/deployBpmn-gazelle.sh"
 
     # Deploy using deployBpmn-gazelle.sh script (it handles multiple tenants)

--- a/src/deployer/operators/mastercard/deploy-operator.sh
+++ b/src/deployer/operators/mastercard/deploy-operator.sh
@@ -156,9 +156,15 @@ deploy_controller() {
         -n mastercard-demo \
         --dry-run=client -o yaml | kubectl apply -f -
 
+    # Create ConfigMap from config file so it can be mounted in the pod
+    # (hostPath does not work on remote clusters where worker nodes lack the local filesystem)
+    kubectl create configmap mastercard-operator-config \
+        --from-file="config.ini=${CONFIG_FILE}" \
+        -n mastercard-demo \
+        --dry-run=client -o yaml | kubectl apply -f -
+
     # Deploy controller as a Deployment
-    # Note: Mount config directory at the SAME path as on host so paths work consistently
-    # Note: Run as same UID as config file owner to access home directory (typically 750 permissions)
+    # Config is mounted from a ConfigMap at /etc/gazelle/config.ini
     cat <<EOF | kubectl apply -f -
 apiVersion: apps/v1
 kind: Deployment
@@ -178,10 +184,6 @@ spec:
         app: mastercard-cbs-operator
     spec:
       serviceAccountName: mastercard-cbs-operator
-      securityContext:
-        runAsUser: ${config_uid}
-        runAsGroup: ${config_uid}
-        fsGroup: ${config_uid}
       containers:
       - name: operator
         image: bitnami/kubectl:latest
@@ -189,38 +191,31 @@ spec:
           - /bin/bash
           - /scripts/reconcile.sh
           - -c
-          - ${CONFIG_FILE}
+          - /etc/gazelle/config.ini
         env:
         - name: HOME
           value: /tmp
         volumeMounts:
         - name: scripts
           mountPath: /scripts
-        - name: mastercard-data
-          mountPath: /opt/mastercard
         - name: config
-          mountPath: ${config_dir}
+          mountPath: /etc/gazelle
           readOnly: true
         resources:
           limits:
-            cpu: "200m"
+            cpu: "100m"
             memory: "256Mi"
           requests:
-            cpu: "100m"
+            cpu: "10m"
             memory: "128Mi"
       volumes:
       - name: scripts
         configMap:
           name: mastercard-operator-scripts
           defaultMode: 0755
-      - name: mastercard-data
-        hostPath:
-          path: ${mastercard_cbs_home}
-          type: Directory
       - name: config
-        hostPath:
-          path: ${config_dir}
-          type: Directory
+        configMap:
+          name: mastercard-operator-config
 EOF
 
     echo "✓ Controller deployed"

--- a/src/deployer/operators/mastercard/deploy-operator.sh
+++ b/src/deployer/operators/mastercard/deploy-operator.sh
@@ -187,6 +187,7 @@ spec:
       containers:
       - name: operator
         image: bitnami/kubectl:latest
+        imagePullPolicy: IfNotPresent
         command:
           - /bin/bash
           - /scripts/reconcile.sh
@@ -233,7 +234,7 @@ verify_deployment() {
     }
 
     echo "Checking operator pod..."
-    kubectl wait --for=condition=ready --timeout=60s pod -l app=mastercard-cbs-operator -n mastercard-demo || {
+    kubectl wait --for=condition=ready --timeout=120s pod -l app=mastercard-cbs-operator -n mastercard-demo || {
         echo "✗ Operator pod not ready"
         kubectl logs -l app=mastercard-cbs-operator -n mastercard-demo --tail=50
         return 1

--- a/src/deployer/operators/mastercard/deploy-operator.sh
+++ b/src/deployer/operators/mastercard/deploy-operator.sh
@@ -234,9 +234,14 @@ verify_deployment() {
     }
 
     echo "Checking operator pod..."
-    kubectl wait --for=condition=ready --timeout=120s pod -l app=mastercard-cbs-operator -n mastercard-demo || {
+    kubectl rollout status deployment/mastercard-cbs-operator -n mastercard-demo --timeout=120s || {
         echo "✗ Operator pod not ready"
-        kubectl logs -l app=mastercard-cbs-operator -n mastercard-demo --tail=50
+        echo "--- Pod status ---"
+        kubectl get pods -l app=mastercard-cbs-operator -n mastercard-demo
+        echo "--- Pod events ---"
+        kubectl describe pods -l app=mastercard-cbs-operator -n mastercard-demo | grep -A20 "Events:"
+        echo "--- Pod logs ---"
+        kubectl logs -l app=mastercard-cbs-operator -n mastercard-demo --tail=30 2>/dev/null || true
         return 1
     }
 

--- a/src/deployer/phee.sh
+++ b/src/deployer/phee.sh
@@ -70,10 +70,8 @@ function prepare_payment_hub_chart() {
   cloneRepo "$PH_EE_ENV_TEMPLATE_REPO_BRANCH" "$PH_EE_ENV_TEMPLATE_REPO_LINK" "$APPS_DIR" "$PH_EE_ENV_TEMPLATE_REPO_DIR"
   
   log_step "Updating FQDNs in Helm chart values and manifests"
-  update_fqdn "$PH_VALUES_FILE" "mifos.gazelle.test" "$GAZELLE_DOMAIN" 
-  update_fqdn "$PH_VALUES_FILE" "mifos.gazelle.localhost" "$GAZELLE_DOMAIN" 
-  update_fqdn_batch "$APPS_DIR/ph_template" "mifos.gazelle.test" "$GAZELLE_DOMAIN"
-  update_fqdn_batch "$APPS_DIR/ph_template" "mifos.gazelle.localhost" "$GAZELLE_DOMAIN"
+  apply_domain_to_file "$PH_VALUES_FILE" "$GAZELLE_DOMAIN"
+  apply_domain_to_dir "$APPS_DIR/ph_template" "$GAZELLE_DOMAIN"
   log_ok
 
   # Run for ph-ee-engine

--- a/src/deployer/vnext.sh
+++ b/src/deployer/vnext.sh
@@ -33,7 +33,7 @@ function deployvNext() {
   log_ok
 
   log_step "Updating FQDNs in manifests"
-  update_fqdn_batch "$APPS_DIR/vnext/packages/installer/manifests" "local" "$GAZELLE_DOMAIN"
+  apply_domain_to_dir "$APPS_DIR/vnext/packages/installer/manifests" "$GAZELLE_DOMAIN" "local"
   find "$APPS_DIR/$VNEXTREPO_DIR/packages/installer/manifests" -type f -name "*.yaml" | while read -r file; do
       perl -pi -e 's/ingressClassName:\s*nginx-ext/ingressClassName: nginx/' "$file"
   done

--- a/src/environmentSetup/k8s.sh
+++ b/src/environmentSetup/k8s.sh
@@ -180,11 +180,11 @@ function install_nginx_local_cluster {
 function install_k8s_tools {
     printf "\r==> Checking and installing Kubernetes tools     "
 
-    # --- NOTE ON VERSIONING ---
-    # TODO 
-    # Define these versions globally (or ensure they are passed in)
-    # local kubectl_version="v1.30.0"
-    # local helm_version="v3.14.4"
+    # For local clusters, match kubectl to the configured k3s version so there
+    # is no version skew between the client binary and the server.
+    if [[ "${environment:-local}" == "local" && -n "$k8s_version" ]]; then
+        KUBECTL_VERSION="v${k8s_version}.0"
+    fi
 
     # Detect architecture
     ARCH=$(uname -m)
@@ -207,46 +207,47 @@ function install_k8s_tools {
 
     for tool in "${!tools[@]}"; do
         if command -v "$tool" >/dev/null 2>&1; then
-            if [[ "$debug" == "true" ]]; then
-                echo "    $tool is already installed. Skipping."
+            # For kubectl, also verify the installed version matches the required version
+            if [[ "$tool" == "kubectl" ]]; then
+                installed_ver=$(kubectl version --client -o json 2>/dev/null | grep -o '"gitVersion":"[^"]*"' | head -1 | cut -d'"' -f4)
+                if [[ "$installed_ver" != "$KUBECTL_VERSION" ]]; then
+                    logWithVerboseCheck "$debug" "$INFO" "kubectl $installed_ver installed but $KUBECTL_VERSION required — reinstalling"
+                else
+                    logWithVerboseCheck "$debug" "$DEBUG" "$tool $installed_ver is already installed. Skipping."
+                    continue
+                fi
+            else
+                logWithVerboseCheck "$debug" "$DEBUG" "$tool is already installed. Skipping."
+                continue
             fi
-            
-            continue
+        fi
+        # Install or reinstall the tool
+        if [[ "$tool" == "kustomize" ]]; then
+            curl -s "${tools[$tool]}" | bash > /dev/null 2>&1
+
+        elif [[ "$tool" == "kubectl" ]]; then
+            curl -s -L "${tools[$tool]}" -o ./"$tool"
+            chmod +x ./"$tool"
+
         else
-            #echo "Installing $tool..."
-            # Installation logic
-            if [[ "$tool" == "kustomize" ]]; then
-                # kustomize uses a special install script
-                curl -s "${tools[$tool]}" | bash > /dev/null 2>&1
-
-            elif [[ "$tool" == "kubectl" ]]; then
-                # kubectl is a direct executable download, so we save it and make it executable
-                curl -s -L "${tools[$tool]}" -o ./"$tool"
-                chmod +x ./"$tool"
-
-            else
-                # Install archives (kubens, kubectx, k9s, helm)
-                curl -s -L "${tools[$tool]}" | tar xz -C . > /dev/null 2>&1
-                if [[ "$tool" == "helm" ]]; then
-                    # Helm has a nested structure after extraction
-                    mv linux-${ARCH_TYPE}/helm ./"$tool" > /dev/null 2>&1
-                    rm -rf linux-${ARCH_TYPE} > /dev/null 2>&1
-                fi
+            # Install archives (kubens, kubectx, k9s, helm)
+            curl -s -L "${tools[$tool]}" | tar xz -C . > /dev/null 2>&1
+            if [[ "$tool" == "helm" ]]; then
+                mv linux-${ARCH_TYPE}/helm ./"$tool" > /dev/null 2>&1
+                rm -rf linux-${ARCH_TYPE} > /dev/null 2>&1
             fi
+        fi
 
-            # Move the resulting executable(s) to the bin path
-            if [[ "$tool" != "kustomize" ]]; then
-                mv ./"$tool" /usr/local/bin > /dev/null 2>&1
-            fi
-            
-            # Verify installation
-            if command -v "$tool" >/dev/null 2>&1; then
-                if [[ "$debug" == "true" ]]; then
-                    echo "    $tool installed successfully."
-                fi
-            else
-                echo "Error: $tool installation failed."
-            fi
+        # Move the resulting executable(s) to the bin path
+        if [[ "$tool" != "kustomize" ]]; then
+            mv ./"$tool" /usr/local/bin > /dev/null 2>&1
+        fi
+
+        # Verify installation
+        if command -v "$tool" >/dev/null 2>&1; then
+            logWithVerboseCheck "$debug" "$DEBUG" "$tool installed successfully."
+        else
+            echo "Error: $tool installation failed."
         fi
     done
     printf "   [ok]\n"

--- a/src/utils/batch/batch_utils.py
+++ b/src/utils/batch/batch_utils.py
@@ -152,9 +152,18 @@ def detect_registering_institution(payee_identifiers, debug=False):
     in_clause = "', '".join(payee_identifiers)
 
     try:
+        pw_result = subprocess.run(
+            ['kubectl', 'get', 'secret', '-n', 'paymenthub', 'operationsmysql',
+             '-o', 'jsonpath={.data.mysql-root-password}'],
+            capture_output=True, text=False, timeout=10,
+        )
+        if pw_result.returncode != 0:
+            return None, {}
+        password = base64.b64decode(pw_result.stdout).decode('utf-8').strip()
+
         query_cmd = [
-            'kubectl', 'exec', '-n', 'infra', 'mysql-0', '--',
-            'mysql', '-umifos', '-ppassword', 'identity_account_mapper',
+            'kubectl', 'exec', '-n', 'paymenthub', 'operationsmysql-0', '--',
+            'mysql', '-uroot', f'-p{password}', 'identity_account_mapper',
             '-e', (
                 f"SELECT registering_institution_id, COUNT(*) as cnt "
                 f"FROM identity_details "
@@ -305,9 +314,18 @@ def check_identity_mapper(registering_institution, debug=False):
         )
 
     try:
+        pw_result = subprocess.run(
+            ['kubectl', 'get', 'secret', '-n', 'paymenthub', 'operationsmysql',
+             '-o', 'jsonpath={.data.mysql-root-password}'],
+            capture_output=True, text=False, timeout=10,
+        )
+        if pw_result.returncode != 0:
+            return None
+        password = base64.b64decode(pw_result.stdout).decode('utf-8').strip()
+
         query_cmd = [
-            'kubectl', 'exec', '-n', 'infra', 'mysql-0', '--',
-            'mysql', '-umifos', '-ppassword', 'identity_account_mapper',
+            'kubectl', 'exec', '-n', 'paymenthub', 'operationsmysql-0', '--',
+            'mysql', '-uroot', f'-p{password}', 'identity_account_mapper',
             '-e', (
                 f"SELECT COUNT(*) FROM identity_details "
                 f"WHERE registering_institution_id = '{registering_institution}'"

--- a/src/utils/batch/submit-batch.py
+++ b/src/utils/batch/submit-batch.py
@@ -244,36 +244,39 @@ def run_submit(csv_file, config_path, tenant, govstack, registering_institution,
     if not validate_tenant(tenant):
         return None
 
-    # Resolve registering institution for GovStack mode
+    # Resolve registering institution for GovStack mode.
+    # The registering institution is the payer — the entity that enrolled the
+    # beneficiaries for this disbursement programme.
+    # - If --tenant is given, the payer IS the tenant: use it directly.
+    # - If --tenant is not given (interactive/scripted with no tenant), auto-detect
+    #   from the CSV payees as a fallback.
     if govstack and registering_institution is None:
-        payees = get_payee_identifiers_from_csv(csv_file)
-        if payees:
-            best, counts = detect_registering_institution(payees, debug=debug)
-            if best:
-                total = len(payees)
-                matched = counts[best]
-                if len(counts) == 1:
+        if tenant:
+            registering_institution = tenant
+            print(f"✓ Registering institution: '{tenant}' (payer tenant)",
+                  file=sys.stderr)
+        else:
+            payees = get_payee_identifiers_from_csv(csv_file)
+            if payees:
+                best, counts = detect_registering_institution(payees, debug=debug)
+                if best:
+                    total = len(payees)
+                    matched = counts[best]
                     print(f"✓ Auto-detected registering institution: '{best}' "
                           f"({matched}/{total} payees matched)", file=sys.stderr)
+                    registering_institution = best
                 else:
-                    others = ', '.join(
-                        f"'{k}'({v})" for k, v in counts.items() if k != best
-                    )
-                    print(f"⚠️  Multiple institutions found: '{best}'({matched}) "
-                          f"[most], {others}", file=sys.stderr)
-                    print(f"   Using '{best}'. Pass --registering-institution to override.",
+                    print(f"\n⚠️  WARNING: Could not auto-detect registering institution.",
                           file=sys.stderr)
-                registering_institution = best
+                    print(f"   Payees from CSV not found in identity-account-mapper.",
+                          file=sys.stderr)
+                    print(f"   Fix: run generate-mifos-vnext-data.py --regenerate",
+                          file=sys.stderr)
+                    print(f"   Or:  pass --registering-institution explicitly",
+                          file=sys.stderr)
             else:
-                print(f"\n⚠️  WARNING: Could not auto-detect registering institution.",
-                      file=sys.stderr)
-                print(f"   Payees from CSV not found in identity-account-mapper.",
-                      file=sys.stderr)
-                print(f"   Fix: run generate-mifos-vnext-data.py --regenerate", file=sys.stderr)
-                print(f"   Or:  pass --registering-institution explicitly", file=sys.stderr)
-        else:
-            print(f"⚠️  No payee_identifier column found in CSV — "
-                  f"cannot auto-detect institution", file=sys.stderr)
+                print(f"⚠️  No payee_identifier column found in CSV — "
+                      f"cannot auto-detect institution", file=sys.stderr)
     elif govstack and registering_institution is not None:
         count = check_identity_mapper(registering_institution, debug=debug)
         if count is not None:

--- a/src/utils/batch/submit-batch.py
+++ b/src/utils/batch/submit-batch.py
@@ -220,7 +220,7 @@ def submit_batch_request(domain, csv_file_path, signature, tenant='greenbank',
 
 
 def run_submit(csv_file, config_path, tenant, govstack, registering_institution,
-               program, secret_key, debug, show_curl):
+               program, secret_key, debug, show_curl, skip_data_check=False):
     """
     Full submission pipeline. Returns response dict or None.
     Extracted so verify-batches.py can call it directly.
@@ -233,13 +233,16 @@ def run_submit(csv_file, config_path, tenant, govstack, registering_institution,
     print("="*80, file=sys.stderr)
     print(f"Using CSV: {csv_file}", file=sys.stderr)
 
-    data_ok, data_issues, data_hint = check_data_loaded(domain, config_path=config_path, debug=debug)
-    if not data_ok:
-        print(f"\nError: MifosX data is not loaded:", file=sys.stderr)
-        for issue in data_issues:
-            print(f"  • {issue}", file=sys.stderr)
-        print(f"{data_hint}", file=sys.stderr)
-        sys.exit(1)
+    if skip_data_check:
+        print("⚠️  Skipping Fineract data check (--skip-data-check)", file=sys.stderr)
+    else:
+        data_ok, data_issues, data_hint = check_data_loaded(domain, config_path=config_path, debug=debug)
+        if not data_ok:
+            print(f"\nError: MifosX data is not loaded:", file=sys.stderr)
+            for issue in data_issues:
+                print(f"  • {issue}", file=sys.stderr)
+            print(f"{data_hint}", file=sys.stderr)
+            sys.exit(1)
 
     if not validate_tenant(tenant):
         return None
@@ -508,6 +511,8 @@ EXAMPLES:
                         help='Print equivalent curl commands to stderr')
     parser.add_argument('--interactive', '-I', action='store_true',
                         help='Interactive mode — prompt for any missing options')
+    parser.add_argument('--skip-data-check', action='store_true',
+                        help='Skip Fineract client check (use for GovStack clusters without Mifos/Fineract)')
 
     args = parser.parse_args()
 
@@ -538,6 +543,7 @@ EXAMPLES:
         secret_key=args.secret_key,
         debug=args.debug,
         show_curl=args.show_curl,
+        skip_data_check=args.skip_data_check,
     )
 
     if result:

--- a/src/utils/batch/verify-batches.py
+++ b/src/utils/batch/verify-batches.py
@@ -164,13 +164,48 @@ def _ops_get(url, tenant, timeout=15):
         return None
 
 
+# Cache so we only probe once per domain per process
+_ops_api_host_cache = {}
+
+def _resolve_ops_api_host(domain, tenant="greenbank"):
+    """
+    Return the subdomain prefix for the operations-app API backend.
+
+    Standard mifos-gazelle: ops.{domain}
+    GovStack cluster:       ops-bk.{domain}  (ops. is the web frontend there)
+
+    Probes ops-bk first (it returns JSON for the API); if that returns HTML
+    the standard deployment has ops. serving the API directly.
+    """
+    if domain in _ops_api_host_cache:
+        return _ops_api_host_cache[domain]
+
+    for prefix in ("ops-bk", "ops"):
+        probe = f"https://{prefix}.{domain}/actuator/health"
+        try:
+            r = requests.get(probe, verify=False, timeout=5)
+            ct = r.headers.get("content-type", "")
+            # Spring Boot returns application/vnd.spring-boot.actuator.*
+            # The Angular frontend returns text/html
+            if "json" in ct and "html" not in ct:
+                _ops_api_host_cache[domain] = prefix
+                return prefix
+        except Exception:
+            pass
+
+    _ops_api_host_cache[domain] = "ops"
+    return "ops"
+
+
 def fetch_batch_summary(domain, batch_id, tenant):
-    url = f"https://ops.{domain}/api/v1/batch/{batch_id}?command=aggregate"
+    host = _resolve_ops_api_host(domain, tenant)
+    url = f"https://{host}.{domain}/api/v1/batch/{batch_id}?command=aggregate"
     return _ops_get(url, tenant)
 
 
 def fetch_batch_transfers(domain, batch_id, tenant, page_size=20):
-    url = f"https://ops.{domain}/api/v1/batch/detail?batchId={batch_id}&pageSize={page_size}"
+    host = _resolve_ops_api_host(domain, tenant)
+    url = f"https://{host}.{domain}/api/v1/batch/detail?batchId={batch_id}&pageSize={page_size}"
     data = _ops_get(url, tenant)
     if data and "content" in data:
         return data["content"]

--- a/src/utils/data-loading/generate-govstack-mastercard-batch.py
+++ b/src/utils/data-loading/generate-govstack-mastercard-batch.py
@@ -1,0 +1,542 @@
+#!/usr/bin/env python3
+"""
+Generate GovStack Mastercard CBS batch CSV and load supplementary data.
+
+Standalone tool for GovStack clusters where Mifos/Fineract/vNext are NOT
+running.  Derives payee MSISDNs from the mock beneficiary phone numbers,
+writes a ready-to-submit MASTERCARD_CBS batch CSV, and optionally loads the
+mastercard_cbs_supplementary_data table in the cluster MySQL.
+
+Source beneficiary data:
+  https://github.com/GovStackWorkingGroup/sandbox-usecase-cross-border-payment
+  /blob/main/src/mockdata/mock-african-beneficiaries.ts
+
+Usage:
+    # Generate CSV only (no cluster access required)
+    ./generate-govstack-mastercard-batch.py --generate-csv
+
+    # Load supplementary data into cluster MySQL
+    ./generate-govstack-mastercard-batch.py --load-supplementary -c ~/config.ini
+
+    # Do both
+    ./generate-govstack-mastercard-batch.py --all -c ~/config.ini
+
+    # Include only ACTIVE beneficiaries
+    ./generate-govstack-mastercard-batch.py --all -c ~/config.ini --active-only
+"""
+
+import argparse
+import configparser
+import csv
+import re
+import subprocess
+import sys
+import uuid
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# GovStack mock beneficiary data
+# Source: mock-african-beneficiaries.ts (10 records, Zimbabwe pension)
+# ---------------------------------------------------------------------------
+GOVSTACK_BENEFICIARIES = [
+    {
+        "payeeIdentity": "ZW0000000000000001",
+        "bankingInstitutionCode": "SBZAZAJJ",
+        "financialAddress": "ZA930000001000000001",
+        "firstName": "Tendai", "middleName": "James", "lastName": "Mukamuri",
+        "status": "ACTIVE",
+        "phoneNumberPrimary": "+27-21-111-1111",
+        "emailAddressPrimary": "tendai.mukamuri1@email.com",
+        "currentAddressLine1": "12 Vilakazi Street",
+        "currentAddressLine2": "Apartment 1A",
+        "currentCity": "Johannesburg",
+        "currentCountry": "ZAF",
+        "monthlyPensionAmount": 3200.00,
+        "bankName": "Standard Bank of South Africa",
+        "bankBranch": "Johannesburg Central",
+    },
+    {
+        "payeeIdentity": "ZW0000000000000002",
+        "bankingInstitutionCode": "FNBSAJJ",
+        "financialAddress": "ZA930000001000000002",
+        "firstName": "Chipo", "middleName": "Rose", "lastName": "Chikafu",
+        "status": "ACTIVE",
+        "phoneNumberPrimary": "+27-31-222-2222",
+        "emailAddressPrimary": "chipo.chikafu@email.com",
+        "currentAddressLine1": "102 Long Street",
+        "currentAddressLine2": "Flat 3C",
+        "currentCity": "Cape Town",
+        "currentCountry": "ZAF",
+        "monthlyPensionAmount": 2890.00,
+        "bankName": "First National Bank",
+        "bankBranch": "Cape Town Central",
+    },
+    {
+        "payeeIdentity": "ZW0000000000000003",
+        "bankingInstitutionCode": "ABSAZAJJ",
+        "financialAddress": "ZA930000001000000003",
+        "firstName": "Farai", "middleName": "Peter", "lastName": "Ncube",
+        "status": "ACTIVE",
+        "phoneNumberPrimary": "+27-11-333-3333",
+        "emailAddressPrimary": "farai.ncube@email.com",
+        "currentAddressLine1": "88 Jan Smuts Avenue",
+        "currentAddressLine2": "Unit 12",
+        "currentCity": "Randburg",
+        "currentCountry": "ZAF",
+        "monthlyPensionAmount": 3100.00,
+        "bankName": "ABSA Bank",
+        "bankBranch": "Randburg Branch",
+    },
+    {
+        "payeeIdentity": "ZW0000000000000004",
+        "bankingInstitutionCode": "SBZAZAJJ",
+        "financialAddress": "ZA930000001000000004",
+        "firstName": "Nomsa", "middleName": "Grace", "lastName": "Maphosa",
+        "status": "PENDING",
+        "phoneNumberPrimary": "+27-41-444-4444",
+        "emailAddressPrimary": "nomsa.maphosa@email.com",
+        "currentAddressLine1": "34 Govan Mbeki Avenue",
+        "currentAddressLine2": "Suite 10",
+        "currentCity": "Port Elizabeth",
+        "currentCountry": "ZAF",
+        "monthlyPensionAmount": 2800.00,
+        "bankName": "Standard Bank of South Africa",
+        "bankBranch": "Port Elizabeth Main",
+    },
+    {
+        "payeeIdentity": "ZW0000000000000005",
+        "bankingInstitutionCode": "CAPITECJJ",
+        "financialAddress": "ZA930000001000000005",
+        "firstName": "Patience", "middleName": "Faith", "lastName": "Zhou",
+        "status": "PENDING",
+        "phoneNumberPrimary": "+27-21-555-5555",
+        "emailAddressPrimary": "patience.zhou@email.com",
+        "currentAddressLine1": "78 Greenmarket Square",
+        "currentAddressLine2": "Flat 5D",
+        "currentCity": "Cape Town",
+        "currentCountry": "ZAF",
+        "monthlyPensionAmount": 3000.00,
+        "bankName": "Capitec Bank",
+        "bankBranch": "Cape Town Branch",
+    },
+    {
+        "payeeIdentity": "ZW0000000000000006",
+        "bankingInstitutionCode": "SBZAZAJJ",
+        "financialAddress": "ZA930000001000000006",
+        "firstName": "Simba", "middleName": "John", "lastName": "Mutasa",
+        "status": "REJECTED",
+        "phoneNumberPrimary": "+27-12-666-6666",
+        "emailAddressPrimary": "simba.mutasa@email.com",
+        "currentAddressLine1": "501 Stanza Bopape Street",
+        "currentAddressLine2": "",
+        "currentCity": "Pretoria",
+        "currentCountry": "ZAF",
+        "monthlyPensionAmount": 3150.00,
+        "bankName": "Standard Bank of South Africa",
+        "bankBranch": "Pretoria Main",
+    },
+    {
+        "payeeIdentity": "ZW0000000000000007",
+        "bankingInstitutionCode": "FNBSAJJ",
+        "financialAddress": "ZA930000001000000007",
+        "firstName": "Tatenda", "middleName": "Peter", "lastName": "Moyo",
+        "status": "REJECTED",
+        "phoneNumberPrimary": "+27-21-777-7777",
+        "emailAddressPrimary": "tatenda.moyo@email.com",
+        "currentAddressLine1": "10 Wale Street",
+        "currentAddressLine2": "Apartment 7B",
+        "currentCity": "Cape Town",
+        "currentCountry": "ZAF",
+        "monthlyPensionAmount": 2850.00,
+        "bankName": "First National Bank",
+        "bankBranch": "Cape Town Central",
+    },
+    {
+        "payeeIdentity": "ZW0000000000000008",
+        "bankingInstitutionCode": "CAPITECJJ",
+        "financialAddress": "ZA930000001000000008",
+        "firstName": "Linda", "middleName": "Joyce", "lastName": "Mawere",
+        "status": "REJECTED",
+        "phoneNumberPrimary": "+27-21-888-8888",
+        "emailAddressPrimary": "linda.mawere@email.com",
+        "currentAddressLine1": "42 Roeland Street",
+        "currentAddressLine2": "Suite 9E",
+        "currentCity": "Cape Town",
+        "currentCountry": "ZAF",
+        "monthlyPensionAmount": 2990.00,
+        "bankName": "Capitec Bank",
+        "bankBranch": "Cape Town Branch",
+    },
+    {
+        "payeeIdentity": "ZW0000000000000009",
+        "bankingInstitutionCode": "ABSAZAJJ",
+        "financialAddress": "ZA930000001000000009",
+        "firstName": "Blessing", "middleName": "Timothy", "lastName": "Dube",
+        "status": "PENDING",
+        "phoneNumberPrimary": "+27-31-999-9999",
+        "emailAddressPrimary": "blessing.dube@email.com",
+        "currentAddressLine1": "15 Margaret Mncadi Ave",
+        "currentAddressLine2": "",
+        "currentCity": "Durban",
+        "currentCountry": "ZAF",
+        "monthlyPensionAmount": 3250.00,
+        "bankName": "ABSA Bank",
+        "bankBranch": "Durban Branch",
+    },
+    {
+        "payeeIdentity": "ZW0000000000000010",
+        "bankingInstitutionCode": "SBZAZAJJ",
+        "financialAddress": "ZA930000001000000010",
+        "firstName": "Rudo", "middleName": "Mercy", "lastName": "Mugabe",
+        "status": "PENDING",
+        "phoneNumberPrimary": "+27-12-101-0101",
+        "emailAddressPrimary": "rudo.mugabe@email.com",
+        "currentAddressLine1": "18 Francis Baard Street",
+        "currentAddressLine2": "",
+        "currentCity": "Pretoria",
+        "currentCountry": "ZAF",
+        "monthlyPensionAmount": 3400.00,
+        "bankName": "Standard Bank of South Africa",
+        "bankBranch": "Pretoria Main",
+    },
+]
+
+# Fictional GovStack Ministry of Social Welfare payer MSISDN
+# (used as the bulk-batch payer; no real account needed for Mastercard sandbox)
+GOVSTACK_PAYER_MSISDN = "27000000000"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def normalize_msisdn(phone: str) -> str:
+    """Strip all non-digit characters from a phone number."""
+    return re.sub(r"\D", "", phone)
+
+
+def filter_beneficiaries(beneficiaries, active_only: bool):
+    if active_only:
+        return [b for b in beneficiaries if b["status"] == "ACTIVE"]
+    return beneficiaries
+
+
+def build_address(b) -> str:
+    parts = [b["currentAddressLine1"]]
+    if b.get("currentAddressLine2"):
+        parts.append(b["currentAddressLine2"])
+    return ", ".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# CSV generation
+# ---------------------------------------------------------------------------
+
+def generate_csv(beneficiaries, output_path: Path):
+    fieldnames = [
+        "id", "request_id", "payment_mode",
+        "payer_identifier_type", "payer_identifier",
+        "payee_identifier_type", "payee_identifier",
+        "amount", "currency", "note",
+    ]
+
+    rows = []
+    for idx, b in enumerate(beneficiaries):
+        msisdn = normalize_msisdn(b["phoneNumberPrimary"])
+        rows.append({
+            "id": idx,
+            "request_id": str(uuid.uuid4()),
+            "payment_mode": "MASTERCARD_CBS",
+            "payer_identifier_type": "MSISDN",
+            "payer_identifier": GOVSTACK_PAYER_MSISDN,
+            "payee_identifier_type": "MSISDN",
+            "payee_identifier": msisdn,
+            "amount": int(b["monthlyPensionAmount"]),
+            "currency": "ZAR",
+            "note": f"GovStack pension - {b['firstName']} {b['lastName']} ({b['payeeIdentity']})",
+        })
+
+    with open(output_path, "w", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Supplementary data loading
+# ---------------------------------------------------------------------------
+
+def get_ini_value(config_file: str, section: str, key: str) -> str:
+    cfg = configparser.ConfigParser()
+    cfg.read(config_file)
+    try:
+        return cfg.get(section, key)
+    except (configparser.NoSectionError, configparser.NoOptionError):
+        return ""
+
+
+def run_kubectl(kubeconfig: str, namespace: str, pod: str, db: str, sql: str, db_pass: str) -> str:
+    cmd = [
+        "kubectl", "--kubeconfig", kubeconfig,
+        "exec", "-n", namespace, pod, "--",
+        "mysql", "-u", "root", f"-p{db_pass}", db,
+        "-N", "-s", "-e", sql,
+    ]
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+        return result.stdout.strip()
+    except subprocess.TimeoutExpired:
+        print(f"  ✗ kubectl exec timed out", file=sys.stderr)
+        return ""
+    except FileNotFoundError:
+        print("  ✗ kubectl not found in PATH", file=sys.stderr)
+        return ""
+
+
+def load_supplementary_data(beneficiaries, config_file: str, namespace: str, debug: bool):
+    config_file = str(Path(config_file).expanduser())
+
+    k8s_user = get_ini_value(config_file, "kubernetes", "k8s_user")
+    kubeconfig = get_ini_value(config_file, "kubernetes", "kubeconfig_path")
+    kubeconfig = str(Path(kubeconfig.replace("$USER", k8s_user)).expanduser())
+
+    if not Path(kubeconfig).exists():
+        print(f"Error: kubeconfig not found: {kubeconfig}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Kubeconfig : {kubeconfig}")
+    print(f"Namespace  : {namespace}")
+
+    # Get MySQL root password from k8s secret
+    try:
+        pw_cmd = [
+            "kubectl", "--kubeconfig", kubeconfig,
+            "get", "secret", "-n", namespace, "operationsmysql",
+            "-o", "jsonpath={.data.mysql-root-password}",
+        ]
+        pw_b64 = subprocess.check_output(pw_cmd, text=True, timeout=15).strip()
+        import base64
+        db_pass = base64.b64decode(pw_b64).decode()
+    except Exception as e:
+        print(f"Error: Could not get MySQL password: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    # Find the MySQL pod
+    try:
+        pod_cmd = [
+            "kubectl", "--kubeconfig", kubeconfig,
+            "get", "pods", "-n", namespace,
+            "-l", "app.kubernetes.io/name=operationsmysql",
+            "-o", "jsonpath={.items[0].metadata.name}",
+        ]
+        mysql_pod = subprocess.check_output(pod_cmd, text=True, timeout=15).strip()
+    except Exception:
+        mysql_pod = ""
+
+    if not mysql_pod:
+        print("Error: Could not find operationsmysql pod", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"MySQL pod  : {mysql_pod}")
+
+    def exec_sql(db, sql):
+        return run_kubectl(kubeconfig, namespace, mysql_pod, db, sql, db_pass)
+
+    # Ensure operations database exists
+    exec_sql("mysql", "CREATE DATABASE IF NOT EXISTS operations")
+
+    # Create table if not exists (reuse existing schema so this is idempotent)
+    create_sql = (
+        "CREATE TABLE IF NOT EXISTS mastercard_cbs_supplementary_data ("
+        "  id BIGINT AUTO_INCREMENT PRIMARY KEY,"
+        "  payee_msisdn VARCHAR(20) NOT NULL,"
+        "  payee_account_number VARCHAR(50),"
+        "  sender_organisation_name VARCHAR(255) NOT NULL DEFAULT 'GovStack Ministry of Social Welfare',"
+        "  sender_address_line1 VARCHAR(255) NOT NULL DEFAULT '123 Government Boulevard',"
+        "  sender_address_city VARCHAR(100) NOT NULL DEFAULT 'Capital City',"
+        "  sender_address_country VARCHAR(3) NOT NULL DEFAULT 'ZAF',"
+        "  payment_origination_country VARCHAR(3) NOT NULL DEFAULT 'ZAF',"
+        "  destination_country_iso3 VARCHAR(3) NOT NULL DEFAULT 'ZAF',"
+        "  beneficiary_currency VARCHAR(3) NOT NULL DEFAULT 'ZAR',"
+        "  beneficiary_currency_decimal_precision INT NOT NULL DEFAULT 2,"
+        "  destination_service_tag VARCHAR(20) NOT NULL DEFAULT 'ZAK-BK',"
+        "  payment_type VARCHAR(10) NOT NULL DEFAULT 'B2P',"
+        "  recipient_first_name VARCHAR(100),"
+        "  recipient_last_name VARCHAR(100),"
+        "  recipient_address_line1 VARCHAR(255),"
+        "  recipient_address_city VARCHAR(100),"
+        "  recipient_phone VARCHAR(20),"
+        "  recipient_email VARCHAR(255),"
+        "  recipient_address_country VARCHAR(3),"
+        "  bank_name VARCHAR(255),"
+        "  bank_swift_code VARCHAR(11),"
+        "  bank_branch_name VARCHAR(255),"
+        "  bank_country_code VARCHAR(3),"
+        "  purpose_of_payment VARCHAR(500),"
+        "  created_by VARCHAR(100),"
+        "  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,"
+        "  UNIQUE KEY uk_msisdn (payee_msisdn),"
+        "  INDEX idx_account (payee_account_number)"
+        ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4"
+    )
+    exec_sql("operations", create_sql)
+
+    inserted = 0
+    for b in beneficiaries:
+        msisdn = normalize_msisdn(b["phoneNumberPrimary"])
+        address = build_address(b)
+        purpose = f"GovStack pension payment to {b['firstName']} {b['lastName']} ({b['payeeIdentity']})"
+        # Escape single quotes in any string fields
+        def esc(s): return str(s).replace("'", "\\'")
+
+        insert_sql = (
+            f"INSERT INTO mastercard_cbs_supplementary_data ("
+            f"  payee_msisdn, payee_account_number,"
+            f"  recipient_first_name, recipient_last_name,"
+            f"  recipient_address_line1, recipient_address_city, recipient_address_country,"
+            f"  recipient_phone, recipient_email,"
+            f"  bank_name, bank_swift_code, bank_branch_name, bank_country_code,"
+            f"  purpose_of_payment, created_by"
+            f") VALUES ("
+            f"  '{esc(msisdn)}', '{esc(b['financialAddress'])}',"
+            f"  '{esc(b['firstName'])}', '{esc(b['lastName'])}',"
+            f"  '{esc(address)}', '{esc(b['currentCity'])}', '{esc(b['currentCountry'])}',"
+            f"  '{esc(msisdn)}', '{esc(b['emailAddressPrimary'])}',"
+            f"  '{esc(b['bankName'])}', '{esc(b['bankingInstitutionCode'])}', '{esc(b['bankBranch'])}', 'ZA',"
+            f"  '{esc(purpose)}', 'generate-govstack-mastercard-batch.py'"
+            f") ON DUPLICATE KEY UPDATE"
+            f"  payee_account_number = VALUES(payee_account_number),"
+            f"  recipient_first_name = VALUES(recipient_first_name),"
+            f"  recipient_last_name  = VALUES(recipient_last_name),"
+            f"  bank_swift_code      = VALUES(bank_swift_code),"
+            f"  bank_name            = VALUES(bank_name)"
+        )
+
+        if debug:
+            print(f"  SQL: {insert_sql[:120]}...", file=sys.stderr)
+
+        result = exec_sql("operations", insert_sql)
+        status = b["status"]
+        print(f"  + {msisdn}  {b['firstName']} {b['lastName']} ({b['payeeIdentity']}) [{status}]")
+        inserted += 1
+
+    return inserted
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    script_dir = Path(__file__).parent
+    default_output = script_dir.parent / "batch"
+    default_config = script_dir.parent.parent.parent / "config" / "config.ini"
+
+    parser = argparse.ArgumentParser(
+        description="Generate GovStack Mastercard batch CSV and load supplementary data",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Generate CSV (no cluster access needed):
+  ./generate-govstack-mastercard-batch.py --generate-csv
+
+  # Load supplementary data into cluster MySQL:
+  ./generate-govstack-mastercard-batch.py --load-supplementary -c ~/config.ini
+
+  # Both at once:
+  ./generate-govstack-mastercard-batch.py --all -c ~/config.ini
+
+  # ACTIVE beneficiaries only:
+  ./generate-govstack-mastercard-batch.py --all -c ~/config.ini --active-only
+
+Submit the generated CSV with:
+  python3 src/utils/batch/submit-batch.py \\
+      -f src/utils/batch/bulk-govstack-mastercard-10.csv \\
+      --tenant greenbank-mastercard
+
+Beneficiary statuses in mock data:
+  ACTIVE  (3): ZW0000000000000001-003  — ready for payment
+  PENDING (4): ZW0000000000000004-005, 009-010  — awaiting approval
+  REJECTED(3): ZW0000000000000006-008  — included for test coverage
+        """,
+    )
+
+    parser.add_argument("--generate-csv", action="store_true",
+                        help="Write bulk-govstack-mastercard-N.csv to output dir")
+    parser.add_argument("--load-supplementary", action="store_true",
+                        help="Load supplementary data into cluster MySQL")
+    parser.add_argument("--all", action="store_true",
+                        help="Do both --generate-csv and --load-supplementary")
+    parser.add_argument("-c", "--config", type=Path, default=default_config,
+                        help=f"Path to config.ini (default: {default_config})")
+    parser.add_argument("-o", "--output-dir", type=Path, default=default_output,
+                        help=f"CSV output directory (default: {default_output})")
+    parser.add_argument("-n", "--namespace", default="paymenthub",
+                        help="Kubernetes namespace (default: paymenthub)")
+    parser.add_argument("--active-only", action="store_true",
+                        help="Include only ACTIVE beneficiaries (skips PENDING/REJECTED)")
+    parser.add_argument("-d", "--debug", action="store_true",
+                        help="Show detailed SQL and kubectl output")
+
+    args = parser.parse_args()
+
+    do_csv  = args.generate_csv or args.all
+    do_supp = args.load_supplementary or args.all
+
+    if not do_csv and not do_supp:
+        parser.print_help()
+        sys.exit(1)
+
+    beneficiaries = filter_beneficiaries(GOVSTACK_BENEFICIARIES, args.active_only)
+    n = len(beneficiaries)
+
+    print("=" * 60)
+    print("GovStack Mastercard Batch Generator")
+    print("=" * 60)
+    print(f"Beneficiaries : {n} ({'ACTIVE only' if args.active_only else 'all statuses'})")
+    print(f"Payer MSISDN  : {GOVSTACK_PAYER_MSISDN}  (GovStack Ministry of Social Welfare)")
+    print()
+
+    if do_csv:
+        args.output_dir.mkdir(parents=True, exist_ok=True)
+        csv_name = f"bulk-govstack-mastercard-{n}.csv"
+        csv_path = args.output_dir / csv_name
+        rows = generate_csv(beneficiaries, csv_path)
+        print(f"CSV generated : {csv_path}  ({len(rows)} rows)")
+        print()
+        print("  id  MSISDN           payeeIdentity           amount  name")
+        print("  " + "-" * 72)
+        for r, b in zip(rows, beneficiaries):
+            msisdn = normalize_msisdn(b["phoneNumberPrimary"])
+            print(f"  {r['id']:<3} {msisdn:<16} {b['payeeIdentity']:<23} {r['amount']:<7} "
+                  f"{b['firstName']} {b['lastName']} [{b['status']}]")
+        print()
+        print(f"Submit with:")
+        print(f"  python3 src/utils/batch/submit-batch.py \\")
+        print(f"      -f {csv_path} \\")
+        print(f"      --tenant greenbank-mastercard")
+        print()
+
+    if do_supp:
+        if not args.config.exists():
+            print(f"Error: config not found: {args.config}", file=sys.stderr)
+            sys.exit(1)
+        print(f"Loading supplementary data from: {args.config}")
+        print()
+        count = load_supplementary_data(
+            beneficiaries,
+            str(args.config),
+            args.namespace,
+            args.debug,
+        )
+        print()
+        print(f"Loaded {count} supplementary data records into operations.mastercard_cbs_supplementary_data")
+        print()
+        print("Reload with:  ./generate-govstack-mastercard-batch.py --load-supplementary -c <config>")
+
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This branch / PR extends Mifos Gazelle with Mastercard CBS connector support, remote cluster reliability improvements, and GovStack cross-border deployment tooling. It also incorporates all dev branch work up to the v2.0.0 release (script reorganisation, closedloop batch fixes, batch verification tooling, and documentation overhaul).  Most work is a result of testing in the GovStack Cloud and successfully running mastercard txns using the GovStack demonstration data 

**Remote Cluster: Domain Re-deployment Fix**
6f0ec43 — update_fqdn only knew to replace the canonical baselines (mifos.gazelle.test, mifos.gazelle.localhost). On a second deploy with a different domain, the already-baked-in custom domain was never replaced, requiring users to delete repos/ph_template to recover. Fix adds get_last_applied_domain/save_applied_domain/apply_domain_to_file/apply_domain_to_dir helpers in core.sh that track the previously-applied domain in config/.last_applied_domain and replace it alongside the canonical baseline on every run.

**Mastercard CBS Operator — Remote Cluster Support**
f7c725a, fda095f, d778c68, 0ba7b5d, 3a47dfc, ae08c0c

**Replaced hostPath volumes with a ConfigMap (mastercard-operator-config) so the operator pod can read config.ini on remote clusters where workers don't share the local filesystem; removed runAsUser/Group securityContext tied to local file ownership**
Fixed SAN length issue in TLS certs when the DNS domain name is too long
Updated operator to use an interim docker image tag; set imagePullPolicy: IfNotPresent for the demo deployment
Fixed local-vs-remote cluster detection logic; BPMN is now deployed from gazelle/orchestration/ dir rather than inside the operator deploy step
Fixed registering institution logic and batch_utils.py database connection setting
GovStack Cross-Border Client
63698e8, b873512

**New src/deployer/cross-border-mifos.sh** — deploys the GovStack cross-border client app (forked from GovStack repo, batch features added)
Added cert-manager annotations to ph_values.yaml to fix CORS errors on the cross-border ingress
GovStack Batch Tooling (non-Fineract clusters)
4e260e0

submit-batch.py: --skip-data-check flag to bypass the Fineract client pre-flight on GovStack clusters that don't run Mifos/Fineract
verify-batches.py: auto-detects ops API host — probes ops-bk.{domain} first (GovStack layout) then falls back to ops.{domain} (standard layout)
**New generate-govstack-mastercard-batch.py**: generates a MASTERCARD_CBS batch CSV and loads supplementary data from mock beneficiary data, no Fineract/vNext required