### PR TITLE
 Add MifosX smoke tests to improve deployment verification

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,20 +27,10 @@ commands:
             fi
 
       - run:
-          name: Health check endpoints
+          name: Smoke tests
           command: |
-            echo "Checking main endpoints..."
-            
-            # Get cluster IP
-            CLUSTER_IP=$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}' || echo "127.0.0.1")
-            
-            # Test main endpoints
-            curl -f http://$CLUSTER_IP/health || echo "Default health check failed"
-            curl -f http://mifos.mifos.gazelle.test || echo "MifosX failed"
-            curl -f http://vnextadmin.mifos.gazelle.test || echo "vNext failed"
-            curl -f http://ops.mifos.gazelle.test || echo "Payment Hub failed"
-            
-            echo "Health checks completed"
+            chmod +x ./src/utils/smoke-tests.sh
+            sudo ./src/utils/smoke-tests.sh -u "$USER" -a mifosx -s true -d true
 
 jobs:
   deploy-test-amd64:

--- a/src/deployer/deployer.sh
+++ b/src/deployer/deployer.sh
@@ -240,31 +240,120 @@ function applyKubeManifests() {
 }
 
 #------------------------------------------------------------
-# Description : Placeholder for vNext application testing logic.
-# Usage : test_vnext
-# Example: test_vnext
+# Description : Returns 0 when an HTTP endpoint responds with one of the
+#               allowed status codes. Uses curl -k because Gazelle uses
+#               self-signed ingress certificates by default.
+# Usage : smoke_http_ok <url> <timeout> <codes_csv> [curl args...]
 #------------------------------------------------------------
-function test_vnext() {
-  echo "TODO" #TODO Write function to test apps
+function smoke_http_ok() {
+  local url="$1"
+  local timeout="${2:-20}"
+  local allowed_codes_csv="${3:-200}"
+  shift 3 || true
+
+  local http_code
+  http_code=$(curl -ksS -o /dev/null -w "%{http_code}" --max-time "$timeout" "$@" "$url" 2>/dev/null)
+  local curl_exit=$?
+
+  if [[ $curl_exit -ne 0 ]]; then
+    return 1
+  fi
+
+  local old_ifs="$IFS"
+  IFS=','
+  read -r -a allowed_codes <<< "$allowed_codes_csv"
+  IFS="$old_ifs"
+
+  local code
+  for code in "${allowed_codes[@]}"; do
+    if [[ "$http_code" == "$code" ]]; then
+      return 0
+    fi
+  done
+
+  return 1
 }
 
 #------------------------------------------------------------
-# Description : Placeholder for Phee application testing logic.
-# Usage : test_phee
-# Example: test_phee
+# Description : Shared wrapper for smoke-test output. In strict mode failures
+#               are returned to the caller; otherwise they are only warned.
+# Usage : finish_smoke_test <name> <status> <strict_mode>
 #------------------------------------------------------------
-function test_phee() {
-  echo "TODO"
+function finish_smoke_test() {
+  local name="$1"
+  local status="$2"
+  local strict_mode="${3:-false}"
+
+  if [[ "$status" -eq 0 ]]; then
+    log_ok
+    return 0
+  fi
+
+  if [[ "$strict_mode" == "true" ]]; then
+    log_failed
+    return 1
+  fi
+
+  log_warn "$name smoke test failed (non-blocking)"
+  return 0
 }
 
 #------------------------------------------------------------
-# Description : Placeholder for MifosX application testing logic.
-# Usage : test_mifosx <instance_name>
-# Example: test_mifosx default
+# Description : Smoke test for MifosX. Verifies namespace readiness, the web
+#               app ingress, and tenant-aware Fineract API reachability.
+# Usage : test_mifosx [strict_mode]
+# Example: test_mifosx true
 #------------------------------------------------------------
 function test_mifosx() {
-  local instance_name=$1
-  # TODO: Implement testing logic
+  local strict_mode="${1:-false}"
+  local status=0
+  local auth="Basic bWlmb3M6cGFzc3dvcmQ="
+
+  log_step "Smoke test: MifosX"
+
+  if ! is_app_running "$MIFOSX_NAMESPACE"; then
+    status=1
+  elif ! smoke_http_ok "https://mifos.${GAZELLE_DOMAIN}" 20 "200,301,302,303,307,308"; then
+    status=1
+  elif ! smoke_http_ok \
+      "https://mifos.${GAZELLE_DOMAIN}/fineract-provider/api/v1/clients?limit=1" \
+      20 "200" \
+      -H "Authorization: ${auth}" \
+      -H "Fineract-Platform-TenantId: greenbank"; then
+    status=1
+  fi
+
+  finish_smoke_test "MifosX" "$status" "$strict_mode"
+}
+
+#------------------------------------------------------------
+# Description : Runs smoke tests for a space-separated list of apps.
+# Usage : run_smoke_tests "mifosx" [strict_mode]
+# Example: run_smoke_tests "all" true
+#------------------------------------------------------------
+function run_smoke_tests() {
+  local apps_to_test="$1"
+  local strict_mode="${2:-false}"
+  local overall_status=0
+
+  if [[ -z "$apps_to_test" || "$apps_to_test" == "all" ]]; then
+    apps_to_test="mifosx"
+  fi
+
+  log_section "Running smoke tests"
+
+  for app in $apps_to_test; do
+    case "$app" in
+      "mifosx")
+        test_mifosx "$strict_mode" || overall_status=1
+        ;;
+      *)
+        log_warn "Unknown smoke-test target '$app' skipped"
+        ;;
+    esac
+  done
+
+  return "$overall_status"
 }
 
 #------------------------------------------------------------

