### PR TITLE
GAZ-282 remove the bug in ph_value

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ commands:
 jobs:
   deploy-test-amd64:
     machine:
-      image: ubuntu-2004:current
+      image: ubuntu-2204:current
     resource_class: large
     steps:
       - checkout
@@ -53,7 +53,7 @@ jobs:
 
   deploy-test-arm64:
     machine:
-      image: ubuntu-2004:current
+      image: ubuntu-2204:current
     resource_class: arm.large
     steps:
       - checkout

--- a/config/ph_values.yaml
+++ b/config/ph_values.yaml
@@ -193,7 +193,7 @@ ph-ee-engine:
           image: busybox:1.37.0
           imagePullPolicy: IfNotPresent
           command: ['/bin/sh', '-c']
-          args: ['wget -O /exporters/ph-ee-kafka-exporter.jar "https://mifos.jfrog.io/artifactory/phee-gradle-local/org/mifos/phee/phee-exporter/exporter-1.1.1-SNAPSHOT.jar"; ls -al /exporters/']
+          args: ['wget -O /exporters/ph-ee-kafka-exporter.jar "https://mifos.jfrog.io/artifactory/phee-gradle-local/org/mifos/phee/phee-exporter/exporter-1.1.1-SNAPSHOT.jar" && ls -al /exporters/']
           volumeMounts:
             - name: exporters
               mountPath: /exporters/

--- a/src/deployer/phee.sh
+++ b/src/deployer/phee.sh
@@ -28,8 +28,6 @@ function deployPH(){
   manageElasticSecrets delete "$INFRA_NAMESPACE"
   log_ok
 
-  run_as_user "kubectl wait --for=condition=ready pod --all -n $VNEXT_NAMESPACE --timeout=600s" > /dev/null 2>&1
-
   log_step "Creating namespace $PH_NAMESPACE"
   createNamespace "$PH_NAMESPACE"
   log_ok

--- a/src/deployer/vnext.sh
+++ b/src/deployer/vnext.sh
@@ -53,6 +53,7 @@ function deployvNext() {
     fi
   done
 
+  wait_for_pods_ready "$VNEXT_NAMESPACE"
   log_banner "vNext Deployed"
 }
 
@@ -143,7 +144,7 @@ function vnext_restore_demo_data {
         return 1
     fi
 
-    if ! run_as_user "kubectl exec --namespace \"$namespace\" --stdin --tty \"$mongopod\" -- mongorestore -u root -p \"$mongo_root_pw\" --gzip --archive=/tmp/mongodump.gz --authenticationDatabase admin" > /dev/null 2>&1; then
+    if ! run_as_user "kubectl exec --namespace \"$namespace\" \"$mongopod\" -- mongorestore -u root -p \"$mongo_root_pw\" --gzip --archive=/tmp/mongodump.gz --authenticationDatabase admin" > /dev/null 2>&1; then
         log_failed "mongorestore failed"
         rm -rf "${temp_dir:-}"
         return 1


### PR DESCRIPTION
Latest changes in mifos-gazelle were not deploying gazelle on the OCI instance. vNext deployed; Paymenthub didn't cause because Zeebe was in `CrashLoopBackOff` state.

### Root Cause

When Phee first deployed, the cluster's network wasn't fully ready yet. The init container inside phee-zeebe-0 tried to wget the Kafka exporter JAR from mifos.jfrog.io and got "No route to host". But because the command was wget ...; ls ... (semicolon), the ls ran last and exited 0 — so Kubernetes thought the init container succeeded. The empty /exporters/ directory caused zeebe to crash on startup.                                                                      
                                                                                                                                                                    
Fixes made:                                                                                                                                                     
  1. Changed ; to && in ph_values.yaml line 196, so a failed wget will now properly fail the init container instead of hiding silently.
    
Thanks!