### PR TITLE
feat: add micro/std/perf JVM profiles

### DIFF
--- a/docs/MIFOS-GAZELLE-README.md
+++ b/docs/MIFOS-GAZELLE-README.md
@@ -77,11 +77,33 @@ The deployment takes 10–20 minutes.  See [Deployment times out](#deployment-ti
 | `-u` | Non-root user (required) | `$USER` | — |
 | `-a` | Components to deploy | `all`, `infra`, `vnext`, `phee`, `mifosx`, `mastercard-demo`, `setup-data` | `all` |
 | `-e` | Cluster environment | `local`, `remote` | `local` |
+| `-p` | JVM/memory profile | `micro`, `std`, `perf` | `std` |
 | `-d` | Debug output | `true`, `false` | `false` |
 | `-r` | Force redeploy | `true`, `false` | `true` |
 | `-h` | Show help | — | — |
 
 `config/config.ini` is the central configuration file — it controls namespaces, repo branches, domains, and which components are enabled. Use `-f` to point to an alternative file (e.g. for per-environment variants). The file is self-documenting; all keys have inline comments.
+
+### Environment sizing (micro/std/perf)
+
+Gazelle supports heap/GC “profiles” to better fit different deployment sizes:
+
+- **`micro`**: Raspberry Pi / low-memory nodes (smaller JVM heaps; keeps Serial GC where present)
+- **`std`**: default (current values)
+- **`perf`**: higher-throughput environments (larger heaps; switches `UseSerialGC` → `UseG1GC` where present)
+
+Example:
+
+```bash
+sudo ./run.sh -u $USER -m deploy -a all -p micro
+```
+
+To confirm the effective JVM heap flags after deploy (per namespace), you can use:
+
+```bash
+kubens paymenthub
+./src/utils/get-java-memory.sh
+```
 
 ---
 

--- a/src/commandline/commandline.sh
+++ b/src/commandline/commandline.sh
@@ -202,7 +202,7 @@ function welcome {
 #------------------------------------------------------------------------------
 function showUsage {
     echo "
-    USAGE: $0 [-f <config_file_path>] -m [mode] -u [user] -a [apps] -e [environment] -d [true/false] -r [true/false]
+    USAGE: $0 [-f <config_file_path>] -m [mode] -u [user] -a [apps] -e [environment] -p [profile] -d [true/false] -r [true/false]
     Example 1 : sudo $0                                          # deploy all apps enabled in config.ini and user \$USER from config.ini
     Example 2 : sudo $0 -m cleanapps -d true                     # delete all apps enabled in config.init,  debug mode \$USER from config.ini
     Example 3 : sudo $0 -m cleanall                              # delete all apps, all local Kubernetes artifacts, and local kubernetes server
@@ -211,6 +211,7 @@ function showUsage {
     Example 7 : sudo $0 -f /opt/my_config.ini                    # Use a custom config file
     Example 8 : sudo $0 -a \"phee,mifosx\" -e remote -d true       # deploy PHEE and MifosX on remote cluster with debug mode
     Example 9 : sudo $0 -a setup-data                            # re-run data generation after a slow first boot
+    Example 10: sudo $0 -m deploy -a all -p micro                # deploy with micro JVM/heap profile (Pi)
 
     Options:
     -f config_file_path .. Specify an alternative config.ini file path (optional)
@@ -218,6 +219,7 @@ function showUsage {
     -u user .............. (non root) user that the process will use for execution (required)
     -a apps .............. Comma-separated list of apps (vnext,phee,mifosx,infra,mastercard-demo,setup-data) or 'all' (optional)
     -e environment ....... Cluster environment (local or remote, optional, default=local)
+    -p profile ........... JVM/memory profile (micro|std|perf, optional, default=std)
     -d debug ............. Enable debug mode (true|false, optional, default=false)
     -r redeploy .......... Force redeployment of apps (true|false, optional, default=true)
     -h|H ................. Display this message
@@ -396,7 +398,7 @@ function getOptions() {
     shift
 
     OPTIND=1
-    while getopts "m:k:d:a:v:u:r:f:e:hH" OPTION ; do
+    while getopts "m:k:d:a:v:u:r:f:e:p:hH" OPTION ; do
         case "${OPTION}" in
             f) options_map["config_file_path"]="${OPTARG}" ;;
             m) options_map["mode"]="${OPTARG}" ;;
@@ -405,6 +407,7 @@ function getOptions() {
             u) options_map["k8s_user"]="${OPTARG}" ;;
             r) options_map["redeploy"]="${OPTARG}" ;;
             e) options_map["environment"]="${OPTARG}" ;;
+            p) options_map["profile"]="${OPTARG}" ;;
             h|H) showUsage;
                  exit 0 ;;
             *) echo "Unknown option: -${OPTION}"
@@ -444,6 +447,8 @@ environment=""
 debug="false"
 redeploy="true"
 kubeconfig_path=""
+jvm_profile="std"
+INFRA_VALUES_FILE=""
 #helm_version=""
 # min_ram=6
 # min_free_space=30