--- a/src/utils/smoke-tests.sh
+++ b/src/utils/smoke-tests.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# smoke-tests.sh -- Optional Gazelle smoke-test runner.
+
+RUN_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../.." && pwd )"
+export RUN_DIR
+
+source "$RUN_DIR/src/commandline/commandline.sh" || {
+  echo "FATAL: Could not source commandline.sh. Check RUN_DIR: $RUN_DIR"
+  exit 1
+}
+
+STRICT_MODE="false"
+APPS_TO_TEST="mifosx"
+
+function show_smoke_usage() {
+  cat <<EOF
+Usage: sudo ./src/utils/smoke-tests.sh [-f <config.ini>] [-u <user>] [-a <apps>] [-s true|false] [-d true|false]
+
+Examples:
+  sudo ./src/utils/smoke-tests.sh -u \$USER
+  sudo ./src/utils/smoke-tests.sh -u \$USER -a mifosx -s true
+EOF
+}
+
+while getopts "f:u:a:s:d:hH" OPTION; do
+  case "${OPTION}" in
+    f) CONFIG_FILE_PATH="${OPTARG}" ;;
+    u) k8s_user="${OPTARG}" ;;
+    a) APPS_TO_TEST="$(echo "${OPTARG}" | tr ',' ' ')" ;;
+    s) STRICT_MODE="${OPTARG}" ;;
+    d) debug="${OPTARG}" ;;
+    h|H)
+      show_smoke_usage
+      exit 0
+      ;;
+    *)
+      show_smoke_usage
+      exit 1
+      ;;
+  esac
+done
+
+check_sudo
+install_crudini
+
+CONFIG_FILE_PATH="${CONFIG_FILE_PATH:-$DEFAULT_CONFIG_FILE}"
+loadConfigFromFile "$CONFIG_FILE_PATH"
+
+if [[ -z "${k8s_user:-}" ]]; then
+  k8s_user="$(resolve_invoker_user)"
+fi
+
+if [[ "$STRICT_MODE" != "true" && "$STRICT_MODE" != "false" ]]; then
+  log_error "Invalid strict mode '$STRICT_MODE'. Use true or false."
+  exit 1
+fi
+
+if [[ "${debug:-false}" != "true" && "${debug:-false}" != "false" ]]; then
+  log_error "Invalid debug value '${debug:-false}'. Use true or false."
+  exit 1
+fi
+
+if [[ -z "${kubeconfig_path:-}" ]]; then
+  k8s_user_home=$(eval echo "~$k8s_user")
+  kubeconfig_path="$k8s_user_home/.kube/config"
+fi
+
+export KUBECONFIG="$kubeconfig_path"
+
+run_smoke_tests "$APPS_TO_TEST" "$STRICT_MODE"
+exit $?


### PR DESCRIPTION
## Description

This PR adds a lightweight smoke-test layer for MifosX deployments in Mifos Gazelle.

The new checks validate:
- MifosX namespace readiness
- MifosX web app reachability
- tenant-aware Fineract API availability

The smoke tests are designed to be fault-tolerant:
- they are isolated from the main deployment flow
- they can run in non-strict mode without affecting normal Gazelle deployments
- they can run in strict mode in CI to catch regressions early

## Why this change

The DMP scope is focused on shipping the latest version of Mifos X in Gazelle.  
Before upgrading MifosX safely, Gazelle needs a reliable way to confirm that a deployed version is actually healthy.

This PR helps build that safety net by introducing basic post-deployment verification for MifosX. That makes it easier to:
- detect regressions during future MifosX upgrades
- improve confidence when changing MifosX version pins or manifests
- support shipping the latest version of Mifos X with lower deployment risk

## Changes made

- implemented `test_mifosx()` in `src/deployer/deployer.sh`
- added reusable smoke-test helpers for HTTP/status validation
- added `src/utils/smoke-tests.sh` as a standalone smoke-test runner
- updated CircleCI to run MifosX smoke tests in strict mode

## Testing

Tested by:
- verifying the smoke-test flow and script wiring in the repo
- ensuring the smoke-test path is separated from the main deployment path
- confirming CI now targets MifosX smoke verification only

## Notes

This PR intentionally focuses only on MifosX because that is the current upgrade target under DMP/C4GT scope.