@@ -451,6 +456,35 @@ kubeconfig_path=""
 #ubuntu_ok_versions_list=""
 export KUBECONFIG=$kubeconfig_path
 CONFIG_FILE_PATH="$DEFAULT_CONFIG_FILE"
+
+render_profile_values() {
+    local profile="$1"
+    local renderer="$RUN_DIR/src/utils/profiles/render_values.py"
+    local out_dir="/tmp"
+
+    if [[ ! -f "$renderer" ]]; then
+        log_warn "Profile renderer not found: $renderer (skipping JVM profile rendering)"
+        return 0
+    fi
+
+    if [[ -f "$RUN_DIR/config/ph_values.yaml" ]]; then
+        local ph_out="$out_dir/gazelle-ph_values.$profile.yaml"
+        python3 "$renderer" --profile "$profile" --kind ph --in "$RUN_DIR/config/ph_values.yaml" --out "$ph_out" || {
+            log_warn "Failed to render PH values for profile '$profile' — using base config/ph_values.yaml"
+            return 0
+        }
+        PH_VALUES_FILE="$ph_out"
+    fi
+
+    if [[ -f "$RUN_DIR/src/deployer/helm/infra/values.yaml" ]]; then
+        local infra_out="$out_dir/gazelle-infra_values.$profile.yaml"
+        python3 "$renderer" --profile "$profile" --kind infra --in "$RUN_DIR/src/deployer/helm/infra/values.yaml" --out "$infra_out" || {
+            log_warn "Failed to render infra values for profile '$profile' — using chart defaults"
+            return 0
+        }
+        INFRA_VALUES_FILE="$infra_out"
+    fi
+}
 
 function main {
     # Determine config file path early (before full option parsing) so that
@@ -509,8 +543,17 @@ function main {
     if [[ -n "${cmd_args_map["debug"]}" ]]; then debug="${cmd_args_map["debug"]}"; fi
     if [[ -n "${cmd_args_map["redeploy"]}" ]]; then redeploy="${cmd_args_map["redeploy"]}"; fi
     if [[ -n "${cmd_args_map["environment"]}" ]]; then environment="${cmd_args_map["environment"]}"; fi
+    if [[ -n "${cmd_args_map["profile"]}" ]]; then jvm_profile="${cmd_args_map["profile"]}"; fi
 
     validateInputs
+
+    jvm_profile="$(echo "$jvm_profile" | tr '[:upper:]' '[:lower:]')"
+    if [[ "$jvm_profile" != "micro" && "$jvm_profile" != "std" && "$jvm_profile" != "perf" ]]; then
+        log_error "Invalid JVM profile '$jvm_profile'. Must be one of: micro, std, perf."
+        showUsage
+        exit 1
+    fi
+    render_profile_values "$jvm_profile"
 
     if [ "$mode" == "deploy" ]; then
         echo -e "${YELLOW}WARN${RESET}   This deployment is recommended for demo, test and educational purposes only."

--- a/src/deployer/deployer.sh
+++ b/src/deployer/deployer.sh
@@ -186,16 +186,28 @@ function deployInfrastructure() {
   log_ok
 
   log_step "Updating FQDNs"
-  apply_domain_to_file "$INFRA_CHART_DIR/values.yaml" "$GAZELLE_DOMAIN"
+  if [[ -n "${INFRA_VALUES_FILE:-}" && -f "${INFRA_VALUES_FILE:-}" ]]; then
+    apply_domain_to_file "$INFRA_VALUES_FILE" "$GAZELLE_DOMAIN"
+  else
+    apply_domain_to_file "$INFRA_CHART_DIR/values.yaml" "$GAZELLE_DOMAIN"
+  fi
   log_ok
 
   ensure_helm_dependencies "$INFRA_CHART_DIR"
 
   log_step "Helm chart (infra)"
   if [ "$debug" = true ]; then
-    deployHelmChartFromDir "$RUN_DIR/src/deployer/helm/infra" "$INFRA_NAMESPACE" "$INFRA_RELEASE_NAME"
+    if [[ -n "${INFRA_VALUES_FILE:-}" && -f "${INFRA_VALUES_FILE:-}" ]]; then
+      deployHelmChartFromDir "$RUN_DIR/src/deployer/helm/infra" "$INFRA_NAMESPACE" "$INFRA_RELEASE_NAME" "$INFRA_VALUES_FILE"
+    else
+      deployHelmChartFromDir "$RUN_DIR/src/deployer/helm/infra" "$INFRA_NAMESPACE" "$INFRA_RELEASE_NAME"
+    fi
   else
-    deployHelmChartFromDir "$RUN_DIR/src/deployer/helm/infra" "$INFRA_NAMESPACE" "$INFRA_RELEASE_NAME" >> /dev/null 2>&1
+    if [[ -n "${INFRA_VALUES_FILE:-}" && -f "${INFRA_VALUES_FILE:-}" ]]; then
+      deployHelmChartFromDir "$RUN_DIR/src/deployer/helm/infra" "$INFRA_NAMESPACE" "$INFRA_RELEASE_NAME" "$INFRA_VALUES_FILE" >> /dev/null 2>&1
+    else
+      deployHelmChartFromDir "$RUN_DIR/src/deployer/helm/infra" "$INFRA_NAMESPACE" "$INFRA_RELEASE_NAME" >> /dev/null 2>&1
+    fi
   fi
   check_command_execution $? "deployHelmChartFromDir infra"
   log_ok

--- a/src/utils/profiles/render_values.py
+++ b/src/utils/profiles/render_values.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""
+Render Gazelle values files for a given environment "profile".
+
+This is intentionally simple (text-based transforms) because:
+- PH-EE values include many JAVA_TOOL_OPTIONS blocks in arrays, which are hard to override via Helm values layering.
+- We want a single flag (-p micro|std|perf) to scale common JVM heap flags without changing upstream charts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+
+
+def _apply_profile_to_text(text: str, profile: str, kind: str) -> str:
+    if profile == "std":
+        return text
+
+    # Common heap replacements seen in this repo values.
+    # Note: We intentionally do not try to be "perfect"; we scale common demo defaults.
+    if profile == "micro":
+        repl = {
+            "-Xmx1024m": "-Xmx512m",
+            "-Xms1024m": "-Xms256m",
+            "-Xmx512m": "-Xmx256m",
+            "-Xms512m": "-Xms128m",
+            "-Xmx256m": "-Xmx192m",
+            "-Xms256m": "-Xms96m",
+            "-Xmx128m": "-Xmx96m",
+            "-Xms128m": "-Xms64m",
+            "-Xmx96m": "-Xmx96m",
+            "-Xms96m": "-Xms64m",
+            "-Xmx64m": "-Xmx64m",
+            "-Xms64m": "-Xms64m",
+        }
+        # SerialGC tends to behave better with tiny heaps.
+        gc_from, gc_to = None, None
+    elif profile == "perf":
+        repl = {
+            "-Xmx64m": "-Xmx128m",
+            "-Xms64m": "-Xms128m",
+            "-Xmx96m": "-Xmx192m",
+            "-Xms96m": "-Xms192m",
+            "-Xmx128m": "-Xmx256m",
+            "-Xms128m": "-Xms256m",
+            "-Xmx192m": "-Xmx384m",
+            "-Xms192m": "-Xms384m",
+            "-Xmx256m": "-Xmx512m",
+            "-Xms256m": "-Xms512m",
+            "-Xmx512m": "-Xmx1024m",
+            "-Xms512m": "-Xms1024m",
+        }
+        # For perf, prefer G1GC over SerialGC (common for larger heaps).
+        gc_from, gc_to = "-XX:+UseSerialGC", "-XX:+UseG1GC"
+    else:
+        raise ValueError(f"Unknown profile: {profile}")
+
+    # Apply deterministic replacements first (string replace).
+    for a, b in repl.items():
+        text = text.replace(a, b)
+
+    if gc_from and gc_to:
+        text = text.replace(gc_from, gc_to)
+
+    # Small infra-specific touch: keep elastic/kibana/node options stable unless explicitly present.
+    # No-op for now; leaving kind hook for future.
+    _ = kind
+
+    # Normalize accidental double spaces after replacements in heap opts lines.
+    text = re.sub(r"[ \t]+\n", "\n", text)
+    return text
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--profile", required=True, choices=["micro", "std", "perf"])
+    ap.add_argument("--kind", required=True, choices=["ph", "infra"])
+    ap.add_argument("--in", dest="inp", required=True)
+    ap.add_argument("--out", dest="out", required=True)
+    args = ap.parse_args()
+
+    inp = pathlib.Path(args.inp)
+    out = pathlib.Path(args.out)
+
+    text = inp.read_text(encoding="utf-8")
+    rendered = _apply_profile_to_text(text, args.profile, args.kind)
+
+    # Ensure output dir exists
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(rendered, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+


### PR DESCRIPTION
Add a -p micro|std|perf flag that renders profile-specific Helm values for infra and Payment Hub EE, enabling heap/GC tuning per deployment environment.

## Summary
- Add `-p micro|std|perf` flag to select JVM/memory sizing profiles.
- Render profile-specific values files at runtime and feed them into Helm deploys (infra + PH-EE).
- Document profile usage and heap verification steps.

## Verified (in this PR)
- Profile rendering changes heap/GC flags in generated values.
- Infra deploy now supports passing a values file to Helm, so infra profile values take effect.

## Test plan (to run on target envs)
- [ ] `sudo ./run.sh -u $USER -m deploy -a all -p micro`
- [ ] `sudo ./run.sh -u $USER -m deploy -a all -p std`
- [ ] `sudo ./run.sh -u $USER -m deploy -a all -p perf`
- [ ] Verify effective JVM flags:
  - `kubens paymenthub && ./src/utils/get-java-memory.sh`