### PR TITLE
[GAZ-268] update Gazelle to  deploy to macOS 

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,141 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What This Is
+
+Mifos Gazelle is a Kubernetes deployment orchestration tool (v2.0.0) that deploys three Digital Public Goods (DPGs) with a single command:
+- **MifosX** — core banking (Apache Fineract v1.12.0)
+- **Payment Hub EE (PHEE)** — payment orchestration
+- **Mojaloop vNext Beta1** — payment switch
+
+The tool is written primarily in Bash (requires bash 4+) with Python 3 utilities for data loading and batch operations.
+
+## Key Commands
+
+### Deploy
+```bash
+# Full deployment
+sudo ./run.sh -u $USER -m deploy -a all
+
+# Deploy specific component(s)
+sudo ./run.sh -u $USER -m deploy -a mifosx
+sudo ./run.sh -u $USER -m deploy -a phee
+sudo ./run.sh -u $USER -m deploy -a vnext
+
+# With debug output
+sudo ./run.sh -u $USER -m deploy -a all -d true
+
+# With custom timeout (seconds)
+sudo ./run.sh -u $USER -m deploy -a all -t 900
+```
+
+### Teardown
+```bash
+sudo ./run.sh -u $USER -m cleanall -a all
+```
+
+### Python Utilities (from `.venv/`)
+```bash
+# Activate the project virtualenv first
+source .venv/bin/activate
+
+# Submit batch payments
+python src/utils/batch/submit-batch.py
+
+# Verify batch results
+python src/utils/batch/verify-batches.py
+
+# List tenants
+python src/utils/batch/list-tenants.py
+```
+
+### Testing Scripts
+```bash
+# Make a test payment
+src/utils/test-scripts/make-payment.sh
+
+# Test batch payment APIs
+src/utils/test-scripts/test-curl-batch.sh
+
+# Retrieve Kubernetes logs
+src/utils/get-kube-logs.sh
+
+# End-to-end Mastercard CBS test
+src/utils/test-scripts/test-mastercard-e2e.sh
+```
+
+### Logging
+Set `logging = true` in `config/config.ini` to write a full run log to `/tmp/gazelle-YYYYMMDD-HHMM.log`.
+
+## Architecture
+
+### Script Execution Flow
+```
+run.sh  →  src/commandline/commandline.sh  →  src/deployer/deployer.sh
+                                          →  src/environmentSetup/environmentSetup.sh
+```
+
+`run.sh` is the sole entry point. On macOS it re-execs itself with Homebrew bash 4+ if the system bash is 3.2. It sources `commandline.sh`, which sources all other modules and parses CLI flags + `config/config.ini`.
+
+### Key Source Files
+
+| File | Role |
+|------|------|
+| `src/commandline/commandline.sh` | CLI parsing, config loading (`crudini`), top-level dispatch |
+| `src/deployer/deployer.sh` | Orchestrates component deployments in dependency order |
+| `src/deployer/core.sh` | Shared K8s functions: pod readiness waits, TLS secrets, Helm deploy wrappers |
+| `src/deployer/mifosx.sh` | MifosX/Fineract deployment logic |
+| `src/deployer/phee.sh` | Payment Hub EE deployment logic |
+| `src/deployer/vnext.sh` | Mojaloop vNext deployment logic |
+| `src/deployer/mastercard.sh` | Mastercard CBS connector deployment |
+| `src/environmentSetup/environmentSetup.sh` | OS prereqs, k3s setup, `/etc/hosts`, Python venv |
+| `src/utils/logger.sh` | Logging framework (INFO/WARNING/ERROR levels) |
+| `src/utils/helpers.sh` | Common helper functions shared across modules |
+
+### Configuration
+
+All deployment settings live in `config/config.ini` (INI format, parsed with `crudini`). Sections:
+- `[general]` — mode, domain, version, startup timeout, logging
+- `[kubernetes]` — environment type (`local`/`remote`/`mac`), k3s version, resource minimums
+- `[dockerhub]` — optional credentials to raise Docker Hub pull rate limits
+- `[infra]` / `[mifosx]` / `[vnext]` / `[phee]` / `[mastercard-demo]` — per-component `enabled` flag, namespace, repo, branch
+
+Config values are loaded into shell variables via `crudini --get`. CLI flags override config file values. `$USER` in the config is expanded to the invoking (non-root) user at runtime.
+
+### Kubernetes Targets
+
+- **`mac`** — Rancher Desktop with k3s (primary dev environment)
+- **`local`** — fresh k3s install on Linux
+- **`remote`** — pre-existing cluster via kubeconfig
+
+### Deployment Dependencies
+
+Infrastructure (NGINX, MySQL, Kafka, Redis, MongoDB, Elasticsearch) must be up before any DPG. Deployment order: `infra` → `mifosx` / `phee` / `vnext` (these three are independent of each other).
+
+### Submodule Repos
+
+`repos/` contains git submodules with deployment artifacts for each DPG:
+- `repos/mifosx/` — K8s manifests and database Dockerfiles
+- `repos/ph_template/` — Payment Hub EE Helm charts (`helm/gazelle/`, `helm/ph-ee-engine/`, etc.)
+- `repos/vnext/` — Mojaloop vNext manifests
+
+### Helm Charts
+
+- `src/deployer/helm/infra/` — Infrastructure umbrella chart (bundles Kafka, Elasticsearch, Redis, MongoDB, MySQL, NGINX)
+- `repos/ph_template/helm/` — Payment Hub EE charts managed by PHEE upstream
+
+### Python Virtualenv
+
+`.venv/` is the project-local Python environment. Dependencies are minimal (`requests`). Scripts in `src/utils/data-loading/` and `src/utils/batch/` use it. Always activate before running Python scripts.
+
+## macOS-Specific Notes
+
+- `run.sh` auto-installs Homebrew bash 4+ if needed (the system `/bin/bash` is 3.2)
+- `sudo` strips PATH on macOS; `run.sh` prepends `/opt/homebrew/bin:/usr/local/bin` after re-exec
+- `crudini` is installed via `pipx` on macOS (Homebrew Python blocks plain `pip install`)
+- Known bug: Rancher Desktop can inject a duplicate `--node-ip` flag causing kubelet crashes — see memory entry `project_k3s_nodeip_bug.md`
+
+## CI/CD
+
+CircleCI (`.circleci/config.yml`) runs `sudo ./run.sh -m deploy -u $USER -a all -d true` on both amd64 and arm64 instances, then verifies pod readiness and health-check endpoints for all three DPGs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,7 +105,7 @@ Config values are loaded into shell variables via `crudini --get`. CLI flags ove
 
 ### Kubernetes Targets
 
-- **`mac`** — Rancher Desktop with k3s (primary dev environment)
+- **`mac`** — Colima with k3s (primary dev environment)
 - **`local`** — fresh k3s install on Linux
 - **`remote`** — pre-existing cluster via kubeconfig
 
@@ -134,7 +134,10 @@ Infrastructure (NGINX, MySQL, Kafka, Redis, MongoDB, Elasticsearch) must be up b
 - `run.sh` auto-installs Homebrew bash 4+ if needed (the system `/bin/bash` is 3.2)
 - `sudo` strips PATH on macOS; `run.sh` prepends `/opt/homebrew/bin:/usr/local/bin` after re-exec
 - `crudini` is installed via `pipx` on macOS (Homebrew Python blocks plain `pip install`)
-- Known bug: Rancher Desktop can inject a duplicate `--node-ip` flag causing kubelet crashes — see memory entry `project_k3s_nodeip_bug.md`
+- Colima + docker + docker-compose are installed automatically via Homebrew on first run; Homebrew itself is also auto-installed if absent
+- The Colima k3s VM uses the `eth0` interface IP for `/etc/hosts` entries (not `127.0.0.1`) because klipper-lb uses iptables DNAT which bypasses Lima's port-forwarding
+- Third-party browsers (Firefox, Opera, Chrome) require **Local Network** permission to reach the Colima VM IP (`192.168.68.x`): System Settings → Privacy & Security → Local Network → enable the browser. Safari works without this as a system app.
+- Browsers require a one-time cert acceptance: visit `https://mifos.mifos.gazelle.test` first and click through the self-signed cert warning before logging in. The NGINX ingress uses a default self-signed cert with no trusted CA. TODO: automate self-signed cert generation + macOS keychain trust during deploy.
 
 ## CI/CD
 

--- a/config/config.ini
+++ b/config/config.ini
@@ -18,7 +18,8 @@ logging = false
 startup_timeout = 600
 
 [kubernetes]
-# Environment type: 'local' for a local k3s cluster or 'remote' for an existing remote cluster.
+# Environment type: 'local' for a local k3s cluster, 'remote' for an existing remote cluster,
+# or 'mac' for OrbStack / Rancher Desktop / Docker Desktop on macOS.
 environment = local
 # Operating system user to configure Kubernetes for. Must be a non-root user that exists on the system.
 k8s_user = $USER

--- a/config/config.ini
+++ b/config/config.ini
@@ -20,8 +20,8 @@ startup_timeout = 600
 
 [kubernetes]
 # Environment type: 'local' for a local k3s cluster, 'remote' for an existing remote cluster,
-# or 'mac' for Rancher Desktop (k3s) on macOS.
-environment = mac 
+# or 'mac' for Colima (k3s) on macOS.
+environment = mac
 # Operating system user to configure Kubernetes for. Must be a non-root user that exists on the system.
 k8s_user = $USER
 # Tested Kubernetes (k3s) version to install for local clusters [Developer use only do not change]

--- a/config/config.ini
+++ b/config/config.ini
@@ -19,7 +19,7 @@ startup_timeout = 600
 
 [kubernetes]
 # Environment type: 'local' for a local k3s cluster, 'remote' for an existing remote cluster,
-# or 'mac' for OrbStack / Rancher Desktop / Docker Desktop on macOS.
+# or 'mac' for Rancher Desktop (k3s) on macOS.
 environment = mac 
 # Operating system user to configure Kubernetes for. Must be a non-root user that exists on the system.
 k8s_user = $USER
@@ -28,7 +28,7 @@ k8s_version = 1.35
 # Path to the kubeconfig file. Defaults to ~/.kube/config if not specified.
 kubeconfig_path = ~/.kube/config
 # Minimum RAM required in GB.
-min_ram = 6
+min_ram = 16
 # Minimum free disk space required in GB.
 min_free_space = 30
 # Tested Linux distributions It is Ubuntu only for now so don't change this

--- a/config/config.ini
+++ b/config/config.ini
@@ -21,7 +21,7 @@ startup_timeout = 600
 [kubernetes]
 # Environment type: 'local' for a local k3s cluster, 'remote' for an existing remote cluster,
 # or 'mac' for Colima (k3s) on macOS.
-environment = mac
+environment = local
 # Operating system user to configure Kubernetes for. Must be a non-root user that exists on the system.
 k8s_user = $USER
 # Tested Kubernetes (k3s) version to install for local clusters [Developer use only do not change]

--- a/config/config.ini
+++ b/config/config.ini
@@ -20,7 +20,7 @@ startup_timeout = 600
 [kubernetes]
 # Environment type: 'local' for a local k3s cluster, 'remote' for an existing remote cluster,
 # or 'mac' for OrbStack / Rancher Desktop / Docker Desktop on macOS.
-environment = local
+environment = mac 
 # Operating system user to configure Kubernetes for. Must be a non-root user that exists on the system.
 k8s_user = $USER
 # Tested Kubernetes (k3s) version to install for local clusters [Developer use only do not change]

--- a/config/ph_values.yaml
+++ b/config/ph_values.yaml
@@ -17,11 +17,11 @@ ph-ee-engine:
     enabled: true
     image: docker.io/openmf/ph-ee-operations-web:dev
     backend:
-      PH_OPS_BACKEND_SERVER_URL: https://ops-bk.mifos.gazelle.localhost/api/v1
-      PH_VOU_BACKEND_SERVER_URL: https://ops-bk.mifos.gazelle.localhost/api/v1
-      PH_ACT_BACKEND_SERVER_URL: https://ops-bk.mifos.gazelle.localhost/api/v1
-      PH_OPS_BULK_CONNECTOR_URL: https://bulk-processor.mifos.gazelle.localhost
-      PH_OPS_SIGNATURE_URL: https://ops.mifos.gazelle.localhost/api/v1/util/x-signature
+      PH_OPS_BACKEND_SERVER_URL: https://ops-bk.mifos.gazelle.test/api/v1
+      PH_VOU_BACKEND_SERVER_URL: https://ops-bk.mifos.gazelle.test/api/v1
+      PH_ACT_BACKEND_SERVER_URL: https://ops-bk.mifos.gazelle.test/api/v1
+      PH_OPS_BULK_CONNECTOR_URL: https://bulk-processor.mifos.gazelle.test
+      PH_OPS_SIGNATURE_URL: https://ops.mifos.gazelle.test/api/v1/util/x-signature
       PH_PLATFORM_TENANT_ID: greenbank
       PH_PLATFORM_TENANT_IDS: "greenbank,bluebank,redbank"
       PH_REGISTERING_INSTITUTION_ID: 123
@@ -86,7 +86,7 @@ ph-ee-engine:
         kubernetes.io/ingress.class: nginx
         nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
         nginx.ingress.kubernetes.io/enable-cors: "true"
-        nginx.ingress.kubernetes.io/cors-allow-origin: "https://ops.mifos.gazelle.localhost"
+        nginx.ingress.kubernetes.io/cors-allow-origin: "https://ops.mifos.gazelle.test"
         nginx.ingress.kubernetes.io/cors-allow-methods: "PUT, GET, POST, OPTIONS, DELETE, PATCH"
         nginx.ingress.kubernetes.io/cors-allow-headers: "DNT,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization,Platform-TenantId,platform-tenantid,purpose,type,x-callback-url,x-correlationid,x-correlation-id,X-Correlation-ID,x-program-id,x-registering-institution-id,x-signature,Sec-Fetch-Dest,Sec-Fetch-Mode,Sec-Fetch-Site,Sec-GPC,Pragma"
         nginx.ingress.kubernetes.io/cors-expose-headers: "Content-Length,Content-Range,X-Correlation-ID,x-correlation-id"
@@ -96,10 +96,10 @@ ph-ee-engine:
         nginx.ingress.kubernetes.io/log-format: '$remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" "$http_x_forwarded_for" $request_uri'
       tls:
       - hosts:
-        - ops-bk.mifos.gazelle.localhost
+        - ops-bk.mifos.gazelle.test
         secretName: sandbox-secret
       hosts:
-        - host: ops-bk.mifos.gazelle.localhost
+        - host: ops-bk.mifos.gazelle.test
           paths:
           - path: "/"
             backend:
@@ -202,16 +202,6 @@ ph-ee-engine:
       replicas: 1
       logLevel: debug
 
-      env: 
-      - name: JAVA_TOOL_OPTIONS
-        value: |
-          -Xms64m
-          -Xmx256m
-          -XX:+UseSerialGC
-          -XX:ReservedCodeCacheSize=32m
-          -XX:MaxMetaspaceSize=96m
-          -XX:+HeapDumpOnOutOfMemoryError
-    
       resources:
         requests:
           cpu: 100m
@@ -222,7 +212,7 @@ ph-ee-engine:
 
       ingress:
         enabled: true
-        host: "zeebe-gateway.mifos.gazelle.localhost"
+        host: "zeebe-gateway.mifos.gazelle.test"
 
     operate:
       enabled: true
@@ -249,7 +239,7 @@ ph-ee-engine:
 
       ingress:
         enabled: true
-        host: "zeebe-operate.mifos.gazelle.localhost"
+        host: "zeebe-operate.mifos.gazelle.test"
 
     tasklist:
       enabled: false
@@ -347,7 +337,6 @@ ph-ee-engine:
     enableGazelleTest: true
     imagePullPolicy: IfNotPresent
     image: docker.io/openmf/ph-ee-integration-test:v1.6.2-gazelle
-    imagePullPolicy: IfNotPresent
     testTags: "@gov and not @ext"
     memoryRequest: "500k"
     testResultsOutputDir: "/tmp"
@@ -376,7 +365,7 @@ ph-ee-engine:
       annotations:
         nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
         nginx.ingress.kubernetes.io/enable-cors: "true"
-        nginx.ingress.kubernetes.io/cors-allow-origin: "https://ops.mifos.gazelle.localhost"
+        nginx.ingress.kubernetes.io/cors-allow-origin: "https://ops.mifos.gazelle.test"
         nginx.ingress.kubernetes.io/cors-allow-methods: "PUT, GET, POST, OPTIONS, DELETE, PATCH"
         nginx.ingress.kubernetes.io/cors-allow-headers: "DNT,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization,Platform-TenantId,platform-tenantid,purpose,type,x-callback-url,x-correlationid,x-correlation-id,X-Correlation-ID,x-program-id,x-registering-institution-id,x-signature,Sec-Fetch-Dest,Sec-Fetch-Mode,Sec-Fetch-Site,Sec-GPC,Pragma"
         nginx.ingress.kubernetes.io/cors-expose-headers: "Content-Length,Content-Range,X-Correlation-ID,x-correlation-id"
@@ -387,7 +376,7 @@ ph-ee-engine:
       tls:
         - secretName: sandbox-secret
       hosts:
-        - host: ops-bk.mifos.gazelle.localhost
+        - host: ops-bk.mifos.gazelle.test
           paths:
           - path: "/"
             backend:
@@ -461,7 +450,7 @@ ph-ee-engine:
         nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"  # End-to-end TLS
         nginx.ingress.kubernetes.io/backend-protocol-ssl-verify: "false"  # Self-signed cert in backend
         nginx.ingress.kubernetes.io/enable-cors: "true"
-        nginx.ingress.kubernetes.io/cors-allow-origin: "https://ops.mifos.gazelle.localhost"
+        nginx.ingress.kubernetes.io/cors-allow-origin: "https://ops.mifos.gazelle.test"
         nginx.ingress.kubernetes.io/cors-allow-methods: "PUT, GET, POST, OPTIONS, DELETE, PATCH"
         nginx.ingress.kubernetes.io/cors-allow-headers: "DNT,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization,Platform-TenantId,platform-tenantid,purpose,type,x-callback-url,x-correlationid,x-correlation-id,X-Correlation-ID,x-program-id,x-registering-institution-id,x-signature,Sec-Fetch-Dest,Sec-Fetch-Mode,Sec-Fetch-Site,Sec-GPC,Pragma"
         nginx.ingress.kubernetes.io/cors-expose-headers: "Content-Length,Content-Range,X-Correlation-ID,x-correlation-id"
@@ -471,10 +460,10 @@ ph-ee-engine:
         nginx.ingress.kubernetes.io/log-format: '$remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" "$http_x_forwarded_for" $request_uri'
       tls:
       - hosts:
-        - bulk-processor.mifos.gazelle.localhost
+        - bulk-processor.mifos.gazelle.test
         secretName: sandbox-secret
       hosts:
-      - host: bulk-processor.mifos.gazelle.localhost
+      - host: bulk-processor.mifos.gazelle.test
         paths:
         - path: /batchtransactions
           backend:
@@ -520,10 +509,10 @@ ph-ee-engine:
         nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
       tls:
       - hosts:
-        - channel.mifos.gazelle.localhost
+        - channel.mifos.gazelle.test
         secretName: sandbox-secret
       hosts:
-        - host: channel.mifos.gazelle.localhost          
+        - host: channel.mifos.gazelle.test          
           paths: 
           - path: /
             backend:
@@ -531,7 +520,7 @@ ph-ee-engine:
                 name: ph-ee-connector-channel
                 port:
                   number: 8443
-        - host: channel-gsma.mifos.gazelle.localhost          
+        - host: channel-gsma.mifos.gazelle.test          
           paths:          
           - path: /
             backend:
@@ -543,7 +532,7 @@ ph-ee-engine:
   minio:
     ingress:
       hosts:
-        - minio.mifos.gazelle.localhost
+        - minio.mifos.gazelle.test
     resources:
       requests:
         memory: 128Mi
@@ -554,7 +543,7 @@ ph-ee-engine:
       annotations: {}
       path: /
       hosts:
-        - minio-console.mifos.gazelle.localhost
+        - minio-console.mifos.gazelle.test
         
   kafka:
     enabled: true
@@ -605,15 +594,7 @@ ph-ee-engine:
       limits:
         cpu: 300m
         memory: 256Mi
-    extraEnvs:
-      - name: JAVA_TOOL_OPTIONS
-        value: |
-          -Xms64m
-          -Xmx128m
-          -XX:+UseSerialGC
-          -XX:ReservedCodeCacheSize=64m
-          -XX:MaxMetaspaceSize=128m
-          -XX:+HeapDumpOnOutOfMemoryError
+    javaToolOptions: "-Xms64m -Xmx128m -XX:+UseSerialGC -XX:ReservedCodeCacheSize=64m -XX:MaxMetaspaceSize=128m -XX:+HeapDumpOnOutOfMemoryError"
 
   zeebe_ops:
     enabled: true

--- a/docs/MIFOS-GAZELLE-README.md
+++ b/docs/MIFOS-GAZELLE-README.md
@@ -8,6 +8,7 @@
 - [Goal](#goal-of-mifos-gazelle)
 - [Features](#mifos-gazelle-features)
 - [Prerequisites](#prerequisites)
+- [macOS Quick Start](#macos-quick-start)
 - [Quick Start](#quick-start)
 - [Deployment Options](#deployment-options)
 - [What to Do Next](#what-to-do-next)
@@ -48,10 +49,45 @@ Mifos Gazelle provides a very simple kubernetes based installation for cloud nat
 
 ## Prerequisites
 
+**Linux (primary)**
 - Ubuntu 22.04 or 24.04 LTS (x86_64 or ARM64)
 - 16 GB RAM minimum (less if deploying individual components)
 - 75 GB+ free space in home directory
 - Non-root user with sudo privileges
+
+**macOS** (developer use only) — see [macOS Quick Start](#macos-quick-start) below. Not a primary tested platform; intended for contributors developing and testing Gazelle locally.
+
+---
+
+## macOS Quick Start
+
+> **Note:** macOS is a secondary, developer-oriented platform. Ubuntu 22.04/24.04 LTS is the primary tested and CI-validated environment — all CI runs on Ubuntu and production deployments should use Linux. macOS support exists to help contributors to the Mifos Gazelle project run and test the full stack locally on their development machines without needing a separate Linux host. Expect occasional rough edges, and please report issues on the `#mifos-gazelle-dev` Slack channel.
+
+Gazelle runs on macOS using [Colima](https://github.com/abiosoft/colima) as the Kubernetes provider. Colima is a lightweight, open-source CLI tool that runs a Lima VM with k3s and containerd — the same k3s version used on Linux, so behaviour is identical across environments. It was chosen over alternatives (Rancher Desktop, Docker Desktop, OrbStack) because it is free, resource-efficient, installs cleanly via Homebrew, and does not require a GUI or a paid licence.
+
+Colima's `socket_vmnet` network backend gives the VM a dedicated routable IP address (`192.168.5.x`) on the host. This is required because the k3s load-balancer (klipper-lb) uses iptables DNAT for ports 80 and 443, which bypasses Lima's port-forwarding and means `127.0.0.1` does not reach the NGINX ingress. The VM IP is used in `/etc/hosts` automatically by the installer.
+
+**Requirements**
+- macOS 13 Ventura or later (Apple Silicon M-series or Intel)
+- 16 GB RAM (12 GB allocatable to the Colima VM)
+- 50 GB+ free disk space — all images and k3s state live inside the Colima VM disk image; a full 3-DPG deployment uses roughly 25–30 GB inside the VM
+- Non-root user — run `sudo ./run.sh -u $USER …`
+
+**First run** installs everything automatically:
+- Homebrew (if absent)
+- Homebrew bash 4+ (macOS ships bash 3.2; the script re-execs itself)
+- Colima, Docker, docker-compose, kubectl, helm, k9s, kubectx, kustomize
+
+```bash
+git clone --branch main https://github.com/openMF/mifos-gazelle.git
+cd mifos-gazelle
+sudo ./run.sh -u $USER -m deploy -a all
+```
+
+**After deployment — browser notes**
+
+- Third-party browsers (Firefox, Chrome, Opera) require **Local Network** permission to reach the Colima VM IP. Grant it at: *System Settings → Privacy & Security → Local Network → enable the browser*. Safari works without this as a system app.
+- Browsers require a one-time certificate acceptance: visit `https://mifos.mifos.gazelle.test` first and click through the self-signed certificate warning before logging in.
 
 ---
 
@@ -145,7 +181,7 @@ When all 3 DPGs are deployed, demonstration data is pre-loaded so you can immedi
 
 To view the resulting transaction history across all tenants:
 ```bash
-./src/utils/view-mifos-transactions.py -c config/config.ini
+./src/utils/view-mifos-transactions.py
 ```
 
 **Observe the results:**
@@ -296,7 +332,7 @@ Mifos Gazelle deploys four default tenants: `default`, `greenbank`, `bluebank` a
 
 - Operations-Web UI has been vastly improved but is still WIP
 - Payment Hub EE mifos-v2.0.0 is deployed which is a branch that builds on v1.13.3 release and is reflected in the mifos-v2.0.0 branches of the Paymenthub EE repositories deployed by mifos-gazelle 
-- ARM64 supported for all 3 DPGs; Raspberry Pi 4 has a MongoDB limitation (requires ARMv8.2A) but Pi 5 is well tested now and works well for P2P payments i.e. make-payment.sh. 
+- ARM64 compatible with all 3 DPGs; Raspberry Pi 4 has a MongoDB limitation (requires ARMv8.2A) but Pi 5 is well tested now and works well for P2P payments i.e. make-payment.sh. 
 - Memory reduction is still wip but 16GB generally works fine for all 3 DPGs on a single node.
 - Kubernetes operator work (openMF/mifos-operators) still planned for a future release
 ---
@@ -397,7 +433,7 @@ This reruns only the data generation and loading step — it does not redeploy a
 **To verify data is present before retrying:**
 ```bash
 # Check MifosX has clients in greenbank and bluebank tenants
-./src/utils/view-mifos-transactions.py -c config/config.ini
+./src/utils/view-mifos-transactions.py
 
 # Check vNext oracle has MSISDN registrations
 kubectl exec -n vnext -l app=account-lookup-svc -- \

--- a/docs/RELEASE-NOTES.md
+++ b/docs/RELEASE-NOTES.md
@@ -2,14 +2,14 @@
 
 ## Major New Features
 
-- **Raspberry Pi Support** - Full and stable Raspberry Pi deployment onto a Pi5 16GB with all components deployed
+- **Raspberry Pi Compatibility** - Full and stable Raspberry Pi deployment onto a Pi5 16GB with all components deployed
 - **Payment Hub v2.0.0 preview** - Extensive Updates to Payment Hub EE with a pre-release view, including upgraded UI, tested workflows, GovStack support
-- **config.ini** - Config.ini supported to add configurations to deployments and enable demo setups
+- **config.ini** - Config.ini available for adding configurations to deployments and enabling demo setups
 - **Reduced Memory Utilization** - All components now require less than 16GB memory
 - **Data Generation and Population** - for MifosX and PaymentHub EE and VNext to allow for demos
 - **Mastercard CBS Connector Demo** - A demo version of the Mastercard CBS Connector which can be configured to connect to the Mastercard Sandbox instance
 - **Updated version of the k9s kubernetes utility automatically installed** - in ~/local/bin/k9s 
-- **Support for installation to local or remote clusters** - support included for deployment to remote clusters
+- **Installation to local or remote clusters** - remote cluster deployment included
 - **Demo Creator** - Standalone Demo Creator which allows for the creation of demos using Mifos Gazelle components [Mifos Gazelle Demo Creator](https://github.com/openMF/mifos-gazelle-demo-creator)
 - **Demo Runtime** - Standalone Demo Runtime environment that allows guided navigation in demos with Mifos Gazelle components [Mifos Gazelle Demo Runtime](https://github.com/openMF/mifos-gazelle-demo-runtime)
 - **Significant Documentation** - New updated documentation for Bulk operations, GovStack Operation, Mastercard CBS Demo, PHEE Releases, Raspberry Pi, Postman collections.
@@ -150,7 +150,7 @@ Mifos would like to recognise the significant contributions of the following con
 
 ## Major New Features
 
-- **ARM64 Support** - Full support for ARM64 architecture
+- **ARM64 Compatibility** - Full ARM64 architecture compatibility
 - **End-to-End Payment Demonstration** - Complete payment flow from a customer in a Mifos Tenant (Greenbank)  to a customer in another Mifos Tenant (Bluebank)  using PHEE, Mifos X, and vNext
 - **Enhanced Observability** - Includes Camunda workflows with Camunda Operate
 - **Reduced Memory Utilization** - All components now require less than 24GB memory

--- a/docs/RELEASE-NOTES.md
+++ b/docs/RELEASE-NOTES.md
@@ -1,3 +1,35 @@
+# Mifos Gazelle v2.1.0 Release Notes (DRAFT)
+
+## Major New Features
+
+- **macOS Support** — Full deployment on macOS via Colima/k3s; `run.sh` automatically installs Homebrew, Colima, Docker, and Docker Compose on first run
+- **macOS Setup Module** — macOS/Colima setup logic extracted into a dedicated `src/environmentSetup/mac_setup.sh` for cleaner separation of concerns
+- **GovStack Cross-Border Payment Support** — Added `cert-manager` for CORS handling and a GovStack cross-border client deployment script with batch payment features
+- **Configurable Helm Timeout** — Helm chart install timeout is now configurable via `config.ini` (`startup_timeout`), replacing a hard-coded value
+
+## Notable Changes
+
+- Fixed vNext pods crash-looping on Colima (macOS)
+- Fixed macOS/Linux platform detection in `commandline.sh`
+- Fixed Bitnami Helm chart registry path (`oci://registry-1.docker.io/bitnamicharts`) reverting a regression
+- Fixed `kubectl` client skew issue in `deploy-operator.sh` and `k8s.sh`
+- Fixed command-line argument parsing to require correct hyphenated flag syntax (GAZ-227)
+- Improved remote cluster support: domain name detection and kubeconfig handling
+- Improved Mastercard CBS demo integration and testing (GAZ-281)
+- Refactored core scripts to follow Google Shell Style Guide — functions renamed to `snake_case`, dead code removed
+- Default `environment` in `config.ini` restored to `local`
+- Added `CLAUDE.md` developer guide to the repository
+- Added CLA contributor check to CI workflow
+
+## Tickets
+
+EPIC: [GAZ-268 - release 2.1.0](https://mifosforge.jira.com/browse/GAZ-268)<br>
+[GAZ-227 - commandline.sh allows parameters without preceding minus sign](https://mifosforge.jira.com/browse/GAZ-227)<br>
+[GAZ-259 - Improve deployment resilience](https://mifosforge.jira.com/browse/GAZ-259)<br>
+[GAZ-281 - Mastercard Test and help integrate solution into GovStack Sandbox Env](https://mifosforge.jira.com/browse/GAZ-281)<br>
+
+---
+
 # Mifos Gazelle v2.0.0 Release Notes
 
 ## Major New Features

--- a/docs/RELEASE-NOTES.md
+++ b/docs/RELEASE-NOTES.md
@@ -6,6 +6,7 @@
 - **macOS Setup Module** — macOS/Colima setup logic extracted into a dedicated `src/environmentSetup/mac_setup.sh` for cleaner separation of concerns
 - **GovStack Cross-Border Payment Support** — Added `cert-manager` for CORS handling and a GovStack cross-border client deployment script with batch payment features
 - **Configurable Helm Timeout** — Helm chart install timeout is now configurable via `config.ini` (`startup_timeout`), replacing a hard-coded value
+- **Claude.md** — project file for Claude-code, it streamlines AI code development for claude-code users (/devs)
 
 ## Notable Changes
 

--- a/docs/VNEXT-README.md
+++ b/docs/VNEXT-README.md
@@ -30,8 +30,8 @@ sudo ./run.sh -u $USER -m deploy -d true -a vNext
 - **Resource Efficient**: Optimized resource usage for testing environments
 - **vNext only**: using the -a flag on the Mifos Gazelle installer 
 
-## Supported Environments
-- the Mifos Gazelle vNext Beta install works on Ubuntu 20.04 and 22.04 LTS on x86_64 or ARM64:
+## Tested Environments
+- the Mifos Gazelle vNext Beta install has been tested on Ubuntu 20.04 and 22.04 LTS on x86_64 or ARM64:
   - Bare metal servers
   - Virtual machines (VirtualBox, Parallels, UTM, QEMU)
   - Cloud instances (AWS, GCP, Azure, etc.)
@@ -127,6 +127,6 @@ ipconfig /flushdns
 - Ideal for development, testing, and educational purposes
 - Not suitable for production deployments
 
-## Support
-- Support for deployment issues through Mifos-Gazelle can be obtained through the Mifos Gazelle Slack channel https://mifos.slack.com/archives/C082PNLUCRK
-- Support for issues with vNext Beta 1 should be directed to the Mojaloop Development Community.
+## Community Help
+- Community help with deployment issues is available on the Mifos Gazelle Slack channel https://mifos.slack.com/archives/C082PNLUCRK
+- For vNext Beta 1 issues, reach out to the Mojaloop Development Community.

--- a/run.sh
+++ b/run.sh
@@ -1,8 +1,14 @@
 #!/bin/bash
 # run.sh -- Main entry point for Mifos Gazelle deployment scripts
 
-RUN_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )" # the directory that this script is in 
-export RUN_DIR 
+RUN_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )" # the directory that this script is in
+export RUN_DIR
+
+# On macOS, sudo strips PATH so Homebrew binaries are not found.
+# Prepend both known Homebrew locations so all subsequent commands work.
+if [[ "$(uname -s)" == "Darwin" ]]; then
+    export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
+fi 
 ########################################################################
 # GLOBAL VARS
 # these are not user configurables - for internal script use only

--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,49 @@
 #!/bin/bash
 # run.sh -- Main entry point for Mifos Gazelle deployment scripts
 
+# macOS ships bash 3.2 which lacks associative arrays (declare -A) and
+# name references (local -n). Re-exec with Homebrew bash 5 when needed.
+if [[ "${BASH_VERSINFO[0]}" -lt 4 ]]; then
+    # Re-exec with an already-installed bash 4+
+    for _brew_bash in /opt/homebrew/bin/bash /usr/local/bin/bash; do
+        if [[ -x "$_brew_bash" ]]; then
+            exec "$_brew_bash" "$0" "$@"
+        fi
+    done
+    # Not found — locate brew and install bash as the non-root invoking user
+    _brew_bin=""
+    for _candidate in /opt/homebrew/bin/brew /usr/local/bin/brew; do
+        [[ -x "$_candidate" ]] && _brew_bin="$_candidate" && break
+    done
+    if [[ -z "$_brew_bin" ]]; then
+        echo "ERROR: bash 4+ and Homebrew are both required on macOS." >&2
+        echo "       Install Homebrew from https://brew.sh then re-run." >&2
+        exit 1
+    fi
+    # Determine the non-root user to run brew as (brew refuses to run as root)
+    _brew_user="${SUDO_USER:-}"
+    if [[ -z "$_brew_user" || "$_brew_user" == "root" ]]; then
+        _brew_user=$(stat -f '%Su' /dev/console 2>/dev/null || echo "")
+    fi
+    if [[ -z "$_brew_user" || "$_brew_user" == "root" ]]; then
+        echo "ERROR: Cannot determine a non-root user to run 'brew install bash'." >&2
+        echo "       Please run: brew install bash" >&2
+        exit 1
+    fi
+    echo "INFO   bash 4+ not found. Installing via Homebrew (this may take a moment)..."
+    if ! sudo -u "$_brew_user" "$_brew_bin" install bash; then
+        echo "ERROR: 'brew install bash' failed. Please install it manually and re-run." >&2
+        exit 1
+    fi
+    for _brew_bash in /opt/homebrew/bin/bash /usr/local/bin/bash; do
+        if [[ -x "$_brew_bash" ]]; then
+            exec "$_brew_bash" "$0" "$@"
+        fi
+    done
+    echo "ERROR: bash 4+ still not found after install. Please check your Homebrew setup." >&2
+    exit 1
+fi
+
 RUN_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )" # the directory that this script is in
 export RUN_DIR
 
@@ -8,7 +51,7 @@ export RUN_DIR
 # Prepend both known Homebrew locations so all subsequent commands work.
 if [[ "$(uname -s)" == "Darwin" ]]; then
     export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
-fi 
+fi
 ########################################################################
 # GLOBAL VARS
 # these are not user configurables - for internal script use only

--- a/run.sh
+++ b/run.sh
@@ -62,6 +62,17 @@ CONFIG_DIR="$BASE_DIR/config"
 UTILS_DIR="$BASE_DIR/src/utils"
 DATA_LOADING_DIR="$UTILS_DIR/data-loading"
 export UTILS_DIR DATA_LOADING_DIR
+
+# Python interpreter: use the project-local venv when available so data-loading
+# scripts have their dependencies (requests, etc.) without touching system Python.
+# Falls back to system python3 if the venv hasn't been created yet (e.g. first run
+# before env-setup, or when running a deploy directly against a remote cluster).
+if [[ -x "$BASE_DIR/.venv/bin/python3" ]]; then
+    PYTHON3="$BASE_DIR/.venv/bin/python3"
+else
+    PYTHON3="python3"
+fi
+export PYTHON3
 INFRA_CHART_DIR="$BASE_DIR/src/deployer/helm/infra" 
 NGINX_VALUES_FILE="$CONFIG_DIR/nginx_values.yaml"
 

--- a/src/commandline/commandline.sh
+++ b/src/commandline/commandline.sh
@@ -521,11 +521,15 @@ function main {
         env_setup_main "$mode"
         deleteApps "$apps"
     elif [ "$mode" == "cleanall" ]; then
-        env_setup_main "$mode"
-        # env_setup_main will not remove remote/mac cluster so need to run deleteApps
-        if [[ "$environment" == "remote" || "$environment" == "mac" ]]; then
-            deleteApps "$mifosx_instances" "all"
+        # For mac/remote: delete app namespaces BEFORE env_setup_main shuts the
+        # cluster down.  env_setup_mac_cluster's cleanall path calls rdctl shutdown
+        # at the end, making kubectl unreachable for any subsequent deleteApps call.
+        if [[ "$environment" == "mac" || "$environment" == "remote" ]]; then
+            if is_cluster_accessible; then
+                deleteApps "$apps"
+            fi
         fi
+        env_setup_main "$mode"
     else
         showUsage
         exit 1

--- a/src/commandline/commandline.sh
+++ b/src/commandline/commandline.sh
@@ -35,7 +35,25 @@ function install_crudini() {
     if ! command -v crudini &> /dev/null; then
         logWithLevel "$INFO" "crudini not found. Attempting to install..."
         if brew_available; then
-            run_brew install crudini >/dev/null 2>&1
+            # crudini is a Python CLI tool (not a Homebrew formula).
+            # Modern macOS with Homebrew-managed Python blocks plain pip install;
+            # use pipx which handles the venv isolation automatically.
+            local user_home
+            user_home=$(eval echo "~${SUDO_USER:-$k8s_user}")
+            # Ensure ~/.local/bin is on PATH (pipx installs there)
+            export PATH="$user_home/.local/bin:$PATH"
+            if ! command -v pipx &>/dev/null; then
+                run_brew install pipx >/dev/null 2>&1
+            fi
+            local pipx_bin=""
+            for candidate in /opt/homebrew/bin/pipx /usr/local/bin/pipx "$user_home/.local/bin/pipx"; do
+                if [[ -x "$candidate" ]]; then pipx_bin="$candidate"; break; fi
+            done
+            if [[ -z "$pipx_bin" ]]; then
+                logWithLevel "$ERROR" "pipx not found after install. Please install crudini manually: brew install pipx && pipx install crudini"
+                exit 1
+            fi
+            sudo -u "${SUDO_USER:-$k8s_user}" "$pipx_bin" install crudini >/dev/null 2>&1
         elif command -v apt-get &> /dev/null; then
             sudo apt-get update && sudo apt-get install -y crudini
         elif command -v dnf &> /dev/null; then

--- a/src/commandline/commandline.sh
+++ b/src/commandline/commandline.sh
@@ -34,8 +34,8 @@ function resolve_invoker_user() {
 function install_crudini() {
     if ! command -v crudini &> /dev/null; then
         logWithLevel "$INFO" "crudini not found. Attempting to install..."
-        if command -v brew &> /dev/null; then
-            brew install crudini >/dev/null 2>&1
+        if brew_available; then
+            run_brew install crudini >/dev/null 2>&1
         elif command -v apt-get &> /dev/null; then
             sudo apt-get update && sudo apt-get install -y crudini
         elif command -v dnf &> /dev/null; then

--- a/src/commandline/commandline.sh
+++ b/src/commandline/commandline.sh
@@ -544,8 +544,18 @@ function main {
         env_setup_main "$mode"
         deleteApps "$apps"
     elif [ "$mode" == "cleanall" ]; then
-        # For mac/remote: delete app namespaces BEFORE env_setup_main shuts the
-        # cluster down.  env_setup_mac_cluster's cleanall path calls rdctl shutdown
+        if [[ "$environment" == "mac" ]]; then
+            printf "\n*** WARNING: cleanall will delete the Colima VM, all deployed\n"
+            printf "*** applications, and ALL local state (including ~/.colima).\n"
+            printf "*** This cannot be undone. Continue? [y/N] "
+            read -r _confirm
+            if [[ "$_confirm" != "y" && "$_confirm" != "Y" ]]; then
+                printf "Aborted.\n"
+                exit 0
+            fi
+        fi
+        # For mac/remote: delete app namespaces BEFORE env_setup_main deletes the
+        # cluster.  env_setup_mac_cluster's cleanall path calls colima delete
         # at the end, making kubectl unreachable for any subsequent deleteApps call.
         if [[ "$environment" == "mac" || "$environment" == "remote" ]]; then
             if is_cluster_accessible; then

--- a/src/commandline/commandline.sh
+++ b/src/commandline/commandline.sh
@@ -12,7 +12,7 @@ DEFAULT_CONFIG_FILE="$RUN_DIR/config/config.ini"
 # Description: Resolves the username of the user who invoked the script,
 #              handling cases where sudo is used.
 #------------------------------------------------------------------------------
-function resolve_invoker_user() {
+resolve_invoker_user() {
   if [[ -n "${SUDO_USER:-}" && "${SUDO_USER}" != "root" ]]; then
     printf '%s\n' "$SUDO_USER"
     return
@@ -31,9 +31,9 @@ function resolve_invoker_user() {
 # Function : install_crudini
 # Description: Installs the 'crudini' tool if it is not already installed.
 #------------------------------------------------------------------------------
-function install_crudini() {
+install_crudini() {
     if ! command -v crudini &> /dev/null; then
-        logWithLevel "$INFO" "crudini not found. Attempting to install..."
+        log_with_level "$INFO" "crudini not found. Attempting to install..."
         if brew_available; then
             # crudini is a Python CLI tool (not a Homebrew formula).
             # Modern macOS with Homebrew-managed Python blocks plain pip install;
@@ -50,7 +50,7 @@ function install_crudini() {
                 if [[ -x "$candidate" ]]; then pipx_bin="$candidate"; break; fi
             done
             if [[ -z "$pipx_bin" ]]; then
-                logWithLevel "$ERROR" "pipx not found after install. Please install crudini manually: brew install pipx && pipx install crudini"
+                log_with_level "$ERROR" "pipx not found after install. Please install crudini manually: brew install pipx && pipx install crudini"
                 exit 1
             fi
             sudo -u "${SUDO_USER:-$k8s_user}" "$pipx_bin" install crudini >/dev/null 2>&1
@@ -61,14 +61,14 @@ function install_crudini() {
         elif command -v yum &> /dev/null; then
             sudo yum install -y crudini
         else
-            logWithLevel "$ERROR" "No supported package manager found (brew/apt-get/dnf/yum). Please install crudini manually."
+            log_with_level "$ERROR" "No supported package manager found (brew/apt-get/dnf/yum). Please install crudini manually."
             exit 1
         fi
         if ! command -v crudini &> /dev/null; then
-            logWithLevel "$ERROR" "Failed to install crudini. Exiting."
+            log_with_level "$ERROR" "Failed to install crudini. Exiting."
             exit 1
         fi
-        logWithLevel "$INFO" "crudini installed successfully."
+        log_with_level "$INFO" "crudini installed successfully."
     fi
 }
 
@@ -81,7 +81,7 @@ function install_crudini() {
 # Parameters:
 #   $1 - Path to config.ini
 #------------------------------------------------------------------------------
-function setup_logging() {
+setup_logging() {
     local config="$1"
     local log_enabled
     log_enabled=$(grep -E '^\s*logging\s*=' "$config" 2>/dev/null | tail -1 \
@@ -96,17 +96,17 @@ function setup_logging() {
 }
 
 #------------------------------------------------------------------------------
-# Function : loadConfigFromFile
+# Function : load_config_from_file
 # Description: Loads configuration parameters from the specified INI file using 'crudini'.
 # Parameters:
 #   $1 - Path to the configuration INI file.
 #------------------------------------------------------------------------------
-function loadConfigFromFile() {
+load_config_from_file() {
     local config_path="$1"
-    logWithLevel "$INFO" "Attempting to load configuration from $config_path using crudini."
+    log_with_level "$INFO" "Attempting to load configuration from $config_path using crudini."
 
     if [ ! -f "$config_path" ]; then
-        logWithLevel "$WARNING" "Configuration file not found: $config_path. Proceeding with defaults and command-line arguments."
+        log_with_level "$WARNING" "Configuration file not found: $config_path. Proceeding with defaults and command-line arguments."
         return 0
     fi
 
@@ -129,7 +129,7 @@ function loadConfigFromFile() {
     if [[ -n "$config_k8s_user" ]]; then
         if [[ "$config_k8s_user" == "\$USER" || "$config_k8s_user" == '$USER' ]]; then
             k8s_user="$(resolve_invoker_user)"
-            #logWithLevel "$INFO" "Expanded '\$USER' in config to invoking username: $k8s_user"
+            #log_with_level "$INFO" "Expanded '\$USER' in config to invoking username: $k8s_user"
         else
             k8s_user="$config_k8s_user"
         fi
@@ -139,7 +139,7 @@ function loadConfigFromFile() {
         if [[ "$config_kubeconfig_path" == "~/.kube/config" ]]; then
             k8s_user_home=$(eval echo "~$k8s_user")
             kubeconfig_path="$k8s_user_home/.kube/config"
-            #logWithLevel "$INFO" "Expanded kubeconfig_path to: $kubeconfig_path"
+            #log_with_level "$INFO" "Expanded kubeconfig_path to: $kubeconfig_path"
         else
             kubeconfig_path="$config_kubeconfig_path"
         fi
@@ -166,7 +166,7 @@ function loadConfigFromFile() {
         app_enabled=$(echo "$app_enabled" | tr '[:upper:]' '[:lower:]')
         if [[ "$app_enabled" == "true" ]]; then
             enabled_apps_list+=" $app_name"
-            #logWithLevel "$INFO" "Config indicates '$app_name' is enabled."
+            #log_with_level "$INFO" "Config indicates '$app_name' is enabled."
         fi
     done
     apps=$(echo "$enabled_apps_list" | xargs)
@@ -189,10 +189,10 @@ function loadConfigFromFile() {
                     if [[ -n "$value" ]]; then
                         # Store value as-is, let bash expand variables when referenced
                         eval "export $var_name=\"\$value\""
-                        #logWithLevel "$INFO" "Loaded from config [$section]: $var_name=$value"
+                        #log_with_level "$INFO" "Loaded from config [$section]: $var_name=$value"
                     fi
                 #else
-                    #logWithLevel "$INFO" "Skipped (already set) [$section]: $var_name=$current_value"
+                    #log_with_level "$INFO" "Skipped (already set) [$section]: $var_name=$current_value"
                 fi
             fi
         done <<< "$section_keys"
@@ -203,7 +203,7 @@ function loadConfigFromFile() {
 # Function : welcome
 # Description: Displays a welcome message for Mifos Gazelle.
 #------------------------------------------------------------------------------
-function welcome {
+welcome() {
     echo -e "${BLUE}"
     echo -e " ██████   █████  ███████ ███████ ██      ██      ███████ "
     echo -e "██       ██   ██    ███  ██      ██      ██      ██      "
@@ -217,10 +217,10 @@ function welcome {
 }
 
 #------------------------------------------------------------------------------
-# Function : showUsage
+# Function : show_usage
 # Description: Displays usage information for the script.
 #------------------------------------------------------------------------------
-function showUsage {
+show_usage() {
     echo "
     USAGE: $0 [-f <config_file_path>] -m [mode] -u [user] -a [apps] -e [environment] -d [true/false] -r [true/false]
     Example 1 : sudo $0                                          # deploy all apps enabled in config.ini and user \$USER from config.ini
@@ -250,7 +250,7 @@ function showUsage {
 # Parameters:
 #   $1 - Name of the array variable to check (passed by name).
 #------------------------------------------------------------------------------
-function check_duplicates() {
+check_duplicates() {
     local -n arr=$1
     declare -A seen
     
@@ -265,25 +265,25 @@ function check_duplicates() {
 }
 
 #------------------------------------------------------------------------------
-# Function : validateInputs
+# Function : validate_inputs
 # Description: Validates command-line inputs and configuration parameters.
 #------------------------------------------------------------------------------
-function validateInputs {
+validate_inputs() {
     if [[ -z "$mode" || -z "$k8s_user" ]]; then
         log_error "Required options -m (mode) and -u (user) must be provided."
-        showUsage
+        show_usage
         exit 1
     fi
 
     if [[ "$k8s_user" == "root" ]]; then
         log_error "The specified user cannot be root. Please specify a non-root user."
-        showUsage
+        show_usage
         exit 1
     fi
 
     if [[ "$mode" != "deploy" && "$mode" != "cleanapps" && "$mode" != "cleanall" ]]; then
         log_error "Invalid mode '$mode'. Must be one of: deploy, cleanapps, cleanall."
-        showUsage
+        show_usage
         exit 1
     fi
 
@@ -297,7 +297,7 @@ function validateInputs {
 
         local current_apps_array
         IFS=' ' read -r -a current_apps_array <<< "$apps"
-        logWithVerboseCheck "$debug" "$DEBUG" "Apps array: ${current_apps_array[*]}"
+        log_with_verbose_check "$debug" "$DEBUG" "Apps array: ${current_apps_array[*]}"
 
         local found_all_keyword="false"
         local specific_apps_count=0
@@ -305,7 +305,7 @@ function validateInputs {
         for app_item in "${current_apps_array[@]}"; do
             if ! [[ " $ALL_VALID_APPS " =~ " $app_item " ]]; then
                 log_error "Invalid app '$app_item'. Must be one of: ${ALL_VALID_APPS// /, }."
-                showUsage
+                show_usage
                 exit 1
             fi
             if [[ "$app_item" == "all" ]]; then
@@ -318,21 +318,21 @@ function validateInputs {
         # Check for duplicate apps
         if ! check_duplicates current_apps_array; then
             log_error "Duplicate applications specified in -a flag."
-            showUsage
+            show_usage
             exit 1
         fi
 
         if [[ "$found_all_keyword" == "true" ]]; then
             if [[ "$specific_apps_count" -gt 0 ]]; then
                 log_error "Cannot combine 'all' with specific apps. Use either 'all' or a list, not both."
-                showUsage
+                show_usage
                 exit 1
             fi
             apps="$CORE_APPS"
-            logWithVerboseCheck "$debug" "$DEBUG" "Expanded 'all' to: $apps"
+            log_with_verbose_check "$debug" "$DEBUG" "Expanded 'all' to: $apps"
         fi
 
-        logWithVerboseCheck "$debug" "$DEBUG" "Apps to process: $apps"
+        log_with_verbose_check "$debug" "$DEBUG" "Apps to process: $apps"
         if [[ " $apps " =~ " infra " ]]; then
             if [[ "$mode" == "deploy" ]]; then
                 # for mode = deploy ensure 'infra' is first app if present
@@ -344,31 +344,31 @@ function validateInputs {
                 apps=$(echo $apps | xargs)
             fi
         fi
-        logWithVerboseCheck "$debug" "$DEBUG" "Final app order: $apps"
+        log_with_verbose_check "$debug" "$DEBUG" "Final app order: $apps"
     fi
 
     if [[ -n "$debug" && "$debug" != "true" && "$debug" != "false" ]]; then
         log_error "Invalid value for debug. Use 'true' or 'false'."
-        showUsage
+        show_usage
         exit 1
     fi
 
     if [[ -n "$redeploy" && "$redeploy" != "true" && "$redeploy" != "false" ]]; then
         log_error "Invalid value for redeploy. Use 'true' or 'false'."
-        showUsage
+        show_usage
         exit 1
     fi
 
     if [[ -n "$environment" && "$environment" != "local" && "$environment" != "remote" && "$environment" != "mac" ]]; then
         log_error "Invalid environment '$environment'. Must be 'local', 'remote', or 'mac'."
-        showUsage
+        show_usage
         exit 1
     fi
 
     if [[ "$environment" == "local" ]]; then
         if [[ -z "$k8s_version" ]]; then
             log_error "k8s_version must be specified for local environment."
-            showUsage
+            show_usage
             exit 1
         fi
     fi
@@ -376,7 +376,7 @@ function validateInputs {
     if [[ "$environment" == "remote" && -n "$kubeconfig_path" ]]; then
         if [[ ! -f "$kubeconfig_path" ]]; then
             log_error "kubeconfig_path '$kubeconfig_path' does not exist or is not a file."
-            showUsage
+            show_usage
             exit 1
         fi
     fi
@@ -384,14 +384,14 @@ function validateInputs {
     if [[ "$(uname -s)" != "Darwin" ]]; then
         if [[ ! " $linux_os_list " =~ " Ubuntu " ]]; then
             log_error "Only Ubuntu is supported in linux_os_list: $linux_os_list."
-            showUsage
+            show_usage
             exit 1
         fi
 
         local os_version=$(lsb_release -r -s | cut -d'.' -f1)
         if [[ ! " $ubuntu_ok_versions_list " =~ " $os_version " ]]; then
             log_error "Ubuntu version '$os_version' is not supported. Supported versions: $ubuntu_ok_versions_list."
-            showUsage
+            show_usage
             exit 1
         fi
     fi
@@ -402,18 +402,18 @@ function validateInputs {
     if [[ ( "$environment" == "remote" || "$environment" == "mac" ) && -z "$kubeconfig_path" ]]; then
         k8s_user_home=$(eval echo "~$k8s_user")
         kubeconfig_path="$k8s_user_home/.kube/config"
-        logWithLevel "$INFO" "No kubeconfig_path specified in config.ini for $environment environment. Defaulting to $kubeconfig_path"
+        log_with_level "$INFO" "No kubeconfig_path specified in config.ini for $environment environment. Defaulting to $kubeconfig_path"
     fi
-} #validateInputs
+} #validate_inputs
 
 #------------------------------------------------------------------------------
-# Function : getOptions
+# Function : get_options
 # Description: Parses command-line options and populates a map with the values.
 # Parameters:
 #   $1 - Name of the associative array to populate with options.
 #   Remaining parameters - Command-line arguments to parse.
 #------------------------------------------------------------------------------
-function getOptions() {
+get_options() {
     local -n options_map=$1
     shift
 
@@ -427,35 +427,35 @@ function getOptions() {
             u) options_map["k8s_user"]="${OPTARG}" ;;
             r) options_map["redeploy"]="${OPTARG}" ;;
             e) options_map["environment"]="${OPTARG}" ;;
-            h|H) showUsage;
+            h|H) show_usage;
                  exit 0 ;;
             *) echo "Unknown option: -${OPTION}"
-               showUsage;
+               show_usage;
                exit 1 ;;
         esac
     done
 }
 
 #------------------------------------------------------------------------------
-# Function : cleanUp
+# Function : clean_up
 # Description: Performs graceful cleanup on script exit.
 #------------------------------------------------------------------------------
-function cleanUp() {
+clean_up() {
     echo
     log_warn "Caught interrupt — performing graceful cleanup."
     exit 2
 }
 
 #------------------------------------------------------------------------------
-# Function : trapCtrlc
+# Function : trap_ctrlc
 # Description: Handles Ctrl-C (SIGINT) signal to perform cleanup.
 #------------------------------------------------------------------------------
-function trapCtrlc {
+trap_ctrlc() {
     echo
-    cleanUp
+    clean_up
 }
 
-trap "trapCtrlc" 2
+trap "trap_ctrlc" 2
 
 
 # Global variables that will hold the final configuration
@@ -474,7 +474,7 @@ kubeconfig_path=""
 export KUBECONFIG=$kubeconfig_path
 CONFIG_FILE_PATH="$DEFAULT_CONFIG_FILE"
 
-function main {
+main() {
     # Determine config file path early (before full option parsing) so that
     # logging can be set up before welcome() prints anything.
     local _early_config="$DEFAULT_CONFIG_FILE"
@@ -491,18 +491,18 @@ function main {
     install_crudini
     if [[ $# -gt 0 && ! "$1" =~ ^- ]]; then
         echo "ERROR: Invalid command syntax. All options must start with a hyphen (e.g., -m)."
-        showUsage
+        show_usage
         exit 1
     fi
 
     declare -A cmd_args_map
-    getOptions cmd_args_map "$@"
+    get_options cmd_args_map "$@"
 
     for key in "${!cmd_args_map[@]}"; do
         if [[ "${cmd_args_map[$key]}" =~ ^- ]]; then
             echo "ERROR: Argument for flag '-${key:0:1}' cannot start with a hyphen (found '${cmd_args_map[$key]}')."
             echo "It looks like you missed a value or provided flags out of order."
-            showUsage
+            show_usage
             exit 1
         fi
     done
@@ -510,39 +510,39 @@ function main {
     if [[ $# -gt 0 ]]; then
         echo "ERROR: Unexpected or malformed argument(s) detected: $@"
         echo "Every option must have a flag (e.g., use -m instead of just m)."
-        showUsage
+        show_usage
         exit 1
     fi
 
     if [[ -n "${cmd_args_map["config_file_path"]}" ]]; then
         CONFIG_FILE_PATH="${cmd_args_map["config_file_path"]}"
     fi
-    logWithLevel "$INFO" "Using config file: $CONFIG_FILE_PATH"
+    log_with_level "$INFO" "Using config file: $CONFIG_FILE_PATH"
 
-    loadConfigFromFile "$CONFIG_FILE_PATH"
+    load_config_from_file "$CONFIG_FILE_PATH"
 
 
     if [[ -n "${cmd_args_map["mode"]}" ]]; then mode="${cmd_args_map["mode"]}"; fi
     if [[ -n "${cmd_args_map["k8s_user"]}" ]]; then k8s_user="${cmd_args_map["k8s_user"]}"; fi
     if [[ -n "${cmd_args_map["apps"]}" ]]; then
         apps=$(echo "${cmd_args_map["apps"]}" | tr ',' ' ')
-        logWithLevel "$INFO" "CLI apps converted to space-separated: $apps"
+        log_with_level "$INFO" "CLI apps converted to space-separated: $apps"
     fi
     if [[ -n "${cmd_args_map["debug"]}" ]]; then debug="${cmd_args_map["debug"]}"; fi
     if [[ -n "${cmd_args_map["redeploy"]}" ]]; then redeploy="${cmd_args_map["redeploy"]}"; fi
     if [[ -n "${cmd_args_map["environment"]}" ]]; then environment="${cmd_args_map["environment"]}"; fi
 
-    validateInputs
+    validate_inputs
 
     if [ "$mode" == "deploy" ]; then
         echo -e "${YELLOW}WARN${RESET}   This deployment is recommended for demo, test and educational purposes only."
         echo
         env_setup_main "$mode"
-        deployApps "$apps" "$redeploy"
+        deploy_apps "$apps" "$redeploy"
     elif [ "$mode" == "cleanapps" ]; then
-        logWithVerboseCheck "$debug" "$INFO" "Cleaning up Mifos Gazelle applications only"
+        log_with_verbose_check "$debug" "$INFO" "Cleaning up Mifos Gazelle applications only"
         env_setup_main "$mode"
-        deleteApps "$apps"
+        delete_apps "$apps"
     elif [ "$mode" == "cleanall" ]; then
         if [[ "$environment" == "mac" ]]; then
             printf "\n*** WARNING: cleanall will delete the Colima VM, all deployed\n"
@@ -556,15 +556,15 @@ function main {
         fi
         # For mac/remote: delete app namespaces BEFORE env_setup_main deletes the
         # cluster.  env_setup_mac_cluster's cleanall path calls colima delete
-        # at the end, making kubectl unreachable for any subsequent deleteApps call.
+        # at the end, making kubectl unreachable for any subsequent delete_apps call.
         if [[ "$environment" == "mac" || "$environment" == "remote" ]]; then
             if is_cluster_accessible; then
-                deleteApps "$apps"
+                delete_apps "$apps"
             fi
         fi
         env_setup_main "$mode"
     else
-        showUsage
+        show_usage
         exit 1
     fi
 }

--- a/src/commandline/commandline.sh
+++ b/src/commandline/commandline.sh
@@ -34,7 +34,7 @@ resolve_invoker_user() {
 install_crudini() {
     if ! command -v crudini &> /dev/null; then
         log_with_level "$INFO" "crudini not found. Attempting to install..."
-        if brew_available; then
+        if [[ "$(uname -s)" == "Darwin" ]]; then
             # crudini is a Python CLI tool (not a Homebrew formula).
             # Modern macOS with Homebrew-managed Python blocks plain pip install;
             # use pipx which handles the venv isolation automatically.

--- a/src/commandline/commandline.sh
+++ b/src/commandline/commandline.sh
@@ -34,14 +34,16 @@ function resolve_invoker_user() {
 function install_crudini() {
     if ! command -v crudini &> /dev/null; then
         logWithLevel "$INFO" "crudini not found. Attempting to install..."
-        if command -v apt-get &> /dev/null; then
+        if command -v brew &> /dev/null; then
+            brew install crudini >/dev/null 2>&1
+        elif command -v apt-get &> /dev/null; then
             sudo apt-get update && sudo apt-get install -y crudini
         elif command -v dnf &> /dev/null; then
             sudo dnf install -y crudini
         elif command -v yum &> /dev/null; then
             sudo yum install -y crudini
         else
-            logWithLevel "$ERROR" "Neither apt-get, dnf, nor yum found. Please install crudini manually."
+            logWithLevel "$ERROR" "No supported package manager found (brew/apt-get/dnf/yum). Please install crudini manually."
             exit 1
         fi
         if ! command -v crudini &> /dev/null; then
@@ -337,8 +339,8 @@ function validateInputs {
         exit 1
     fi
 
-    if [[ -n "$environment" && "$environment" != "local" && "$environment" != "remote" ]]; then
-        log_error "Invalid environment '$environment'. Must be 'local' or 'remote'."
+    if [[ -n "$environment" && "$environment" != "local" && "$environment" != "remote" && "$environment" != "mac" ]]; then
+        log_error "Invalid environment '$environment'. Must be 'local', 'remote', or 'mac'."
         showUsage
         exit 1
     fi
@@ -359,26 +361,28 @@ function validateInputs {
         fi
     fi
 
-    if [[ ! " $linux_os_list " =~ " Ubuntu " ]]; then
-        log_error "Only Ubuntu is supported in linux_os_list: $linux_os_list."
-        showUsage
-        exit 1
-    fi
+    if [[ "$(uname -s)" != "Darwin" ]]; then
+        if [[ ! " $linux_os_list " =~ " Ubuntu " ]]; then
+            log_error "Only Ubuntu is supported in linux_os_list: $linux_os_list."
+            showUsage
+            exit 1
+        fi
 
-    local os_version=$(lsb_release -r -s | cut -d'.' -f1)
-    if [[ ! " $ubuntu_ok_versions_list " =~ " $os_version " ]]; then
-        log_error "Ubuntu version '$os_version' is not supported. Supported versions: $ubuntu_ok_versions_list."
-        showUsage
-        exit 1
+        local os_version=$(lsb_release -r -s | cut -d'.' -f1)
+        if [[ ! " $ubuntu_ok_versions_list " =~ " $os_version " ]]; then
+            log_error "Ubuntu version '$os_version' is not supported. Supported versions: $ubuntu_ok_versions_list."
+            showUsage
+            exit 1
+        fi
     fi
 
     environment="${environment:-local}"
     debug="${debug:-false}"
     redeploy="${redeploy:-true}"
-    if [[ "$environment" == "remote" && -z "$kubeconfig_path" ]]; then
+    if [[ ( "$environment" == "remote" || "$environment" == "mac" ) && -z "$kubeconfig_path" ]]; then
         k8s_user_home=$(eval echo "~$k8s_user")
         kubeconfig_path="$k8s_user_home/.kube/config"
-        logWithLevel "$INFO" "No kubeconfig_path specified in config.ini for remote environment. Defaulting to $kubeconfig_path"
+        logWithLevel "$INFO" "No kubeconfig_path specified in config.ini for $environment environment. Defaulting to $kubeconfig_path"
     fi
 } #validateInputs
 
@@ -500,8 +504,8 @@ function main {
         deleteApps "$apps"
     elif [ "$mode" == "cleanall" ]; then
         env_setup_main "$mode"
-        # env_setup_main will not remove remote cluster so need to run deleteApps
-        if [[ "$environment" == "remote" ]]; then
+        # env_setup_main will not remove remote/mac cluster so need to run deleteApps
+        if [[ "$environment" == "remote" || "$environment" == "mac" ]]; then
             deleteApps "$mifosx_instances" "all"
         fi
     else

--- a/src/deployer/core.sh
+++ b/src/deployer/core.sh
@@ -6,26 +6,26 @@
 # Description: Check if the application is deployed by 
 # verifying the number of "Ready" pods in a namespace
 #------------------------------------------------------
-function is_app_running() {
+is_app_running() {
     local namespace="$1"
     local min_pods=2
     
     # Validate inputs
     [[ -z "$namespace" ]] && {
-        logWithVerboseCheck "$debug" error "Namespace missing: namespace=$namespace"
+        log_with_verbose_check "$debug" error "Namespace missing: namespace=$namespace"
         return 1
     }
     
     # Debug: Print namespace and minimum pods
-    logWithVerboseCheck "$debug" debug "Checking for at least $min_pods pods, all Ready, in namespace $namespace"
+    log_with_verbose_check "$debug" debug "Checking for at least $min_pods pods, all Ready, in namespace $namespace"
     
     # Check if namespace exists
     local namespace_check
     namespace_check=$(run_as_user "kubectl get namespace \"$namespace\" -o name")
     local namespace_exit_code=$?
-    logWithVerboseCheck "$debug" debug "Namespace check exit code: $namespace_exit_code, output: [$namespace_check]"
+    log_with_verbose_check "$debug" debug "Namespace check exit code: $namespace_exit_code, output: [$namespace_check]"
     [[ $namespace_exit_code -ne 0 ]] && {
-        logWithVerboseCheck "$debug" error "Namespace $namespace does not exist or is inaccessible"
+        log_with_verbose_check "$debug" error "Namespace $namespace does not exist or is inaccessible"
         return 1
     }
     
@@ -34,7 +34,7 @@ function is_app_running() {
     local exit_code=$?
 
     # Strip any lines that look like debug/command echo (e.g., "DEBUG Running as ...")
-    pod_list=$(echo "$raw_output" | grep -v 'DEBUG' | grep -v "kubectl" || true)
+    pod_list=$(echo "$raw_output" | grep -vE '(DEBUG|kubectl)' || true)
     
     # Count total pods and ready pods
     total_pods=$(echo "$pod_list" | grep -c '^')
@@ -43,27 +43,27 @@ function is_app_running() {
     ready_count=$(echo "$pod_list" | awk '{split($2,a,"/"); if(a[1]==a[2] && a[1]>0) print}' | grep -c '^')
 
     # Debug: Print kubectl exit code, pod list, total pods, and ready count
-    logWithVerboseCheck "$debug" debug "kubectl exit code: $exit_code, pod list: [$pod_list], total pods: $total_pods, ready pods: $ready_count"
+    log_with_verbose_check "$debug" debug "kubectl exit code: $exit_code, pod list: [$pod_list], total pods: $total_pods, ready pods: $ready_count"
 
-    logWithVerboseCheck "$debug" "$DEBUG" "is_app_running($namespace): total_pods=$total_pods, ready_count=$ready_count, min_pods=$min_pods"
+    log_with_verbose_check "$debug" "$DEBUG" "is_app_running($namespace): total_pods=$total_pods, ready_count=$ready_count, min_pods=$min_pods"
     
     # Check if command failed
     [[ $exit_code -ne 0 ]] && {
-        logWithVerboseCheck "$debug" error "Failed to retrieve pods in namespace $namespace"
+        log_with_verbose_check "$debug" error "Failed to retrieve pods in namespace $namespace"
         return 1
     }
     
     # Check if there are enough pods and all are Ready
     if [[ $total_pods -ge $min_pods && $ready_count -ge $min_pods ]]; then
-        logWithVerboseCheck "$debug" debug "Found $total_pods pods, all Ready, in namespace $namespace, meeting minimum of $min_pods"
+        log_with_verbose_check "$debug" debug "Found $total_pods pods, all Ready, in namespace $namespace, meeting minimum of $min_pods"
         return 0
     else
-        logWithVerboseCheck "$debug" debug "Check failed: $total_pods pods, $ready_count Ready, in namespace $namespace (requires at least $min_pods pods, all Ready)"
+        log_with_verbose_check "$debug" debug "Check failed: $total_pods pods, $ready_count Ready, in namespace $namespace (requires at least $min_pods pods, all Ready)"
         return 1
     fi
 } # end of is_app_running
 
-function wait_for_pods_ready() {
+wait_for_pods_ready() {
     local namespace="$1"
     log_step "Waiting for $namespace pods to stabilise"
 
@@ -73,17 +73,17 @@ function wait_for_pods_ready() {
 
       if [ -z "$NOT_READY" ]; then
         STABLE_COUNT=$((STABLE_COUNT + 1))
-        logWithVerboseCheck "$debug" "$DEBUG" "All pods ready — stable count: $STABLE_COUNT/3"
+        log_with_verbose_check "$debug" "$DEBUG" "All pods ready — stable count: $STABLE_COUNT/3"
       else
         STABLE_COUNT=0
-        logWithVerboseCheck "$debug" "$DEBUG" "Some pods not ready — waiting 60s..."
+        log_with_verbose_check "$debug" "$DEBUG" "Some pods not ready — waiting 60s..."
       fi
       sleep 60
     done
     log_ok
 }
 #------------------------------------------------------------------------------
-# Function : createIngressSecret
+# Function : create_ingress_secret
 # Description: Creates a self-signed TLS cert with multiple SANs and stores it as a Kubernetes secret.
 # Parameters:
 #   $1 - Namespace
@@ -91,7 +91,7 @@ function wait_for_pods_ready() {
 #   $3 - Secret name
 #   $4 - Comma-separated SAN list (optional) - e.g. "ops.example.com,api.example.com,*.example.com"
 #------------------------------------------------------------------------------
-function createIngressSecret {
+create_ingress_secret() {
     local namespace="$1"
     local primary_domain="$2"
     local secret_name="$3"
@@ -114,7 +114,7 @@ function createIngressSecret {
     fi
 
     log_step "Creating TLS secret '$secret_name' ($primary_domain, $((index-1)) SANs)"
-    logWithVerboseCheck "$debug" "$DEBUG" "SANs:\n$san_config"
+    log_with_verbose_check "$debug" "$DEBUG" "SANs:\n$san_config"
 
     # Generate private key
     openssl genrsa -out "$key_dir/$primary_domain.key" 2048 >/dev/null 2>&1
@@ -187,7 +187,7 @@ EOF
 
 
 #------------------------------------------------------------------------------
-# Function : manageElasticSecrets
+# Function : manage_elastic_secrets
 # Description: Creates or deletes Elasticsearch related Kubernetes secrets.
 #              On create, generates a self-signed certificate and packages it
 #              as a PKCS12 file using only openssl — no external repo required.
@@ -195,7 +195,7 @@ EOF
 #   $1 - Action: "create" or "delete"
 #   $2 - Namespace where the secrets are managed
 #------------------------------------------------------------------------------
-function manageElasticSecrets {
+manage_elastic_secrets() {
     local action="$1"
     local namespace="$2"
     local password="XVYgwycNuEygEEEI0hQF"
@@ -317,7 +317,6 @@ function manageElasticSecrets {
                 log_warn "Failed to delete secret $secret: $delete_output"
                 all_success=false
             fi
-            # echo "DEBUG removed secret $secret in namespace $namespace ok" 
         done
 
         if [ "$all_success" = false ]; then
@@ -368,16 +367,6 @@ update_fqdn() {
 
 }
 
-# update_fqdn() {
-#     local file="$1"
-#     local old_fqdn="$2"
-#     local new_fqdn="$3"
-    
-#     [ ! -f "$file" ] && echo "Error: File not found" && return 1
-#     perl -pi -e "s/\\b([a-zA-Z0-9.-]+)\\.$old_fqdn\\b/\$1.$new_fqdn/g" "$file"
-
-# }
-
 #------------------------------------------------------------------------------
 # Function to update all YAML files in a directory structure
 # Example:
@@ -401,11 +390,11 @@ update_fqdn_batch() {
 # Parameters:
 #   $1 - Path to the Helm chart directory
 #------------------------------------------------------------------------------
-function ensure_helm_dependencies() {
+ensure_helm_dependencies() {
   local chartPath=$1
   local chartName=$(basename "$chartPath")
   
-  logWithVerboseCheck "$debug" "$DEBUG" "Ensuring helm dependencies for $chartName"
+  log_with_verbose_check "$debug" "$DEBUG" "Ensuring helm dependencies for $chartName"
 
   if [[ -f "$chartPath/Chart.lock" && -s "$chartPath/Chart.lock" ]]; then
     local expected actual
@@ -414,7 +403,7 @@ function ensure_helm_dependencies() {
 
     if [[ $actual -ge $expected && $expected -gt 0 ]]; then
       # All dependencies already present — nothing to do
-      logWithVerboseCheck "$debug" "$DEBUG" "helm dependencies for $chartName already present ($actual/$expected), skipping fetch"
+      log_with_verbose_check "$debug" "$DEBUG" "helm dependencies for $chartName already present ($actual/$expected), skipping fetch"
       return 0
     fi
   fi
@@ -422,9 +411,9 @@ function ensure_helm_dependencies() {
   # Dependencies missing — run helm dep update as the invoking user directly
   # (not via run_as_user/su) so that credential helpers and PATH work correctly
   if ! (cd "$chartPath" && helm dep update); then
-    logWithLevel "$ERROR" "helm dependency fetch failed for '$chartName'."
-    logWithLevel "$ERROR" "Try running manually as your normal user:"
-    logWithLevel "$ERROR" "  cd $chartPath && helm dep update"
+    log_with_level "$ERROR" "helm dependency fetch failed for '$chartName'."
+    log_with_level "$ERROR" "Try running manually as your normal user:"
+    log_with_level "$ERROR" "  cd $chartPath && helm dep update"
     exit 1
   fi
 }

--- a/src/deployer/core.sh
+++ b/src/deployer/core.sh
@@ -408,16 +408,23 @@ function ensure_helm_dependencies() {
   logWithVerboseCheck "$debug" "$DEBUG" "Ensuring helm dependencies for $chartName"
 
   if [[ -f "$chartPath/Chart.lock" && -s "$chartPath/Chart.lock" ]]; then
-    # Count entries in Chart.lock and compare with .tgz files in charts/
-    local expected=$(grep -c "name:" "$chartPath/Chart.lock")
-    local actual=$(find "$chartPath/charts" -maxdepth 1 -name '*.tgz' 2>/dev/null | wc -l)
-    
+    local expected actual
+    expected=$(grep -c "name:" "$chartPath/Chart.lock")
+    actual=$(find "$chartPath/charts" -maxdepth 1 -name '*.tgz' 2>/dev/null | wc -l | tr -d '[:space:]')
+
     if [[ $actual -ge $expected && $expected -gt 0 ]]; then
-      run_as_user "cd $chartPath && helm dep build" >> /dev/null 2>&1
-    else
-      run_as_user "cd $chartPath && helm dep update" >> /dev/null 2>&1
+      # All dependencies already present — nothing to do
+      logWithVerboseCheck "$debug" "$DEBUG" "helm dependencies for $chartName already present ($actual/$expected), skipping fetch"
+      return 0
     fi
-  else
-    run_as_user "cd $chartPath && helm dep update" >> /dev/null 2>&1
+  fi
+
+  # Dependencies missing — run helm dep update as the invoking user directly
+  # (not via run_as_user/su) so that credential helpers and PATH work correctly
+  if ! (cd "$chartPath" && helm dep update); then
+    logWithLevel "$ERROR" "helm dependency fetch failed for '$chartName'."
+    logWithLevel "$ERROR" "Try running manually as your normal user:"
+    logWithLevel "$ERROR" "  cd $chartPath && helm dep update"
+    exit 1
   fi
 }

--- a/src/deployer/deployer.sh
+++ b/src/deployer/deployer.sh
@@ -115,8 +115,8 @@ function deployHelmChartFromDir() {
     return 1
   fi
 
-  # Build helm install command
-  local helm_cmd="helm install --wait --timeout 600s $release_name $chart_dir -n $namespace"
+  # Use upgrade --install so re-runs work even if a previous install failed
+  local helm_cmd="helm upgrade --install --wait --timeout 600s $release_name $chart_dir -n $namespace"
   if [ -n "$values_file" ]; then
       helm_cmd="$helm_cmd -f $values_file"
   fi

--- a/src/deployer/deployer.sh
+++ b/src/deployer/deployer.sh
@@ -31,11 +31,13 @@ function cloneRepo() {
   # Check if repository and branch exist
   if [ -d "$repo_path" ]; then
     cd "$repo_path" || return 1
-    # Check if specified branch exists locally
-    if git show-ref --verify --quiet "refs/heads/$branch"; then
+    # Accept if branch exists as local ref, remote-tracking ref, or is currently checked out
+    if git show-ref --verify --quiet "refs/heads/$branch" \
+        || git show-ref --verify --quiet "refs/remotes/origin/$branch" \
+        || [ "$(git rev-parse --abbrev-ref HEAD 2>/dev/null)" = "$branch" ]; then
       return 0
     fi
-    # Remove repo if branch doesn't exist
+    # Remove repo if branch doesn't exist anywhere
     echo "Branch $branch not found in $repo_path. Recloning..."
     rm -rf "$repo_path"
   fi

--- a/src/deployer/deployer.sh
+++ b/src/deployer/deployer.sh
@@ -10,12 +10,12 @@ source "$RUN_DIR/src/utils/helpers.sh" || { echo "FATAL: Could not source helper
 
 #------------------------------------------------------------
 # Description : Clones/updates a Git repo. Reclones only if repo or branch missing.
-# Usage : cloneRepo <branch> <repo_link> <target_dir> <dir_name>
-# Example: cloneRepo main link target-dir repo-name
+# Usage : clone_repo <branch> <repo_link> <target_dir> <dir_name>
+# Example: clone_repo main link target-dir repo-name
 #------------------------------------------------------------
-function cloneRepo() {
+clone_repo() {
   if [ "$#" -ne 4 ]; then
-    echo "Usage: cloneRepo <branch> <repo_link> <target_directory> <cloned_directory_name>"
+    echo "Usage: clone_repo <branch> <repo_link> <target_directory> <cloned_directory_name>"
     return 1
   fi
 
@@ -45,7 +45,7 @@ function cloneRepo() {
   # Clone the repository
   run_as_user "git clone -b \"$branch\" \"$repo_link\" \"$repo_path\" " >/dev/null 2>&1
   if [ $? -eq 0 ]; then
-    logWithVerboseCheck "$debug" "$DEBUG" "Cloned $repo_link → $repo_path"
+    log_with_verbose_check "$debug" "$DEBUG" "Cloned $repo_link → $repo_path"
   else
     log_error "Failed to clone $repo_link to $repo_path"
     return 1
@@ -54,13 +54,13 @@ function cloneRepo() {
 
 #------------------------------------------------------------
 # Description : Deletes K8s namespaces matching a regex pattern.
-# Usage : deleteResourcesInNamespaceMatchingPattern <regex_pattern>
-# Example: deleteResourcesInNamespaceMatchingPattern "app-.*"
+# Usage : delete_resources_in_namespace_matching_pattern <regex_pattern>
+# Example: delete_resources_in_namespace_matching_pattern "app-.*"
 #------------------------------------------------------------
-function deleteResourcesInNamespaceMatchingPattern() {
+delete_resources_in_namespace_matching_pattern() {
     local pattern="$1"
     if [ -z "$pattern" ]; then
-        log_error "deleteResourcesInNamespaceMatchingPattern: pattern argument required"
+        log_error "delete_resources_in_namespace_matching_pattern: pattern argument required"
         exit 1
     fi
         
@@ -74,7 +74,6 @@ function deleteResourcesInNamespaceMatchingPattern() {
     matching_namespaces=$(echo "$all_namespaces_output" | grep -E "$pattern" | sed 's/^namespace\///' || true)
 
     if [ -z "$matching_namespaces" ]; then
-        # printf "      namespaces %s not found    [skipping] \n"  $pattern
         return 0
     fi
     
@@ -98,12 +97,12 @@ function deleteResourcesInNamespaceMatchingPattern() {
 
 #------------------------------------------------------------
 # Description : Deploys a Helm chart from a local dir to a K8s NS.
-# Usage : deployHelmChartFromDir <dir> <ns> <release> [values_file]
-# Example: deployHelmChartFromDir ./chart infra infra-rls values.yaml
+# Usage : deploy_helm_chart_from_dir <dir> <ns> <release> [values_file]
+# Example: deploy_helm_chart_from_dir ./chart infra infra-rls values.yaml
 #------------------------------------------------------------
-function deployHelmChartFromDir() {
+deploy_helm_chart_from_dir() {
   if [ "$#" -lt 3 ] || [ "$#" -gt 4 ]; then
-    echo "Usage: deployHelmChartFromDir <chart_dir> <namespace> <release_name> [values_file]"
+    echo "Usage: deploy_helm_chart_from_dir <chart_dir> <namespace> <release_name> [values_file]"
     return 1
   fi
 
@@ -137,10 +136,10 @@ function deployHelmChartFromDir() {
 #------------------------------------------------------------
 # Description : Creates a K8s namespace if it doesn't exist.
 #               Configures Docker Hub authentication if credentials available.
-# Usage : createNamespace <namespace>
-# Example: createNamespace mifosx-ns
+# Usage : create_namespace <namespace>
+# Example: create_namespace mifosx-ns
 #------------------------------------------------------------
-function createNamespace() {
+create_namespace() {
   local namespace=$1
 
   # Check if the namespace already exists
@@ -164,10 +163,10 @@ function createNamespace() {
 
 #------------------------------------------------------------
 # Description : Deploys infrastructure chart via Helm.
-# Usage : deployInfrastructure [redeploy_bool]
-# Example: deployInfrastructure true
+# Usage : deploy_infrastructure [redeploy_bool]
+# Example: deploy_infrastructure true
 #------------------------------------------------------------
-function deployInfrastructure() {
+deploy_infrastructure() {
   local redeploy="${1:-false}"
 
   if is_app_running "$INFRA_NAMESPACE" && [[ "$redeploy" == "false" ]]; then
@@ -178,13 +177,13 @@ function deployInfrastructure() {
 
   if is_app_running "$INFRA_NAMESPACE"; then
     log_step "Removing existing infrastructure"
-    deleteResourcesInNamespaceMatchingPattern "$INFRA_NAMESPACE"
+    delete_resources_in_namespace_matching_pattern "$INFRA_NAMESPACE"
     log_ok
   fi
 
   log_step "Creating namespace $INFRA_NAMESPACE"
-  createNamespace "$INFRA_NAMESPACE"
-  check_command_execution $? "createNamespace $INFRA_NAMESPACE"
+  create_namespace "$INFRA_NAMESPACE"
+  check_command_execution $? "create_namespace $INFRA_NAMESPACE"
   log_ok
 
   log_step "Updating FQDNs"
@@ -196,11 +195,11 @@ function deployInfrastructure() {
 
   log_step "Helm chart (infra)"
   if [ "$debug" = true ]; then
-    deployHelmChartFromDir "$RUN_DIR/src/deployer/helm/infra" "$INFRA_NAMESPACE" "$INFRA_RELEASE_NAME"
+    deploy_helm_chart_from_dir "$RUN_DIR/src/deployer/helm/infra" "$INFRA_NAMESPACE" "$INFRA_RELEASE_NAME"
   else
-    deployHelmChartFromDir "$RUN_DIR/src/deployer/helm/infra" "$INFRA_NAMESPACE" "$INFRA_RELEASE_NAME" >> /dev/null 2>&1
+    deploy_helm_chart_from_dir "$RUN_DIR/src/deployer/helm/infra" "$INFRA_NAMESPACE" "$INFRA_RELEASE_NAME" >> /dev/null 2>&1
   fi
-  check_command_execution $? "deployHelmChartFromDir infra"
+  check_command_execution $? "deploy_helm_chart_from_dir infra"
   log_ok
 
   log_banner "Infrastructure Deployed"
@@ -208,12 +207,12 @@ function deployInfrastructure() {
 
 #------------------------------------------------------------
 # Description : Applies K8s YAML manifests from a directory.
-# Usage : applyKubeManifests <directory> <namespace>
-# Example: applyKubeManifests ./k8s-files mifosx-ns
+# Usage : apply_kube_manifests <directory> <namespace>
+# Example: apply_kube_manifests ./k8s-files mifosx-ns
 #------------------------------------------------------------
-function applyKubeManifests() {
+apply_kube_manifests() {
     if [ "$#" -ne 2 ]; then
-        echo "Usage: applyKubeManifests <directory> <namespace>"
+        echo "Usage: apply_kube_manifests <directory> <namespace>"
         return 1
     fi
     
@@ -243,37 +242,9 @@ function applyKubeManifests() {
 }
 
 #------------------------------------------------------------
-# Description : Placeholder for vNext application testing logic.
-# Usage : test_vnext
-# Example: test_vnext
-#------------------------------------------------------------
-function test_vnext() {
-  echo "TODO" #TODO Write function to test apps
-}
-
-#------------------------------------------------------------
-# Description : Placeholder for Phee application testing logic.
-# Usage : test_phee
-# Example: test_phee
-#------------------------------------------------------------
-function test_phee() {
-  echo "TODO"
-}
-
-#------------------------------------------------------------
-# Description : Placeholder for MifosX application testing logic.
-# Usage : test_mifosx <instance_name>
-# Example: test_mifosx default
-#------------------------------------------------------------
-function test_mifosx() {
-  local instance_name=$1
-  # TODO: Implement testing logic
-}
-
-#------------------------------------------------------------
 # Description : Prints cleanup end message .
 #------------------------------------------------------------
-function print_cleanup_end_message() {
+print_cleanup_end_message() {
   log_banner "Cleanup Complete"
   echo
 }
@@ -283,7 +254,7 @@ function print_cleanup_end_message() {
 # Usage : print_deployment_end_message
 # Example: print_deployment_end_message
 #------------------------------------------------------------
-function print_deployment_end_message() {
+print_deployment_end_message() {
   local data_gen_failed="${1:-false}"
 
   log_banner "Mifos Gazelle Ready"
@@ -304,10 +275,10 @@ function print_deployment_end_message() {
 
 #------------------------------------------------------------
 # Description : Deletes all or specific applications by namespace.
-# Usage : deleteApps <ignored> <"app1 app2"|all>
-# Example: deleteApps _ "mifosx vnext"
+# Usage : delete_apps <ignored> <"app1 app2"|all>
+# Example: delete_apps _ "mifosx vnext"
 #------------------------------------------------------------
-function deleteApps() {
+delete_apps() {
   local appsToDelete="$1"
 
   log_section "Removing applications"
@@ -315,22 +286,22 @@ function deleteApps() {
     case "$app" in
       "vnext")
         log_step "Removing vNext"
-        deleteResourcesInNamespaceMatchingPattern "$VNEXT_NAMESPACE"
+        delete_resources_in_namespace_matching_pattern "$VNEXT_NAMESPACE"
         log_ok
         ;;
       "mifosx")
         log_step "Removing MifosX"
-        deleteResourcesInNamespaceMatchingPattern "$MIFOSX_NAMESPACE"
+        delete_resources_in_namespace_matching_pattern "$MIFOSX_NAMESPACE"
         log_ok
         ;;
       "phee")
         log_step "Removing Payment Hub EE"
-        deleteResourcesInNamespaceMatchingPattern "$PH_NAMESPACE"
+        delete_resources_in_namespace_matching_pattern "$PH_NAMESPACE"
         log_ok
         ;;
       "infra")
         log_step "Removing infrastructure"
-        deleteResourcesInNamespaceMatchingPattern "$INFRA_NAMESPACE"
+        delete_resources_in_namespace_matching_pattern "$INFRA_NAMESPACE"
         log_ok
         ;;
       "mastercard-demo")
@@ -339,8 +310,8 @@ function deleteApps() {
         log_ok
         ;;
       *)
-        log_error "Invalid app '$app' for deletion. This should have been caught by validateInputs."
-        showUsage
+        log_error "Invalid app '$app' for deletion. This should have been caught by validate_inputs."
+        show_usage
         exit 1
         ;;
     esac
@@ -351,56 +322,59 @@ function deleteApps() {
 
 #------------------------------------------------------------
 # Description : Orchestrates deployment of apps (infra, vnext, etc.).
-# Usage : deployApps <"app1 app2"... > [redeploy]
-# Example: deployApps _ "vnext mifosx" true
+# Usage : deploy_apps <"app1 app2"... > [redeploy]
+# Example: deploy_apps _ "vnext mifosx" true
 #------------------------------------------------------------
-function deployApps() {
+deploy_apps() {
   local appsToDeploy="$1"
   local redeploy="${2:-false}"
   local data_gen_failed=false
 
-  logWithVerboseCheck "$debug" "$DEBUG" "Apps to deploy: $appsToDeploy (redeploy=$redeploy)"
+  log_with_verbose_check "$debug" "$DEBUG" "Apps to deploy: $appsToDeploy (redeploy=$redeploy)"
+
+  # Ensure infra is up before any DPG deployment. The idempotency guard inside
+  # deploy_infrastructure makes this a no-op if infra is already running.
+  # Skip when infra itself is being deployed — its case arm handles that below.
+  if [[ "$appsToDeploy" != *"infra"* ]]; then
+    deploy_infrastructure "false"
+  fi
 
   for app in $appsToDeploy; do
     case "$app" in
       "infra")
-        deployInfrastructure "$redeploy"
+        deploy_infrastructure "$redeploy"
         ;;
       "vnext")
-        deployInfrastructure "false"
-        deployvNext
+        deploy_vnext
         ;;
       "mifosx")
-        deployInfrastructure "false"
-        DeployMifosXfromYaml "$MIFOSX_MANIFESTS_DIR"
-        if ! generateMifosXandVNextData; then
+        deploy_mifosx_from_yaml "$MIFOSX_MANIFESTS_DIR"
+        if ! generate_mifosx_and_vnext_data; then
           data_gen_failed=true
         fi
         ;;
       "setup-data")
-        if ! generateMifosXandVNextData; then
+        if ! generate_mifosx_and_vnext_data; then
           data_gen_failed=true
         fi
         ;;
       "phee")
-        deployInfrastructure "false"
-        deployPH
+        deploy_ph
         ;;
       "mastercard-demo")
         if [[ "$redeploy" == "true" ]]; then
-          deleteApps "mastercard-demo"
+          delete_apps "mastercard-demo"
         fi
-        deployInfrastructure "false"
         if ! run_as_user "kubectl get namespace \"$PH_NAMESPACE\"" &> /dev/null; then
           log_error "Payment Hub namespace not found. Deploy phee first: ./run.sh -a phee"
           exit 1
         fi
-        logWithVerboseCheck "$debug" "$DEBUG" "MASTERCARD_CBS_HOME=$MASTERCARD_CBS_HOME"
+        log_with_verbose_check "$debug" "$DEBUG" "MASTERCARD_CBS_HOME=$MASTERCARD_CBS_HOME"
         deploy_mastercard
         ;;
       *)
         log_error "Unknown application '$app'. This should have been caught by validation."
-        showUsage
+        show_usage
         exit 1
         ;;
     esac

--- a/src/deployer/helm/infra/Chart.yaml
+++ b/src/deployer/helm/infra/Chart.yaml
@@ -15,7 +15,7 @@ dependencies:
 - name: kafka
   alias: kafka
   condition: kafka.enabled
-  repository: oci://registry-1.docker.io/bitnamicharts
+  repository: https://charts.bitnami.com/bitnami
   tags:
   - gazelle
   - dependency
@@ -66,7 +66,7 @@ dependencies:
 - name: elasticsearch
   alias: elasticsearch
   condition: elasticsearch.enabled
-  repository: oci://registry-1.docker.io/bitnamicharts
+  repository: https://charts.bitnami.com/bitnami
   tags:
   - mojaloop
   - dependency

--- a/src/deployer/helm/infra/Chart.yaml
+++ b/src/deployer/helm/infra/Chart.yaml
@@ -15,7 +15,7 @@ dependencies:
 - name: kafka
   alias: kafka
   condition: kafka.enabled
-  repository: https://charts.bitnami.com/bitnami
+  repository: oci://registry-1.docker.io/bitnamicharts
   tags:
   - gazelle
   - dependency
@@ -66,7 +66,7 @@ dependencies:
 - name: elasticsearch
   alias: elasticsearch
   condition: elasticsearch.enabled
-  repository: https://charts.bitnami.com/bitnami
+  repository: oci://registry-1.docker.io/bitnamicharts
   tags:
   - mojaloop
   - dependency

--- a/src/deployer/helm/infra/values.yaml
+++ b/src/deployer/helm/infra/values.yaml
@@ -171,7 +171,7 @@ redpanda-console:
     enabled: true
     className: nginx
     hosts:
-      - host: redpanda-console.mifos.gazelle.localhost
+      - host: redpanda-console.mifos.gazelle.test
         paths:
           - path: /
             pathType: ImplementationSpecific
@@ -208,7 +208,7 @@ mongo-express:
     enabled: true
     ingressClassName: nginx
     hosts:
-      - host: mongoexpress.mifos.gazelle.localhost
+      - host: mongoexpress.mifos.gazelle.test
         paths:
           - /
 
@@ -287,7 +287,7 @@ elasticsearch:
   ingress:
     enabled: true
     ingressClassName: nginx
-    hostname: elasticsearch.mifos.gazelle.localhost
+    hostname: elasticsearch.mifos.gazelle.test
     tls:
       - enabled: false
 
@@ -312,7 +312,7 @@ elasticsearch:
     ingress:
       enabled: true
       ingressClassName: nginx
-      hostname: kibana.mifos.gazelle.localhost
+      hostname: kibana.mifos.gazelle.test
       tls:
         enabled: false
 

--- a/src/deployer/helm/infra/values.yaml
+++ b/src/deployer/helm/infra/values.yaml
@@ -18,14 +18,14 @@ kafka:
 
   broker:
     replicaCount: 1
-    heapOpts: "-Xms64M -Xmx256M"
-    resources: 
+    heapOpts: "-Xms256M -Xmx512M"
+    resources:
       limits:
-        memory: "500Mi" # Using Mi for clarity and consistency
-        cpu: "500m"
-      requests: 
-        memory: "64Mi" # Using Mi for clarity and consistency
-        cpu: "100m"
+        memory: "1Gi"  # Must exceed heap + JVM overhead (metaspace, native, GC threads)
+        cpu: "1000m"
+      requests:
+        memory: "512Mi"
+        cpu: "250m"
   
   extraConfig: |
     auto.create.topics.enable=true

--- a/src/deployer/mastercard.sh
+++ b/src/deployer/mastercard.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Mastercard CBS Deployment Script for Mifos-Gazelle
 # Integrates Mastercard CBS connector with PaymentHub using Kubernetes operator
 
@@ -9,7 +9,7 @@
 # IMPORTANT: Do not source commandline.sh here - it creates circular dependency
 # This script is sourced by deployer.sh, which is already called from commandline.sh
 # All necessary variables are already set in the environment
-# logger.sh (GREEN/RESET/logWithLevel/logWithVerboseCheck) is available via helpers.sh
+# logger.sh (GREEN/RESET/log_with_level/log_with_verbose_check) is available via helpers.sh
 
 # Expand ~ to the actual user's home directory (handles sudo)
 expand_tilde() {
@@ -68,7 +68,7 @@ check_prerequisites() {
 }
 
 create_namespace() {
-    logWithVerboseCheck "$debug" "$INFO" "Creating namespace: $MASTERCARD_NAMESPACE"
+    log_with_verbose_check "$debug" "$INFO" "Creating namespace: $MASTERCARD_NAMESPACE"
 
     run_as_user "kubectl create namespace $MASTERCARD_NAMESPACE --dry-run=client -o yaml" \
         | run_as_user "kubectl apply -f -" > /dev/null 2>&1
@@ -79,7 +79,7 @@ create_namespace() {
 }
 
 create_secrets() {
-    logWithVerboseCheck "$debug" "$INFO" "Creating Kubernetes secrets"
+    log_with_verbose_check "$debug" "$INFO" "Creating Kubernetes secrets"
 
     if ! run_as_user "kubectl get secret mastercard-cbs-credentials -n $MASTERCARD_NAMESPACE" &> /dev/null; then
         run_as_user "kubectl create secret generic mastercard-cbs-credentials \
@@ -87,7 +87,7 @@ create_secrets() {
             --from-literal=client_id=${MASTERCARD_CLIENT_ID:-demo} \
             --from-literal=client_secret=${MASTERCARD_CLIENT_SECRET:-demo} \
             --from-literal=partner_id=${MASTERCARD_PARTNER_ID:-MIFOS_GOVSTACK}" > /dev/null 2>&1
-        logWithVerboseCheck "$debug" "$INFO" "Created mastercard-cbs-credentials secret"
+        log_with_verbose_check "$debug" "$INFO" "Created mastercard-cbs-credentials secret"
     fi
 
     local signing_key_path encryption_cert_path decryption_key_path
@@ -109,10 +109,10 @@ create_secrets() {
             run_as_user "kubectl create secret generic mastercard-cbs-certs \
                 -n $MASTERCARD_NAMESPACE \
                 $cert_args" > /dev/null 2>&1
-            logWithVerboseCheck "$debug" "$INFO" "Created mastercard-cbs-certs secret from local cert files"
+            log_with_verbose_check "$debug" "$INFO" "Created mastercard-cbs-certs secret from local cert files"
         fi
     else
-        logWithVerboseCheck "$debug" "$WARNING" "MASTERCARD_SIGNING_KEY_PATH not set - certs must be bundled in Docker image (localdev only)"
+        log_with_verbose_check "$debug" "$WARNING" "MASTERCARD_SIGNING_KEY_PATH not set - certs must be bundled in Docker image (localdev only)"
     fi
 
     if run_as_user "kubectl get secret operationsmysql -n $PAYMENTHUB_NAMESPACE" &> /dev/null; then
@@ -125,7 +125,7 @@ create_secrets() {
                     del(.metadata.resourceVersion, .metadata.uid, .metadata.creationTimestamp)
                 ' \
                 | run_as_user "kubectl apply -f -" > /dev/null 2>&1
-            logWithVerboseCheck "$debug" "$INFO" "Copied operationsmysql as mysql-secret to $MASTERCARD_NAMESPACE"
+            log_with_verbose_check "$debug" "$INFO" "Copied operationsmysql as mysql-secret to $MASTERCARD_NAMESPACE"
         fi
     else
         log_warn "operationsmysql secret not found in $PAYMENTHUB_NAMESPACE"
@@ -142,7 +142,7 @@ deploy_operator() {
 
     local config_file
     config_file=$(resolve_config_file)
-    logWithVerboseCheck "$debug" "$INFO" "Deploying operator with config: $config_file"
+    log_with_verbose_check "$debug" "$INFO" "Deploying operator with config: $config_file"
 
     cd "$operator_dir"
     if [ "$debug" == "true" ]; then
@@ -169,7 +169,7 @@ deploy_connector() {
     local localdev_section=""
 
     if [ "${MASTERCARD_LOCALDEV_ENABLED:-false}" == "true" ]; then
-        logWithVerboseCheck "$debug" "$INFO" "Connector local development mode enabled"
+        log_with_verbose_check "$debug" "$INFO" "Connector local development mode enabled"
         image_repo="eclipse-temurin"
         image_tag="17"
         localdev_section="  localdev:
@@ -218,7 +218,7 @@ ${localdev_section}
       memory: "256Mi"
 EOF
     chmod 644 "$cr_file"
-    logWithVerboseCheck "$debug" "$INFO" "Applying connector CR from $cr_file"
+    log_with_verbose_check "$debug" "$INFO" "Applying connector CR from $cr_file"
 
     local apply_output
     apply_output=$(run_as_user "kubectl apply -f '$cr_file' 2>&1")
@@ -228,7 +228,7 @@ EOF
         log_error "Failed to apply connector CR: $apply_output"
         return 1
     fi
-    logWithVerboseCheck "$debug" "$INFO" "Connector CR: $apply_output"
+    log_with_verbose_check "$debug" "$INFO" "Connector CR: $apply_output"
 }
 
 wait_for_deployment() {
@@ -271,9 +271,9 @@ deploy_bpmn_workflow() {
         return 1
     fi
 
-    logWithVerboseCheck "$debug" "$INFO" "Deploying BPMN workflow for greenbank"
+    log_with_verbose_check "$debug" "$INFO" "Deploying BPMN workflow for greenbank"
     if run_as_user "bash \"$deploy_script\" -c \"$config_file\" -f \"$workflow_file\" -t greenbank" > /dev/null 2>&1; then
-        logWithVerboseCheck "$debug" "$DEBUG" "BPMN deployed for greenbank"
+        log_with_verbose_check "$debug" "$DEBUG" "BPMN deployed for greenbank"
     else
         log_warn "Failed to deploy BPMN workflow for greenbank"
         return 1
@@ -281,9 +281,9 @@ deploy_bpmn_workflow() {
 
     for tenant in redbank bluebank; do
         if run_as_user "bash \"$deploy_script\" -c \"$config_file\" -f \"$workflow_file\" -t $tenant" > /dev/null 2>&1; then
-            logWithVerboseCheck "$debug" "$DEBUG" "BPMN deployed for $tenant"
+            log_with_verbose_check "$debug" "$DEBUG" "BPMN deployed for $tenant"
         else
-            logWithVerboseCheck "$debug" "$DEBUG" "Skipped $tenant (tenant may not exist)"
+            log_with_verbose_check "$debug" "$DEBUG" "Skipped $tenant (tenant may not exist)"
         fi
     done
 }
@@ -303,7 +303,7 @@ load_supplementary_data() {
         return 0
     fi
 
-    logWithVerboseCheck "$debug" "$INFO" "Loading supplementary data via $data_loader"
+    log_with_verbose_check "$debug" "$INFO" "Loading supplementary data via $data_loader"
     if [ "$debug" == "true" ]; then
         run_as_user "bash \"$data_loader\" -c \"$config_file\""
     else
@@ -331,7 +331,7 @@ generate_mastercard_csv() {
     fi
 
     local output_dir="$RUN_DIR/src/utils/data-loading"
-    logWithVerboseCheck "$debug" "$INFO" "Generating bulk-gazelle-mastercard-6.csv"
+    log_with_verbose_check "$debug" "$INFO" "Generating bulk-gazelle-mastercard-6.csv"
     if [ "$debug" == "true" ]; then
         run_as_user "\"$PYTHON3\" \"$csv_generator\" -c \"$config_file\" --mode mastercard --num-rows 6 --output-dir \"$output_dir\""
     else
@@ -344,10 +344,10 @@ generate_mastercard_csv() {
 }
 
 configure_payment_mode() {
-    logWithVerboseCheck "$debug" "$INFO" "Payment mode MASTERCARD_CBS requires bulk-processor config:"
-    logWithVerboseCheck "$debug" "$INFO" "  payment-modes: [{id: MASTERCARD_CBS, type: BULK, endpoint: bulk_connector_mastercard_cbs-{dfspid}}]"
+    log_with_verbose_check "$debug" "$INFO" "Payment mode MASTERCARD_CBS requires bulk-processor config:"
+    log_with_verbose_check "$debug" "$INFO" "  payment-modes: [{id: MASTERCARD_CBS, type: BULK, endpoint: bulk_connector_mastercard_cbs-{dfspid}}]"
     if [ -d "$HOME/ph-ee-bulk-processor" ]; then
-        logWithVerboseCheck "$debug" "$INFO" "Hostpath detected - rebuild JAR and restart pod after editing application.yaml"
+        log_with_verbose_check "$debug" "$INFO" "Hostpath detected - rebuild JAR and restart pod after editing application.yaml"
     fi
 }
 
@@ -385,7 +385,7 @@ cleanup() {
 deploy_mastercard() {
     log_section "Deploying Mastercard CBS"
     check_prerequisites
-    logWithVerboseCheck "$debug" "$DEBUG" "Namespace: $MASTERCARD_NAMESPACE"
+    log_with_verbose_check "$debug" "$DEBUG" "Namespace: $MASTERCARD_NAMESPACE"
 
     log_step "Creating namespace $MASTERCARD_NAMESPACE"
     create_namespace

--- a/src/deployer/mastercard.sh
+++ b/src/deployer/mastercard.sh
@@ -333,9 +333,9 @@ generate_mastercard_csv() {
     local output_dir="$RUN_DIR/src/utils/data-loading"
     logWithVerboseCheck "$debug" "$INFO" "Generating bulk-gazelle-mastercard-6.csv"
     if [ "$debug" == "true" ]; then
-        run_as_user "python3 \"$csv_generator\" -c \"$config_file\" --mode mastercard --num-rows 6 --output-dir \"$output_dir\""
+        run_as_user "\"$PYTHON3\" \"$csv_generator\" -c \"$config_file\" --mode mastercard --num-rows 6 --output-dir \"$output_dir\""
     else
-        run_as_user "python3 \"$csv_generator\" -c \"$config_file\" --mode mastercard --num-rows 6 --output-dir \"$output_dir\"" > /tmp/mastercard-csv-gen.log 2>&1
+        run_as_user "\"$PYTHON3\" \"$csv_generator\" -c \"$config_file\" --mode mastercard --num-rows 6 --output-dir \"$output_dir\"" > /tmp/mastercard-csv-gen.log 2>&1
     fi
 
     if [ $? -ne 0 ]; then

--- a/src/deployer/mifosx.sh
+++ b/src/deployer/mifosx.sh
@@ -147,7 +147,7 @@ function generateMifosXandVNextData {
 
       log_step "Generating MifosX clients and registering vNext Oracle associations"
       echo
-      run_as_user "python3 \"$RUN_DIR/src/utils/data-loading/generate-mifos-vnext-data.py\" -c \"$CONFIG_FILE_PATH\" 2>&1"
+      run_as_user "\"$PYTHON3\" \"$RUN_DIR/src/utils/data-loading/generate-mifos-vnext-data.py\" -c \"$CONFIG_FILE_PATH\" 2>&1"
       local data_gen_exit=$?
 
       if [[ $data_gen_exit -ne 0 ]]; then

--- a/src/deployer/mifosx.sh
+++ b/src/deployer/mifosx.sh
@@ -2,13 +2,13 @@
 # mifosx.sh -- Mifos Gazelle deployer script for Mifos X 
 
 #------------------------------------------------------------------------------
-# Function: DeployMifosXfromYaml
+# Function: deploy_mifosx_from_yaml
 # Description: Deploys MifosX (Fineract + web app) using Kubernetes manifests from a specified directory.
 # Parameters:
 #   $1 - Directory containing the Kubernetes manifests for MifosX deployment.
 #   $2 - (Optional) Timeout in seconds to wait for the fineract-server pod to be ready. Default is 600 seconds.
 #------------------------------------------------------------------------------
-function DeployMifosXfromYaml() {
+deploy_mifosx_from_yaml() {
     manifests_dir=$1
     timeout_secs=${2:-600}  # Default timeout of 10 minutes if not specified
 
@@ -24,14 +24,14 @@ function DeployMifosXfromYaml() {
     run_as_user "kubectl wait --for=condition=ready pod --all -n $PH_NAMESPACE --timeout=600s" > /dev/null 2>&1
 
     log_step "Removing existing MifosX resources"
-    deleteResourcesInNamespaceMatchingPattern "$MIFOSX_NAMESPACE"
+    delete_resources_in_namespace_matching_pattern "$MIFOSX_NAMESPACE"
     log_ok
 
     log_step "Creating namespace $MIFOSX_NAMESPACE"
-    createNamespace "$MIFOSX_NAMESPACE"
+    create_namespace "$MIFOSX_NAMESPACE"
     log_ok
 
-    cloneRepo "$MIFOSX_BRANCH" "$MIFOSX_REPO_LINK" "$APPS_DIR" "$MIFOSX_REPO_DIR"
+    clone_repo "$MIFOSX_BRANCH" "$MIFOSX_REPO_LINK" "$APPS_DIR" "$MIFOSX_REPO_DIR"
 
     log_step "Updating FQDNs in manifests"
     update_fqdn "$MIFOSX_MANIFESTS_DIR/web-app-deployment.yaml" "mifos.gazelle.test" "$GAZELLE_DOMAIN"
@@ -45,7 +45,7 @@ function DeployMifosXfromYaml() {
     log_ok
 
     log_step "Applying manifests"
-    applyKubeManifests "$manifests_dir" "$MIFOSX_NAMESPACE"
+    apply_kube_manifests "$manifests_dir" "$MIFOSX_NAMESPACE"
     log_ok
 
     log_banner "MifosX Deployed"
@@ -64,7 +64,7 @@ function DeployMifosXfromYaml() {
 # Parameters: None (uses GAZELLE_DOMAIN)
 # Returns:    0 if all tenants ready, 1 on timeout
 #------------------------------------------------------------------------------
-function wait_for_fineract_api_ready {
+wait_for_fineract_api_ready() {
   local tenants=("greenbank" "bluebank" "redbank")
   local base_url="https://mifos.${GAZELLE_DOMAIN}/fineract-provider/api/v1"
   local auth="Basic bWlmb3M6cGFzc3dvcmQ="   # mifos:password
@@ -101,14 +101,14 @@ function wait_for_fineract_api_ready {
           "${base_url}/paymenttypes" 2>/dev/null)
 
         if [[ "$paymenttypes_body" =~ ^\[ && "$paymenttypes_body" != "[]" ]]; then
-          logWithVerboseCheck "$debug" "$DEBUG" "Tenant '${tenant}' ready (${elapsed}s elapsed)"
+          log_with_verbose_check "$debug" "$DEBUG" "Tenant '${tenant}' ready (${elapsed}s elapsed)"
           ready=true
           break
         else
-          logWithVerboseCheck "$debug" "$DEBUG" "Tenant '${tenant}' schema ready, seed data pending (${elapsed}s/${timeout}s)"
+          log_with_verbose_check "$debug" "$DEBUG" "Tenant '${tenant}' schema ready, seed data pending (${elapsed}s/${timeout}s)"
         fi
       else
-        logWithVerboseCheck "$debug" "$DEBUG" "Tenant '${tenant}' schema not ready — HTTP ${clients_code:-000} (${elapsed}s/${timeout}s)"
+        log_with_verbose_check "$debug" "$DEBUG" "Tenant '${tenant}' schema not ready — HTTP ${clients_code:-000} (${elapsed}s/${timeout}s)"
       fi
 
       sleep $retry_interval
@@ -120,11 +120,11 @@ function wait_for_fineract_api_ready {
 }
 
 #------------------------------------------------------------------------------
-# Function : generateMifosXandVNextData
+# Function : generate_mifosx_and_vnext_data
 # Description: Generates MifosX clients and accounts & registers associations with vNext Oracle.
 # Parameters: None
 #------------------------------------------------------------------------------
-function generateMifosXandVNextData {
+generate_mifosx_and_vnext_data() {
   local timeout=${startup_timeout:-600}
   local recheck_time=30
   local start_time
@@ -161,7 +161,7 @@ function generateMifosXandVNextData {
     else
       elapsed=$(( $(date +%s) - start_time ))
       if [[ $elapsed -lt $timeout ]]; then
-        logWithVerboseCheck "$debug" "$DEBUG" "vNext or MifosX not running — retrying in ${recheck_time}s (${elapsed}s/${timeout}s)"
+        log_with_verbose_check "$debug" "$DEBUG" "vNext or MifosX not running — retrying in ${recheck_time}s (${elapsed}s/${timeout}s)"
         sleep $recheck_time
         elapsed=$(( $(date +%s) - start_time ))
       fi

--- a/src/deployer/phee.sh
+++ b/src/deployer/phee.sh
@@ -2,14 +2,14 @@
 # phee.sh -- Mifos Gazelle deployer script for PaymentHub EE 
 
 #------------------------------------------------------------------------------
-# Function : deployPH
+# Function : deploy_ph
 # Description: Deploys PaymentHub EE using Helm charts.
 #------------------------------------------------------------------------------
-function deployPH(){
+deploy_ph(){
   gazelleChartPath="$APPS_DIR/$PH_EE_ENV_TEMPLATE_REPO_DIR/helm/gazelle"
   pheeEngineChartPath="$APPS_DIR/$PH_EE_ENV_TEMPLATE_REPO_DIR/helm/ph-ee-engine"
 
-  # createIngressSecret "$PH_NAMESPACE"  \
+  # create_ingress_secret "$PH_NAMESPACE"  \
   # "bulk-processor.$GAZELLE_DOMAIN" \
   # "sandbox-secret" \
   # "ops.$GAZELLE_DOMAIN,api.$GAZELLE_DOMAIN,*.$GAZELLE_DOMAIN,localhost"
@@ -24,33 +24,33 @@ function deployPH(){
   fi
 
   log_step "Removing existing Payment Hub resources"
-  deleteResourcesInNamespaceMatchingPattern "$PH_NAMESPACE"
-  manageElasticSecrets delete "$INFRA_NAMESPACE"
+  delete_resources_in_namespace_matching_pattern "$PH_NAMESPACE"
+  manage_elastic_secrets delete "$INFRA_NAMESPACE"
   log_ok
 
   run_as_user "kubectl wait --for=condition=ready pod --all -n $VNEXT_NAMESPACE --timeout=600s" > /dev/null 2>&1
 
   log_step "Creating namespace $PH_NAMESPACE"
-  createNamespace "$PH_NAMESPACE"
+  create_namespace "$PH_NAMESPACE"
   log_ok
 
   prepare_payment_hub_chart
 
   log_step "Creating elastic secrets"
-  manageElasticSecrets delete "$INFRA_NAMESPACE"
-  manageElasticSecrets create "$PH_NAMESPACE"
-  manageElasticSecrets create "$INFRA_NAMESPACE"
+  manage_elastic_secrets delete "$INFRA_NAMESPACE"
+  manage_elastic_secrets create "$PH_NAMESPACE"
+  manage_elastic_secrets create "$INFRA_NAMESPACE"
   log_ok
 
-  createIngressSecret "$PH_NAMESPACE" \
+  create_ingress_secret "$PH_NAMESPACE" \
     "bulk-processor.$GAZELLE_DOMAIN" \
     "sandbox-secret" \
     "ops.$GAZELLE_DOMAIN,ops-bk.$GAZELLE_DOMAIN,api.$GAZELLE_DOMAIN,*.$GAZELLE_DOMAIN,localhost,ph-ee-connector-channel,ph-ee-connector-channel.$PH_NAMESPACE.svc.cluster.local"
 
-  deployPhHelmChartFromDir "$PH_NAMESPACE" "$gazelleChartPath" "$PH_VALUES_FILE"
+  deploy_ph_helm_chart_from_dir "$PH_NAMESPACE" "$gazelleChartPath" "$PH_VALUES_FILE"
 
   local bpmns_to_deploy=$(ls -l "$BASE_DIR/orchestration/feel"/*.bpmn | wc -l)
-  logWithVerboseCheck "$debug" "$DEBUG" "BPMNs to deploy: $bpmns_to_deploy"
+  log_with_verbose_check "$debug" "$DEBUG" "BPMNs to deploy: $bpmns_to_deploy"
   if are_bpmns_loaded $bpmns_to_deploy; then
     echo "    BPMN diagrams already loaded — skipping."
   else
@@ -65,9 +65,9 @@ function deployPH(){
 # Description: Prepares the PaymentHub EE Helm chart by cloning necessary repositories
 #              and updating FQDNs in values files and manifests.
 #------------------------------------------------------------------------------
-function prepare_payment_hub_chart() {
+prepare_payment_hub_chart() {
   # Clone the repositories
-  cloneRepo "$PH_EE_ENV_TEMPLATE_REPO_BRANCH" "$PH_EE_ENV_TEMPLATE_REPO_LINK" "$APPS_DIR" "$PH_EE_ENV_TEMPLATE_REPO_DIR"
+  clone_repo "$PH_EE_ENV_TEMPLATE_REPO_BRANCH" "$PH_EE_ENV_TEMPLATE_REPO_LINK" "$APPS_DIR" "$PH_EE_ENV_TEMPLATE_REPO_DIR"
   
   log_step "Updating FQDNs in Helm chart values and manifests"
   update_fqdn "$PH_VALUES_FILE" "mifos.gazelle.test" "$GAZELLE_DOMAIN" 
@@ -86,14 +86,14 @@ function prepare_payment_hub_chart() {
 }
 
 #------------------------------------------------------------------------------
-# Function : deployPhHelmChartFromDir
+# Function : deploy_ph_helm_chart_from_dir
 # Description: Deploys a Helm chart for PaymentHub EE from a specified directory.
 # Parameters:
 #   $1 - Namespace to deploy to
 #   $2 - Directory containing the Helm chart
 #   $3 - (Optional) Values file for the Helm chart
 #------------------------------------------------------------------------------
-function deployPhHelmChartFromDir(){
+deploy_ph_helm_chart_from_dir(){
   local namespace="$1"
   local chartDir="$2"      # Directory containing the Helm chart
   local valuesFile="$3"    # Values file for the Helm chart
@@ -107,7 +107,7 @@ function deployPhHelmChartFromDir(){
   fi
 
   log_step "Helm install ($releaseName)"
-  logWithVerboseCheck "$debug" "$DEBUG" "→ $helm_cmd"
+  log_with_verbose_check "$debug" "$DEBUG" "→ $helm_cmd"
 
   if [ "$debug" = true ]; then
     su - "$k8s_user" -c "bash -c '$helm_cmd'"
@@ -147,7 +147,7 @@ deploy_bpmns() {
           --form 'file=@\"$file\"' \
           -s -o /dev/null -w '%{http_code}'"
 
-      logWithVerboseCheck "$debug" "$DEBUG" "Uploading $(basename $file)"
+      log_with_verbose_check "$debug" "$DEBUG" "Uploading $(basename $file)"
       http_code=$(eval "$cmd")
       exit_code=$?
 
@@ -178,7 +178,7 @@ deploy_bpmns() {
 #------------------------------------------------------------------------------
 # Function: generate_sample_csvs
 # Description: Generates sample bulk payment CSV files for closedloop and mojaloop
-#              testing. Called from generateMifosXandVNextData() after Fineract is ready.
+#              testing. Called from generate_mifosx_and_vnext_data() after Fineract is ready.
 #              Files are gitignored and recreated on each deploy.
 #------------------------------------------------------------------------------
 generate_sample_csvs() {
@@ -186,7 +186,7 @@ generate_sample_csvs() {
     local output_dir="$RUN_DIR/src/utils/batch"
 
     if [ ! -f "$csv_generator" ]; then
-            logWithVerboseCheck "$debug" "$WARNING" "CSV generator not found: $csv_generator"
+            log_with_verbose_check "$debug" "$WARNING" "CSV generator not found: $csv_generator"
         return 0
     fi
 
@@ -232,8 +232,8 @@ are_bpmns_loaded() {
           }
         }' 2>/dev/null | jq -r '.aggregations.by_bpmn_id.buckets | length // 0')
 
-    [[ "$COUNT" =~ ^[0-9]+$ ]] || { logWithVerboseCheck "$debug" "$DEBUG" "ES query failed — assuming BPMNs not loaded"; return 1; }
+    [[ "$COUNT" =~ ^[0-9]+$ ]] || { log_with_verbose_check "$debug" "$DEBUG" "ES query failed — assuming BPMNs not loaded"; return 1; }
 
-    logWithVerboseCheck "$debug" "$DEBUG" "Unique BPMNs already deployed: $COUNT"
+    log_with_verbose_check "$debug" "$DEBUG" "Unique BPMNs already deployed: $COUNT"
     (( COUNT >= MIN_REQUIRED )) && return 0 || return 1
 }

--- a/src/deployer/phee.sh
+++ b/src/deployer/phee.sh
@@ -196,11 +196,11 @@ generate_sample_csvs() {
 
     local csv_exit=0
     if [ "$debug" == "true" ]; then
-        run_as_user "python3 \"$csv_generator\" -c \"$CONFIG_FILE_PATH\" --mode closedloop --num-rows 4 --output-dir \"$output_dir\"" 2>&1 | tee -a /tmp/phee-csv-gen.log; csv_exit=$((csv_exit + ${PIPESTATUS[0]}))
-        run_as_user "python3 \"$csv_generator\" -c \"$CONFIG_FILE_PATH\" --mode mojaloop --num-rows 4 --output-dir \"$output_dir\"" 2>&1 | tee -a /tmp/phee-csv-gen.log; csv_exit=$((csv_exit + ${PIPESTATUS[0]}))
+        run_as_user "\"$PYTHON3\" \"$csv_generator\" -c \"$CONFIG_FILE_PATH\" --mode closedloop --num-rows 4 --output-dir \"$output_dir\"" 2>&1 | tee -a /tmp/phee-csv-gen.log; csv_exit=$((csv_exit + ${PIPESTATUS[0]}))
+        run_as_user "\"$PYTHON3\" \"$csv_generator\" -c \"$CONFIG_FILE_PATH\" --mode mojaloop --num-rows 4 --output-dir \"$output_dir\"" 2>&1 | tee -a /tmp/phee-csv-gen.log; csv_exit=$((csv_exit + ${PIPESTATUS[0]}))
     else
-        run_as_user "python3 \"$csv_generator\" -c \"$CONFIG_FILE_PATH\" --mode closedloop --num-rows 4 --output-dir \"$output_dir\"" >> /tmp/phee-csv-gen.log 2>&1; csv_exit=$((csv_exit + $?))
-        run_as_user "python3 \"$csv_generator\" -c \"$CONFIG_FILE_PATH\" --mode mojaloop --num-rows 4 --output-dir \"$output_dir\"" >> /tmp/phee-csv-gen.log 2>&1; csv_exit=$((csv_exit + $?))
+        run_as_user "\"$PYTHON3\" \"$csv_generator\" -c \"$CONFIG_FILE_PATH\" --mode closedloop --num-rows 4 --output-dir \"$output_dir\"" >> /tmp/phee-csv-gen.log 2>&1; csv_exit=$((csv_exit + $?))
+        run_as_user "\"$PYTHON3\" \"$csv_generator\" -c \"$CONFIG_FILE_PATH\" --mode mojaloop --num-rows 4 --output-dir \"$output_dir\"" >> /tmp/phee-csv-gen.log 2>&1; csv_exit=$((csv_exit + $?))
     fi
 
     if [ "$csv_exit" -ne 0 ]; then

--- a/src/deployer/vnext.sh
+++ b/src/deployer/vnext.sh
@@ -32,6 +32,10 @@ function deployvNext() {
   update_vnext_service_urls "$APPS_DIR/vnext/packages/installer/manifests"
   log_ok
 
+  log_step "Fixing liveness probes in manifests"
+  fix_vnext_liveness_probes "$APPS_DIR/vnext/packages/installer/manifests"
+  log_ok
+
   log_step "Updating FQDNs in manifests"
   update_fqdn_batch "$APPS_DIR/vnext/packages/installer/manifests" "local" "$GAZELLE_DOMAIN"
   find "$APPS_DIR/$VNEXTREPO_DIR/packages/installer/manifests" -type f -name "*.yaml" | while read -r file; do
@@ -88,6 +92,50 @@ function update_vnext_service_urls() {
     done < <(find "$target_dir" -type f \( -name "*.yaml" -o -name "*.yml" \) -print0) 
     
     #echo "Service URL updates complete."
+}
+
+#------------------------------------------------------------------------------
+# Function : fix_vnext_liveness_probes
+# Description: Replaces broken nc-based exec liveness probes with tcpSocket probes.
+#
+# The upstream vNext manifests use a single-element exec command:
+#   command:
+#   - nc -z localhost PORT || exit -1
+#
+# Linux exec() treats the entire string as the binary name (spaces included),
+# so the probe always fails and the kubelet kills the pod after 10 attempts.
+# tcpSocket probes are checked by the kubelet externally — no tooling needed
+# inside the container.
+#
+# Also fixes a bug in the upstream reporting-api-svc manifest where the probe
+# checked port 5005 but the service listens on 5000.
+#
+# TODO: remove this function once vNext manifests are vendored into Gazelle
+#       and the probes are corrected at source.
+# Parameters:
+#   $1 - Directory containing the vNext manifests.
+#------------------------------------------------------------------------------
+function fix_vnext_liveness_probes() {
+    local target_dir="$1"
+
+    if [[ -z "$target_dir" ]] || [[ ! -d "$target_dir" ]]; then
+        log_error "fix_vnext_liveness_probes: directory '$target_dir' does not exist"
+        return 1
+    fi
+
+    while IFS= read -r -d '' f; do
+        perl -0777 -pi -e '
+            s{(\n([ ]+)livenessProbe:\n)[ ]+exec:\n[ ]+command:\n[ ]+- nc -z localhost (\d+) \|\| exit -1\n}
+             {$1 . $2 . "  tcpSocket:\n" . $2 . "    port: " . $3 . "\n"}ge
+        ' "$f"
+    done < <(find "$target_dir" -type f -name "*.yaml" -print0)
+
+    # The upstream reporting-api-svc manifest had nc -z on port 5005 but the
+    # service listens on 5000 — correct the port after the probe type is fixed.
+    local reporting_api="$target_dir/reporting/reporting-api-svc-deployment.yaml"
+    if [[ -f "$reporting_api" ]]; then
+        sed_inplace -e 's/port: 5005/port: 5000/' "$reporting_api"
+    fi
 }
 
 #------------------------------------------------------------------------------

--- a/src/deployer/vnext.sh
+++ b/src/deployer/vnext.sh
@@ -81,7 +81,7 @@ function update_vnext_service_urls() {
     while IFS= read -r -d '' f; do
         sed_inplace \
             -e 's|value: kafka:9092$|value: kafka.infra.svc.cluster.local:9092|g' \
-            -e 's|value: mongodb://root:mongoDbPas42@mongodb:27017/\s*$|value: mongodb://root:mongoDbPas42@mongodb.infra.svc.cluster.local:27017/|g' \
+            -e 's|value: mongodb://root:mongoDbPas42@mongodb:27017/[[:space:]]*$|value: mongodb://root:mongoDbPas42@mongodb.infra.svc.cluster.local:27017/|g' \
             -e 's|value: redis-master$|value: redis-master.infra.svc.cluster.local|g' \
             -e 's|value: http://infra-elasticsearch:9200$|value: http://infra-elasticsearch.infra.svc.cluster.local:9200|g' \
             "$f"

--- a/src/deployer/vnext.sh
+++ b/src/deployer/vnext.sh
@@ -78,12 +78,14 @@ function update_vnext_service_urls() {
     #echo "    Updating service URLs in: $target_dir"
     
     # Find all YAML files and apply replacements (idempotent - won't duplicate if run multiple times)
-    find "$target_dir" -type f \( -name "*.yaml" -o -name "*.yml" \) -exec sed -i \
-        -e 's|value: kafka:9092$|value: kafka.infra.svc.cluster.local:9092|g' \
-        -e 's|value: mongodb://root:mongoDbPas42@mongodb:27017/\s*$|value: mongodb://root:mongoDbPas42@mongodb.infra.svc.cluster.local:27017/|g' \
-        -e 's|value: redis-master$|value: redis-master.infra.svc.cluster.local|g' \
-        -e 's|value: http://infra-elasticsearch:9200$|value: http://infra-elasticsearch.infra.svc.cluster.local:9200|g' \
-        {} \; 
+    while IFS= read -r -d '' f; do
+        sed_inplace \
+            -e 's|value: kafka:9092$|value: kafka.infra.svc.cluster.local:9092|g' \
+            -e 's|value: mongodb://root:mongoDbPas42@mongodb:27017/\s*$|value: mongodb://root:mongoDbPas42@mongodb.infra.svc.cluster.local:27017/|g' \
+            -e 's|value: redis-master$|value: redis-master.infra.svc.cluster.local|g' \
+            -e 's|value: http://infra-elasticsearch:9200$|value: http://infra-elasticsearch.infra.svc.cluster.local:9200|g' \
+            "$f"
+    done < <(find "$target_dir" -type f \( -name "*.yaml" -o -name "*.yml" \) -print0) 
     
     #echo "Service URL updates complete."
 }
@@ -143,7 +145,7 @@ function vnext_restore_demo_data {
         return 1
     fi
 
-    if ! run_as_user "kubectl exec --namespace \"$namespace\" --stdin --tty \"$mongopod\" -- mongorestore -u root -p \"$mongo_root_pw\" --gzip --archive=/tmp/mongodump.gz --authenticationDatabase admin" > /dev/null 2>&1; then
+    if ! run_as_user "kubectl exec --namespace \"$namespace\" \"$mongopod\" -- mongorestore -u root -p \"$mongo_root_pw\" --gzip --archive=/tmp/mongodump.gz --authenticationDatabase admin" > /dev/null 2>&1; then
         log_failed "mongorestore failed"
         rm -rf "${temp_dir:-}"
         return 1

--- a/src/deployer/vnext.sh
+++ b/src/deployer/vnext.sh
@@ -2,10 +2,10 @@
 # vnext.sh -- Mifos Gazelle deployer script for vNext Beta 1 switch 
 
 #------------------------------------------------------------------------------
-# Function : deployvNext
+# Function : deploy_vnext
 # Description: Deploys Mojaloop vNext using Kubernetes manifests.
 #------------------------------------------------------------------------------
-function deployvNext() {
+deploy_vnext() {
   log_section "Deploying Mojaloop vNext"
 
   if is_app_running "$VNEXT_NAMESPACE"; then
@@ -16,14 +16,14 @@ function deployvNext() {
   fi
 
   log_step "Removing existing vNext resources"
-  deleteResourcesInNamespaceMatchingPattern "$VNEXT_NAMESPACE"
+  delete_resources_in_namespace_matching_pattern "$VNEXT_NAMESPACE"
   log_ok
 
   log_step "Creating namespace $VNEXT_NAMESPACE"
-  createNamespace "$VNEXT_NAMESPACE"
+  create_namespace "$VNEXT_NAMESPACE"
   log_ok
 
-  cloneRepo "$VNEXTBRANCH" "$VNEXT_REPO_LINK" "$APPS_DIR" "$VNEXTREPO_DIR"
+  clone_repo "$VNEXTBRANCH" "$VNEXT_REPO_LINK" "$APPS_DIR" "$VNEXTREPO_DIR"
 
   rm -f "$APPS_DIR/$VNEXTREPO_DIR/packages/installer/manifests/ttk/ttk-cli.yaml" > /dev/null 2>&1
   rm -rf "$APPS_DIR/$VNEXTREPO_DIR/packages/installer/manifests/infra" > /dev/null 2>&1
@@ -50,10 +50,10 @@ function deployvNext() {
   for index in "${!VNEXT_LAYER_DIRS[@]}"; do
     folder="${VNEXT_LAYER_DIRS[index]}"
     log_step "Applying layer $((index+1)) manifests"
-    applyKubeManifests "$folder" "$VNEXT_NAMESPACE"
+    apply_kube_manifests "$folder" "$VNEXT_NAMESPACE"
     log_ok
     if [ "$index" -eq 0 ]; then
-      logWithVerboseCheck "$debug" "$DEBUG" "Cross-cutting concerns layer applied — proceeding"
+      log_with_verbose_check "$debug" "$DEBUG" "Cross-cutting concerns layer applied — proceeding"
     fi
   done
 
@@ -66,7 +66,7 @@ function deployvNext() {
 # Parameters:
 #   $1 - Directory containing the vNext manifests.
 #------------------------------------------------------------------------------
-function update_vnext_service_urls() {
+update_vnext_service_urls() {
     local target_dir="$1"
     
     # Check if directory parameter is provided
@@ -115,7 +115,7 @@ function update_vnext_service_urls() {
 # Parameters:
 #   $1 - Directory containing the vNext manifests.
 #------------------------------------------------------------------------------
-function fix_vnext_liveness_probes() {
+fix_vnext_liveness_probes() {
     local target_dir="$1"
 
     if [[ -z "$target_dir" ]] || [[ ! -d "$target_dir" ]]; then
@@ -146,7 +146,7 @@ function fix_vnext_liveness_probes() {
 #   $2 - Name of the MongoDB dump file (e.g., mongodump.gz).
 #   $3 - Kubernetes namespace where vNext is deployed.
 #------------------------------------------------------------------------------
-function vnext_restore_demo_data {
+vnext_restore_demo_data() {
     local mongo_data_dir="$1"
     local mongo_dump_file="$2"
     local namespace="$3"
@@ -201,59 +201,4 @@ function vnext_restore_demo_data {
 
     rm -rf "${temp_dir:-}"
     log_ok
-}
-
-#------------------------------------------------------------------------------
-# NOTE: this is not used in Gazelle v1.1.0 but may be useful in future releases
-# Function : vnext_configure_ttk
-# Description: Configures the Testing Toolkit (TTK) in the vNext deployment by copying
-#              necessary environment and specification files into the TTK pods.
-# Parameters:
-#   $1 - Directory containing the TTK files to be copied.
-#   $2 - Kubernetes namespace where vNext is deployed.
-#------------------------------------------------------------------------------
-function vnext_configure_ttk {
-  local ttk_files_dir=$1
-  local namespace=$2
-  local warning_issued=false
-  log_section "Configuring the Testing Toolkit"
-
-  local bb_pod_status
-  bb_pod_status=$(kubectl get pods bluebank-backend-0 --namespace "$namespace" --no-headers 2>/dev/null | awk '{print $3}')
-
-  if [[ "$bb_pod_status" != "Running" ]]; then
-    echo "    TTK pod not running — skipping (TTK may not support arm64 and is not essential)"
-    return 0
-  fi
-
-  # Define TTK pod destinations
-  local ttk_pod_env_dest="/opt/app/examples/environments"
-  local ttk_pod_spec_dest="/opt/app/spec_files"
-  
-  # Function to check and report on kubectl cp command success
-  check_kubectl_cp() {
-    if ! kubectl cp "$1" "$2" --namespace "$namespace" 2>/dev/null; then
-      log_warn "Failed to copy $(basename $1) to $2"
-      warning_issued=true
-    fi
-  }
-  
-  # Copy BlueBank files
-  check_kubectl_cp "$ttk_files_dir/environment/hub_local_environment.json" "bluebank-backend-0:$ttk_pod_env_dest/hub_local_environment.json"
-  check_kubectl_cp "$ttk_files_dir/environment/dfsp_local_environment.json" "bluebank-backend-0:$ttk_pod_env_dest/dfsp_local_environment.json"
-  check_kubectl_cp "$ttk_files_dir/spec_files/user_config_bluebank.json" "bluebank-backend-0:$ttk_pod_spec_dest/user_config.json"
-  check_kubectl_cp "$ttk_files_dir/spec_files/default.json" "bluebank-backend-0:$ttk_pod_spec_dest/rules_callback/default.json"
-  
-  # Copy GreenBank files
-  check_kubectl_cp "$ttk_files_dir/environment/hub_local_environment.json" "greenbank-backend-0:$ttk_pod_env_dest/hub_local_environment.json"
-  check_kubectl_cp "$ttk_files_dir/environment/dfsp_local_environment.json" "greenbank-backend-0:$ttk_pod_env_dest/dfsp_local_environment.json"
-  check_kubectl_cp "$ttk_files_dir/spec_files/user_config_greenbank.json" "greenbank-backend-0:$ttk_pod_spec_dest/user_config.json"
-  check_kubectl_cp "$ttk_files_dir/spec_files/default.json" "greenbank-backend-0:$ttk_pod_spec_dest/rules_callback/default.json"
-
-  # Final status message
-  if [[ "$warning_issued" == false ]]; then
-    log_ok
-  else
-    log_warn "Some TTK files failed to copy."
-  fi
 }

--- a/src/environmentSetup/environmentSetup.sh
+++ b/src/environmentSetup/environmentSetup.sh
@@ -278,83 +278,124 @@ function env_setup_local_cluster {
 }   
 
 #------------------------------------------------------------------------------
-# Function: install_mac_k8s
-# Description: Ensures a local Kubernetes cluster is running on macOS.
-#              Prefers OrbStack; falls back to Rancher Desktop / Docker Desktop.
-#              Installs OrbStack via Homebrew if nothing is found.
+# Function: _wait_for_k8s
+# Description: Polls until the cluster is accessible or timeout is reached.
+# Parameters:
+#   $1 - timeout in seconds (default 180)
 #------------------------------------------------------------------------------
-function install_mac_k8s {
-    printf "\r==> Checking macOS Kubernetes provider     "
+function _wait_for_k8s {
+    local timeout="${1:-180}"
+    local waited=0
+    while ! is_cluster_accessible && [[ $waited -lt $timeout ]]; do
+        sleep 5; (( waited += 5 ))
+        printf "\r    Waiting for Rancher Desktop Kubernetes (%ds/%ds)..." "$waited" "$timeout"
+    done
+    printf "\n"
+    is_cluster_accessible
+}
 
-    # Already running — nothing to do
+#------------------------------------------------------------------------------
+# Function: install_mac_k8s
+# Description: Ensures Rancher Desktop (k3s) is running on macOS.
+#              Rancher Desktop is the only supported provider — it uses k3s,
+#              matching the Ubuntu environment and avoiding image pull issues.
+#              Errors if another Kubernetes provider is found running.
+#------------------------------------------------------------------------------
+#------------------------------------------------------------------------------
+# Function: _find_rdctl
+# Description: Locates the rdctl binary at known macOS install paths.
+#              Rancher Desktop puts rdctl inside the app bundle and symlinks
+#              it to ~/.rd/bin, but neither is on PATH when running via sudo.
+#------------------------------------------------------------------------------
+function _find_rdctl {
+    local user_home
+    user_home=$(eval echo "~$k8s_user")
+    for candidate in \
+        "$user_home/.rd/bin/rdctl" \
+        "/Applications/Rancher Desktop.app/Contents/Resources/resources/darwin/bin/rdctl" \
+        "/usr/local/bin/rdctl" \
+        "/opt/homebrew/bin/rdctl"; do
+        if [[ -x "$candidate" ]]; then
+            printf '%s' "$candidate"
+            return 0
+        fi
+    done
+    return 1
+}
+
+#------------------------------------------------------------------------------
+# Function: _start_rancher_desktop
+# Description: Starts Rancher Desktop via rdctl with standard Gazelle settings.
+#------------------------------------------------------------------------------
+function _start_rancher_desktop {
+    local rdctl
+    if ! rdctl=$(_find_rdctl); then
+        printf "** Error: rdctl not found. Rancher Desktop may not have installed correctly.\n"
+        exit 1
+    fi
+    sudo -u "$k8s_user" "$rdctl" start \
+        --application.start-in-background \
+        --kubernetes.enabled \
+        --kubernetes.version "1.30.0" \
+        --container-engine.name containerd \
+        --virtual-machine.memory-in-gb 16 \
+        --virtual-machine.number-cpus 4
+}
+
+function install_mac_k8s {
+    printf "\r==> Checking macOS Kubernetes provider\n"
+
+    # If cluster is accessible, verify it is Rancher Desktop
     if is_cluster_accessible; then
-        printf "                  [ok]\n"
+        local current_context
+        current_context=$(su - "$k8s_user" -c "kubectl config current-context" 2>/dev/null)
+        if [[ "$current_context" != "rancher-desktop" ]]; then
+            printf "** Error: A Kubernetes cluster is already running but it is not Rancher Desktop.\n"
+            printf "   Current context: %s\n" "$current_context"
+            printf "   mifos-gazelle requires Rancher Desktop on macOS.\n"
+            printf "   Please stop the other provider and re-run.\n"
+            exit 1
+        fi
+        printf "    Rancher Desktop Kubernetes is ready        [ok]\n"
         return 0
     fi
 
-    # Docker Desktop — most common on Mac, try first
-    if [[ -d "/Applications/Docker.app" ]]; then
-        printf "\n    Docker Desktop found"
-        # Only use it if already running — don't start it, fall through to OrbStack if not
-        if su - "$k8s_user" -c "docker info" >/dev/null 2>&1; then
-            printf ", checking Kubernetes...\n"
-            if su - "$k8s_user" -c "kubectl config get-contexts docker-desktop" >/dev/null 2>&1; then
-                su - "$k8s_user" -c "kubectl config use-context docker-desktop" >/dev/null 2>&1
-                if is_cluster_accessible; then
-                    printf "    Docker Desktop Kubernetes is ready         [ok]\n"
-                    return 0
-                fi
-            fi
-            printf "    Docker Desktop Kubernetes is not enabled — falling back to OrbStack.\n"
-            printf "    (To use Docker Desktop instead: Settings → Kubernetes → Enable Kubernetes → Apply)\n"
-        else
-            printf " (not running) — trying OrbStack.\n"
-        fi
-    fi
-
-    # OrbStack installed
-    if command -v orb &>/dev/null || [[ -d "/Applications/OrbStack.app" ]]; then
-        printf "\n    OrbStack found, starting Kubernetes engine...\n"
-        su - "$k8s_user" -c "orb start" >/dev/null 2>&1
-        local waited=0
-        while ! is_cluster_accessible && [[ $waited -lt 60 ]]; do
-            sleep 5; (( waited += 5 ))
-            printf "\r    Waiting for OrbStack Kubernetes (%ds)..." "$waited"
-        done
-        printf "\n"
-        if is_cluster_accessible; then
-            printf "    OrbStack Kubernetes is ready               [ok]\n"
+    # Rancher Desktop installed but not running — start it
+    if [[ -d "/Applications/Rancher Desktop.app" ]]; then
+        printf "    Rancher Desktop found, starting...\n"
+        _start_rancher_desktop
+        if _wait_for_k8s 180; then
+            printf "    Rancher Desktop Kubernetes is ready        [ok]\n"
             return 0
         fi
-        printf "** Error: OrbStack did not become ready.\n"
-        printf "   Open OrbStack → Settings → Kubernetes and ensure it is enabled.\n"
+        printf "** Error: Rancher Desktop did not become ready within 3 minutes.\n"
+        printf "   Open Rancher Desktop and check for errors.\n"
         exit 1
     fi
 
-    # Nothing found — install OrbStack via brew
-    printf "\n    No Kubernetes provider found. Installing OrbStack via Homebrew...\n"
-    if ! command -v brew &>/dev/null; then
+    # Not installed — install via Homebrew then start
+    printf "    Rancher Desktop not found. Installing via Homebrew...\n"
+    if ! brew_available; then
         printf "** Error: Homebrew is required. Install from https://brew.sh **\n"
         exit 1
     fi
-    su - "$k8s_user" -c "brew install --cask orbstack" >/dev/null 2>&1
-    if [[ $? -ne 0 ]]; then
-        printf "** Error: OrbStack installation failed. Install manually from https://orbstack.dev **\n"
+    if ! sudo -u "$k8s_user" brew install --cask rancher; then
+        printf "** Error: Rancher Desktop installation failed.\n"
         exit 1
     fi
-    su - "$k8s_user" -c "open -a OrbStack" 2>/dev/null
-    printf "\n"
-    printf "    OrbStack installed. Please complete these one-time steps:\n"
-    printf "      1. OrbStack will open — accept any permission prompts\n"
-    printf "      2. In OrbStack Settings, ensure Kubernetes is enabled\n"
-    printf "      3. Re-run: sudo ./run.sh\n\n"
-    exit 0
+    printf "    Configuring and starting Rancher Desktop (this may take a few minutes)...\n"
+    _start_rancher_desktop
+    if ! _wait_for_k8s 180; then
+        printf "** Error: Rancher Desktop did not become ready within 3 minutes.\n"
+        exit 1
+    fi
+    printf "    Rancher Desktop Kubernetes is ready        [ok]\n"
 }
 
 #------------------------------------------------------------------------------
 # Function: env_setup_mac_cluster
-# Description: Sets up Gazelle on a macOS host using OrbStack / Rancher Desktop /
-#              Docker Desktop as the local Kubernetes provider.
+# Description: Sets up Gazelle on a macOS host using Rancher Desktop (k3s) as
+#              the preferred Kubernetes provider, with Docker Desktop as fallback.
 # Parameters:
 #   $1 - Mode of operation: "deploy", "cleanapps", or "cleanall"
 #------------------------------------------------------------------------------

--- a/src/environmentSetup/environmentSetup.sh
+++ b/src/environmentSetup/environmentSetup.sh
@@ -3,26 +3,27 @@
 
 source "$RUN_DIR/src/environmentSetup/helpers.sh" || { echo "FATAL: Could not source helpers.sh. Check RUN_DIR: $RUN_DIR"; exit 1; }
 source "$RUN_DIR/src/environmentSetup/k8s.sh" || { echo "FATAL: Could not source k8s.sh. Check RUN_DIR: $RUN_DIR"; exit 1; }
+source "$RUN_DIR/src/environmentSetup/mac_setup.sh" || { echo "FATAL: Could not source mac_setup.sh. Check RUN_DIR: $RUN_DIR"; exit 1; }
 
 #------------------------------------------------------------------------------
 # Function: install_os_prerequisites   
 # Description: Installs required operating system packages if they are not already installed.
 #------------------------------------------------------------------------------
-function install_os_prerequisites {
-    printf "\n\r==> Check & install operating system packages"
+install_os_prerequisites() {
+    log_step "Check & install operating system packages"
     if [[ "$(uname -s)" == "Darwin" ]]; then
-        _ensure_homebrew
+        ensure_homebrew
         if ! command -v jq &>/dev/null; then
-            logWithVerboseCheck "$debug" debug "jq is not installed. Installing via brew..."
+            log_with_verbose_check "$debug" debug "jq is not installed. Installing via brew..."
             run_brew install jq >/dev/null 2>&1
         else
-            logWithVerboseCheck "$debug" debug "jq is already installed\n"
+            log_with_verbose_check "$debug" debug "jq is already installed\n"
         fi
-        printf "       [ok]\n"
+        log_ok
         return 0
     fi
     if ! command -v docker &> /dev/null; then
-        logWithVerboseCheck "$debug" debug "Docker is not installed. Installing Docker..."
+        log_with_verbose_check "$debug" debug "Docker is not installed. Installing Docker..."
         apt update >> /dev/null 2>&1
         apt install -y apt-transport-https ca-certificates curl software-properties-common >> /dev/null 2>&1
         curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg >> /dev/null 2>&1
@@ -30,27 +31,27 @@ function install_os_prerequisites {
         apt update >> /dev/null 2>&1
         apt install -y docker-ce docker-ce-cli containerd.io >> /dev/null 2>&1
         usermod -aG docker "$k8s_user"
-        printf "   ok \n"
+        log_ok
     else
-        logWithVerboseCheck "$debug" debug "Docker is already installed.\n"
+        log_with_verbose_check "$debug" debug "Docker is already installed.\n"
     fi
     if ! command -v nc &> /dev/null; then
-        logWithVerboseCheck "$debug" debug "nc (netcat) is not installed. Installing..."
+        log_with_verbose_check "$debug" debug "nc (netcat) is not installed. Installing..."
         apt-get update >> /dev/null 2>&1
         apt-get install -y netcat >> /dev/null 2>&1
-        printf "ok\n"
+        log_ok
     else
-        logWithVerboseCheck "$debug" debug "nc (netcat) is already installed.\n"
+        log_with_verbose_check "$debug" debug "nc (netcat) is already installed.\n"
     fi
     if ! command -v jq &> /dev/null; then
-        logWithVerboseCheck "$debug" debug "jq is not installed. Installing ..."
+        log_with_verbose_check "$debug" debug "jq is not installed. Installing ..."
         apt-get update >> /dev/null 2>&1
         apt-get -y install jq >> /dev/null 2>&1
-        printf "ok\n"
+        log_ok
     else
-        logWithVerboseCheck "$debug" debug "jq is already installed\n"
+        log_with_verbose_check "$debug" debug "jq is already installed\n"
     fi
-    printf "       [ok]\n"
+    log_ok
 }
 
 #------------------------------------------------------------------------------
@@ -61,30 +62,30 @@ function install_os_prerequisites {
 #              Homebrew Python packages are modified.
 #              Idempotent: skips creation/install if already up to date.
 #------------------------------------------------------------------------------
-function ensure_python_venv {
+ensure_python_venv() {
     local venv_dir="$RUN_DIR/.venv"
     local requirements="$RUN_DIR/src/utils/data-loading/requirements.txt"
 
-    printf "\r==> Python virtualenv for data-loading scripts  "
+    log_step "Python virtualenv for data-loading scripts"
 
     # Create the venv as the k8s_user so they can run scripts without sudo
     if [[ ! -x "$venv_dir/bin/python3" ]]; then
-        run_as_user "python3 -m venv \"$venv_dir\""
+        run_as_user "python3 -m venv \"$venv_dir\"" >/dev/null
         if [[ $? -ne 0 ]]; then
-            printf "\n** Error: failed to create Python venv at $venv_dir\n"
+            log_error "Failed to create Python venv at $venv_dir"
             exit 1
         fi
     fi
 
     # Install/upgrade requirements (pip will skip packages already at the right version)
-    run_as_user "\"$venv_dir/bin/pip\" install --quiet --upgrade pip"
-    run_as_user "\"$venv_dir/bin/pip\" install --quiet -r \"$requirements\""
+    run_as_user "\"$venv_dir/bin/pip\" install --quiet --upgrade pip" >/dev/null
+    run_as_user "\"$venv_dir/bin/pip\" install --quiet -r \"$requirements\"" >/dev/null
     if [[ $? -ne 0 ]]; then
-        printf "\n** Error: failed to install Python requirements\n"
+        log_error "Failed to install Python requirements"
         exit 1
     fi
 
-    printf "        [ok]\n"
+    log_ok
 }
 
 #------------------------------------------------------------------------------
@@ -101,7 +102,7 @@ GAZELLE_HOSTS_END="# END mifos-gazelle"
 # Description: Removes the mifos-gazelle block from /etc/hosts.
 #              Safe to call even if the block is not present.
 #------------------------------------------------------------------------------
-function remove_hosts {
+remove_hosts() {
     perl -i -ne '
         if (/^\Q'"$GAZELLE_HOSTS_BEGIN"'\E/) { $skip=1 }
         print unless $skip;
@@ -116,9 +117,9 @@ function remove_hosts {
 #              idempotent and handles IP changes (e.g. after a VM restart).
 #              The block is self-contained — no other lines are touched.
 #------------------------------------------------------------------------------
-function add_hosts {
+add_hosts() {
     if [[ "$environment" == "local" || "$environment" == "mac" ]]; then
-        printf "==> Mifos-gazelle: update local hosts file  "
+        log_step "Updating /etc/hosts for Gazelle services"
 
         local DOMAIN="${GAZELLE_DOMAIN:-mifos.gazelle.test}"
 
@@ -187,28 +188,30 @@ function add_hosts {
         } >> /etc/hosts
 
     else
-        printf "==> Skipping /etc/hosts modification for remote cluster \n"
+        log_step "Updating /etc/hosts for Gazelle services"
+        log_skipped
+        return 0
     fi
-    printf "        [ok]\n"
+    log_ok
 }
 #------------------------------------------------------------------------------
 # Function: delete_k8s_local_cluster   
 # Description: Deletes the local Kubernetes cluster and removes related configurations.
 #------------------------------------------------------------------------------
-function delete_k8s_local_cluster {
-    printf "    removing local kubernetes cluster   "
+delete_k8s_local_cluster() {
+    log_step "removing local kubernetes cluster"
     rm -f /usr/local/bin/helm >> /dev/null 2>&1
     /usr/local/bin/k3s-uninstall.sh >> /dev/null 2>&1
     if [[ $? -eq 0 ]]; then
-        printf "            [ok] \n"
+        log_ok
     else
-        echo -e "\n==> k3s not installed"
+        log_warn "k3s not installed"
     fi
     perl -i -ne 'print unless /START_GAZELLE/ .. /END_GAZELLE/' "$k8s_user_home/.bashrc"
     perl -i -ne 'print unless /START_GAZELLE/ .. /END_GAZELLE/' "$k8s_user_home/.bash_profile"
 }
 
-function print_end_message {
+print_end_message() {
     echo -e "\n${GREEN}============================"
     echo -e "Environment setup successful"
     echo -e "============================${RESET}"
@@ -218,7 +221,7 @@ function print_end_message {
 # Function: print_end_message_delete   
 # Description: Prints a message indicating successful cleanup of the environment.
 #------------------------------------------------------------------------------
-function print_end_message_delete {
+print_end_message_delete() {
     echo -e "\n===================================================="
     echo -e "cleanup successful "
     echo -e "Thank you for using Mifos Gazelle"
@@ -226,7 +229,7 @@ function print_end_message_delete {
     echo -e "Copyright © 2023 The Mifos Initiative\n"
 }
 
-function print_remote_cluster_start_message {
+print_remote_cluster_start_message() {
     echo -e "\n${BLUE}================================"
     echo -e "Remote Cluster Setup and deployment "
     echo -e "================================${RESET}\n"
@@ -236,7 +239,7 @@ function print_remote_cluster_start_message {
 # Function: configure_k8s_user_env   
 # Description: Configures the shell environment for the Kubernetes user.
 #------------------------------------------------------------------------------
-function configure_k8s_user_env {
+configure_k8s_user_env() {
     local shell_rc shell_profile completion_cmd complete_cmd
     start_message="# GAZELLE_START start of config added by mifos-gazelle #"
     end_message="#GAZELLE_END end of config added by mifos-gazelle #"
@@ -255,7 +258,7 @@ function configure_k8s_user_env {
 
     grep "start of config added by mifos-gazelle" "$shell_rc" >/dev/null 2>&1
     if [[ $? -ne 0 ]]; then
-        printf "==> Configure user shell for kubernetes "
+        log_step "Configure user shell for kubernetes"
         printf "%s\n" "$start_message" >> "$shell_rc"
         echo "$completion_cmd" >> "$shell_rc"
         echo "alias k=kubectl " >> "$shell_rc"
@@ -267,19 +270,20 @@ function configure_k8s_user_env {
         echo "export KUBECONFIG=$kubeconfig_path" >> "$shell_rc"
         printf "%s\n" "$end_message" >> "$shell_rc"
 
-        perl -p -i.bak -e 's/^.*KUBECONFIG.*\n?//g' "$shell_profile"
+        perl -pi -e 's/^.*KUBECONFIG.*\n?//g' "$shell_profile"
         if [[ "$(uname -s)" == "Darwin" ]]; then
             echo "export KUBECONFIG=$kubeconfig_path" >> "$shell_profile"
         else
-            perl -p -i.bak -e 's/^.*bashrc.*\n?//g' "$shell_profile"
+            perl -pi -e 's/^.*bashrc.*\n?//g' "$shell_profile"
             echo "source ~/.bashrc" >> "$shell_profile"
             echo "export KUBECONFIG=$kubeconfig_path" >> "$shell_profile"
         fi
 
         chown "$k8s_user":"$k8s_user" "$shell_rc" "$shell_profile"
-        printf "         [ok]\n"
+        log_ok
     else
-        printf "\r==> user's shell already configured for k8s       [skipping]\n"
+        log_step "user's shell already configured for k8s"
+        log_skipped
     fi
 }
 
@@ -306,7 +310,7 @@ is_cluster_accessible() {
     local ready_nodes=$(su - "$k8s_user" -c "$k8s_user_cmd" | grep -c " Ready ")    
     if [[ "$ready_nodes" -eq 0 ]]; then
         # This means we could access the cluster, but no nodes are reported as Ready.
-        logWithVerboseCheck "$debug" info "Kubernetes cluster is reachable, but zero nodes are in the 'Ready' state."
+        log_with_verbose_check "$debug" info "Kubernetes cluster is reachable, but zero nodes are in the 'Ready' state."
         return 1
     fi
     return 0
@@ -317,13 +321,14 @@ is_cluster_accessible() {
 # Parameters:
 #   $1 - Mode of operation: "deploy", "cleanapps"
 #------------------------------------------------------------------------------
-function env_setup_remote_cluster {
+env_setup_remote_cluster() {
     local mode="$1"
     if ! is_cluster_accessible; then
-        printf "** Error: Remote kubernetes cluster is NOT accessible. Please check your KUBECONFIG and network connectivity. ** \n\n"
+        log_error "Remote kubernetes cluster is NOT accessible. Please check your KUBECONFIG and network connectivity."
         exit 1
-    else 
-        printf "\r==> Remote kubernetes cluster is accessible       [ok]\n"
+    else
+        log_step "Remote kubernetes cluster is accessible"
+        log_ok
         return 0
     fi
     # note that we might need to install NGINX here or interrogate remote cluster for existing ingress controller
@@ -336,12 +341,11 @@ function env_setup_remote_cluster {
 # Parameters:
 #   $1 - Mode of operation: "deploy", "cleanapps", or "cleanall"
 #------------------------------------------------------------------------------
-function env_setup_local_cluster {
+env_setup_local_cluster() {
     local mode="$1"
 
     if [[ "$mode" == "deploy" ]]; then
         check_resources_ok
-        install_os_prerequisites
         ensure_python_venv
         add_hosts
 
@@ -351,23 +355,20 @@ function env_setup_local_cluster {
         fi
         check_and_load_helm_repos
         install_nginx_local_cluster
-        printf "\r==> local kubernetes v%s configured  for %s \n" \
-                  "$k8s_version" "$k8s_user"
+        log_section "local kubernetes v${k8s_version} configured for ${k8s_user}"
         print_end_message
     elif [[ "$mode" == "cleanapps" ]]; then
         if ! is_local_cluster_installed; then
-            printf "    ** Error:  Local kubernetes cluster is NOT installed   \n\n"
+            log_error "Local kubernetes cluster is NOT installed"
             exit 1
         fi
         if ! is_cluster_accessible; then
-            printf "    ** Error: Local kubernetes cluster is NOT accessible   \n\n"
+            log_error "Local kubernetes cluster is NOT accessible"
             exit 1
         fi
     elif [[ "$mode" == "cleanall" ]]; then
-        #printf "\n==> Deleting local kubernetes cluster...  \n"
         if ! is_local_cluster_installed; then
-            printf "    Local kubernetes cluster is NOT installed   \n"
-            printf "    Nothing to delete. Exiting.\n\n"
+            log_warn "Local kubernetes cluster is NOT installed — nothing to delete."
             print_end_message_delete
             exit 0
         fi
@@ -375,414 +376,13 @@ function env_setup_local_cluster {
         remove_hosts
         print_end_message_delete
     else
-        showUsage
+        show_usage
         exit 1
     fi
 }   
 
-#------------------------------------------------------------------------------
-# Function: _configure_mac_vm_limits
-# Description: Increases inotify and file-descriptor kernel limits inside the
-#              Colima Lima VM.  Without this, Java/Spring-Boot pods that
-#              open many fsnotify watchers (bulk-processor, zeebe-broker, etc.)
-#              hit "too many open files" errors.  Settings are applied immediately
-#              and written to /etc/sysctl.d/99-gazelle.conf so they survive Lima
-#              VM restarts.  Idempotent: safe to call on every run.
-#------------------------------------------------------------------------------
-function _configure_mac_vm_limits {
-    local colima
-    if ! colima=$(_find_colima); then
-        printf "    Warning: colima not found — skipping VM kernel limit tuning\n"
-        return 0
-    fi
 
-    printf "    Configuring VM kernel limits (inotify / file descriptors)...\n"
-
-    # Apply immediately (takes effect for all running and new processes).
-    sudo -u "$k8s_user" "$colima" exec -- sudo sysctl -w fs.inotify.max_user_watches=1048576  >/dev/null 2>&1 || true
-    sudo -u "$k8s_user" "$colima" exec -- sudo sysctl -w fs.inotify.max_user_instances=8192   >/dev/null 2>&1 || true
-    sudo -u "$k8s_user" "$colima" exec -- sudo sysctl -w fs.file-max=2097152                  >/dev/null 2>&1 || true
-
-    # Persist across Lima VM restarts (idempotent: only write if not already present).
-    sudo -u "$k8s_user" "$colima" exec -- sudo sh -c \
-        'grep -q max_user_watches /etc/sysctl.d/99-gazelle.conf 2>/dev/null || printf "fs.inotify.max_user_watches=1048576\nfs.inotify.max_user_instances=8192\nfs.file-max=2097152\n" > /etc/sysctl.d/99-gazelle.conf' \
-        >/dev/null 2>&1 || true
-
-    printf "    VM kernel limits configured            [ok]\n"
-}
-
-#------------------------------------------------------------------------------
-# Function: _configure_mac_k3s_node_ip
-# Description: Configures k3s inside the Colima Lima VM to bind to
-#              the socket_vmnet (eth0) interface rather than the vznat interface.
-#
-#              Lima has two external interfaces:
-#                eth0  (192.168.5.x) — socket_vmnet, directly routable from Mac
-#                vznat (192.168.68.x) — VZ NAT for internet; overlaps with many
-#                                       physical LAN subnets, causing routing
-#                                       ambiguity on the Mac side.
-#
-#              Without this fix, k3s svclb binds to the vznat IP which the Mac
-#              may route to a physical LAN device instead of the Lima VM.
-#
-#              Writes /etc/rancher/k3s/config.yaml inside the VM (persists on
-#              the VM disk across restarts) and restarts k3s.  Idempotent.
-#------------------------------------------------------------------------------
-function _configure_mac_k3s_node_ip {
-    local colima
-    if ! colima=$(_find_colima); then
-        printf "    Warning: colima not found — skipping k3s node-ip config\n"
-        return 0
-    fi
-
-    # Detect eth0 IP inside the Lima VM (socket_vmnet, directly reachable from Mac)
-    local eth0_ip
-    eth0_ip=$(sudo -u "$k8s_user" "$colima" exec -- ip -4 addr show eth0 2>/dev/null \
-        | awk '/inet /{print $2}' | cut -d'/' -f1)
-
-    if [[ -z "$eth0_ip" ]]; then
-        printf "    Warning: could not detect Lima VM eth0 IP — skipping k3s node-ip config\n"
-        return 0
-    fi
-
-    printf "    Configuring k3s node-ip to %s (socket_vmnet eth0)...\n" "$eth0_ip"
-
-    # Idempotent: skip if already configured with this IP
-    local current_ip
-    current_ip=$(sudo -u "$k8s_user" "$colima" exec -- \
-        sudo sh -c 'grep -E "^node-ip:" /etc/rancher/k3s/config.yaml 2>/dev/null' \
-        | awk -F'"' '{print $2}')
-    if [[ "$current_ip" == "$eth0_ip" ]]; then
-        printf "    k3s node-ip already set to %s   [ok]\n" "$eth0_ip"
-        return 0
-    fi
-
-    # Write the config file inside the Lima VM
-    sudo -u "$k8s_user" "$colima" exec -- sudo sh -c \
-        "mkdir -p /etc/rancher/k3s && printf 'node-ip: \"%s\"\nnode-external-ip: \"%s\"\n' '$eth0_ip' '$eth0_ip' > /etc/rancher/k3s/config.yaml" \
-        >/dev/null 2>&1
-
-    # Restart k3s so it picks up the new node-ip config.
-    # Try each init mechanism in turn; fall back to a full VM restart.
-    printf "    Restarting k3s...\n"
-    local restarted=false
-    if sudo -u "$k8s_user" "$colima" exec -- sudo rc-service k3s restart >/dev/null 2>&1; then
-        # OpenRC (Alpine Linux — Colima Lima VM)
-        restarted=true
-    elif sudo -u "$k8s_user" "$colima" exec -- sudo service k3s restart >/dev/null 2>&1; then
-        restarted=true
-    elif sudo -u "$k8s_user" "$colima" exec -- sudo dinitctl restart k3s >/dev/null 2>&1; then
-        restarted=true
-    else
-        # No init service found — restart the whole VM (slowest but reliable)
-        printf "    No k3s service manager found — restarting Colima VM...\n"
-        sudo -u "$k8s_user" "$colima" stop >/dev/null 2>&1 || true
-        sleep 5
-        _start_colima
-        restarted=true
-    fi
-
-    # Wait for the cluster to recover
-    if [[ "$restarted" == true ]] && _wait_for_k8s 180; then
-        printf "    k3s node-ip configured              [ok]\n"
-    else
-        printf "    Warning: k3s did not recover within 3 minutes after restart\n"
-    fi
-}
-
-#------------------------------------------------------------------------------
-# Function: _wait_for_k8s
-# Description: Polls until the cluster is accessible or timeout is reached.
-#              Also retries 'kubectl config use-context colima' on each
-#              iteration because Colima writes its kubeconfig entry
-#              asynchronously after starting — the context may not exist when
-#              the loop begins.
-# Parameters:
-#   $1 - timeout in seconds (default 240)
-#------------------------------------------------------------------------------
-function _wait_for_k8s {
-    local timeout="${1:-240}"
-    local waited=0
-    while ! is_cluster_accessible && [[ $waited -lt $timeout ]]; do
-        su - "$k8s_user" -c "kubectl config use-context colima" >/dev/null 2>&1 || true
-        sleep 5; (( waited += 5 ))
-        printf "\r    Waiting for Colima Kubernetes (%ds/%ds)..." "$waited" "$timeout"
-    done
-    printf "\n"
-    is_cluster_accessible
-}
-
-#------------------------------------------------------------------------------
-# Function: _recover_mac_k8s
-# Description: Attempts automatic recovery when the Colima VM is
-#              running but the k3s cluster is not reachable.
-#
-#              Tier 1 (fast ~15s): removes any stale /etc/rancher/k3s/config.yaml
-#              written by previous gazelle runs and restarts k3s in place.
-#
-#              Tier 2 (slower ~2min): if k3s is still unreachable, performs a
-#              full colima stop + start to reset the VM cleanly.
-#
-# Returns: 0 if cluster becomes accessible, 1 if recovery failed.
-#------------------------------------------------------------------------------
-function _recover_mac_k8s {
-    local colima
-    if ! colima=$(_find_colima); then
-        printf "    Warning: colima not found — cannot attempt auto-recovery\n"
-        return 1
-    fi
-
-    # ---- Tier 1: clean stale config artifact + in-place k3s restart ----
-    printf "    Auto-recovery tier 1: restarting k3s inside the VM...\n"
-    sudo -u "$k8s_user" "$colima" exec -- sudo rm -f /etc/rancher/k3s/config.yaml >/dev/null 2>&1 || true
-    sudo -u "$k8s_user" "$colima" exec -- sudo rc-service k3s restart >/dev/null 2>&1 || \
-        sudo -u "$k8s_user" "$colima" exec -- sudo service k3s restart >/dev/null 2>&1 || true
-
-    su - "$k8s_user" -c "kubectl config use-context colima" >/dev/null 2>&1 || true
-    if _wait_for_k8s 60; then
-        printf "    Auto-recovery tier 1 succeeded              [ok]\n"
-        return 0
-    fi
-
-    # ---- Tier 2: full VM restart ----
-    printf "    Auto-recovery tier 2: restarting Colima VM...\n"
-    sudo -u "$k8s_user" "$colima" stop >/dev/null 2>&1 || true
-    sleep 5
-    _start_colima
-    su - "$k8s_user" -c "kubectl config use-context colima" >/dev/null 2>&1 || true
-    if _wait_for_k8s 240; then
-        printf "    Auto-recovery tier 2 succeeded              [ok]\n"
-        return 0
-    fi
-
-    printf "** Auto-recovery failed. Try:\n"
-    printf "   1. Run: colima stop && colima start --kubernetes --kubernetes-version v1.30.0+k3s1 --runtime containerd --memory 16 --cpu 4\n"
-    printf "   2. If the problem persists, run: colima delete && re-run ./run.sh\n"
-    return 1
-}
-
-#------------------------------------------------------------------------------
-# Function: install_mac_k8s
-# Description: Ensures Colima (k3s) is running on macOS.
-#              Colima is the supported provider — it uses k3s via Lima,
-#              matching the Ubuntu environment and avoiding image pull issues.
-#              Errors if another Kubernetes provider is found running.
-#------------------------------------------------------------------------------
-#------------------------------------------------------------------------------
-# Function: _ensure_homebrew
-# Description: Auto-installs Homebrew if not present. Safe to call as root
-#              (uses sudo -u $k8s_user internally). Exits on failure.
-#------------------------------------------------------------------------------
-function _ensure_homebrew {
-    if brew_available; then
-        return 0
-    fi
-    printf "    Homebrew not found — installing (this may take a few minutes)...\n"
-    sudo -u "$k8s_user" /bin/bash -c \
-        "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)" \
-        </dev/null
-    export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
-    if ! brew_available; then
-        printf "** Error: Homebrew installation failed. Install manually from https://brew.sh **\n"
-        exit 1
-    fi
-    printf "    Homebrew installed                       [ok]\n"
-}
-
-#------------------------------------------------------------------------------
-# Function: _find_colima
-# Description: Locates the colima binary at known macOS install paths.
-#              colima is not on PATH when running via sudo, so we check
-#              known Homebrew locations explicitly.
-#------------------------------------------------------------------------------
-function _find_colima {
-    for candidate in \
-        "/opt/homebrew/bin/colima" \
-        "/usr/local/bin/colima"; do
-        if [[ -x "$candidate" ]]; then
-            printf '%s' "$candidate"
-            return 0
-        fi
-    done
-    if command -v colima &>/dev/null; then
-        command -v colima; return 0
-    fi
-    return 1
-}
-
-#------------------------------------------------------------------------------
-# Function: _start_colima
-# Description: Starts Colima with k3s and containerd for standard Gazelle use.
-#              k3s version matches the Ubuntu local environment.
-#              containerd is used (not Docker) for consistency.
-#------------------------------------------------------------------------------
-function _start_colima {
-    local colima
-    if ! colima=$(_find_colima); then
-        printf "** Error: colima not found. Install with: brew install colima\n"
-        exit 1
-    fi
-    # Pass Homebrew PATH explicitly — sudo strips PATH so colima's internal
-    # kubectl dependency check fails without it.
-    sudo -u "$k8s_user" env PATH="/opt/homebrew/bin:/usr/local/bin:$PATH" \
-        "$colima" start \
-        --kubernetes \
-        --kubernetes-version "v1.30.0+k3s1" \
-        --runtime docker \
-        --memory 16 \
-        --cpu 4 \
-        --network-address
-}
-
-function install_mac_k8s {
-    printf "\r==> Checking macOS Kubernetes provider\n"
-    _ensure_homebrew
-
-    # socket_vmnet sudoers: required for colima --network-address to get a routable VM IP.
-    # colima sudoers emits the necessary /etc/sudoers.d snippet; idempotent on every run.
-    local colima_bin
-    if colima_bin=$(_find_colima); then
-        sudo -u "$k8s_user" "$colima_bin" sudoers 2>/dev/null \
-            | tee /etc/sudoers.d/colima >/dev/null 2>&1 || true
-    fi
-
-    # Ensure kubeconfig context is colima if available (may be stale from prior provider)
-    su - "$k8s_user" -c "kubectl config use-context colima" >/dev/null 2>&1 || true
-
-    # If cluster is accessible, verify it is Colima
-    if is_cluster_accessible; then
-        local current_context
-        current_context=$(su - "$k8s_user" -c "kubectl config current-context" 2>/dev/null)
-        if [[ "$current_context" != "colima" ]]; then
-            printf "** Error: A Kubernetes cluster is already running but it is not Colima.\n"
-            printf "   Current context: %s\n" "$current_context"
-            printf "   mifos-gazelle requires Colima on macOS.\n"
-            printf "   Please stop the other provider and re-run.\n"
-            exit 1
-        fi
-        printf "    Colima Kubernetes is ready                 [ok]\n"
-        return 0
-    fi
-
-    # VM may already be running in a broken state (e.g. kubelet crashed due to a
-    # stale config artifact from a previous run).  Try auto-recovery before
-    # attempting a full start, so we don't waste time shutting down a live VM.
-    local colima
-    if colima=$(_find_colima); then
-        local vm_state
-        vm_state=$(sudo -u "$k8s_user" "$colima" list --json 2>/dev/null \
-            | python3 -c "import sys,json; items=json.load(sys.stdin); print(items[0].get('status','') if items else '')" 2>/dev/null || true)
-        if [[ "$vm_state" == "Running" ]]; then
-            printf "    VM is running but cluster is unreachable — attempting auto-recovery...\n"
-            if _recover_mac_k8s; then
-                printf "    Colima Kubernetes is ready                 [ok]\n"
-                return 0
-            fi
-            # Recovery failed — fall through to a clean start below
-        fi
-    fi
-
-    # Colima installed but not running (or recovery failed) — start it
-    if colima=$(_find_colima); then
-        printf "    Colima found, starting...\n"
-        _start_colima
-        # Ensure kubeconfig points at colima (may be stale from a previous provider)
-        su - "$k8s_user" -c "kubectl config use-context colima" >/dev/null 2>&1 || true
-        if _wait_for_k8s 240; then
-            printf "    Colima Kubernetes is ready                 [ok]\n"
-            return 0
-        fi
-        printf "** Error: Colima did not become ready.\n"
-        printf "   Run: colima list    and check for errors.\n"
-        exit 1
-    fi
-
-    # Not installed — install Colima + Docker tooling via Homebrew then start
-    printf "    Colima not found. Installing via Homebrew (this may take a few minutes)...\n"
-    if ! sudo -u "$k8s_user" brew install colima docker docker-compose; then
-        printf "** Error: Colima installation failed.\n"
-        exit 1
-    fi
-    printf "    Starting Colima with Kubernetes (this may take a few minutes)...\n"
-    _start_colima
-    if ! _wait_for_k8s 300; then
-        printf "** Error: Colima did not become ready.\n"
-        exit 1
-    fi
-    printf "    Colima Kubernetes is ready                 [ok]\n"
-}
-
-#------------------------------------------------------------------------------
-# Function: env_setup_mac_cluster
-# Description: Sets up Gazelle on a macOS host using Colima (k3s) as the
-#              Kubernetes provider.
-# Parameters:
-#   $1 - Mode of operation: "deploy", "cleanapps", or "cleanall"
-#------------------------------------------------------------------------------
-function env_setup_mac_cluster {
-    local mode="$1"
-    if [[ "$mode" == "deploy" ]]; then
-        check_resources_ok
-        install_mac_k8s
-        _configure_mac_vm_limits
-        # NOTE: _configure_mac_k3s_node_ip is intentionally NOT called here.
-        # The default Colima k3s setup works correctly without explicit node-ip binding.
-        # The function exists and is updated for potential future use if needed.
-        ensure_python_venv
-        add_hosts
-        check_and_load_helm_repos
-        install_nginx_local_cluster
-        printf "\r==> macOS kubernetes cluster configured for %s\n" "$k8s_user"
-        print_end_message
-    elif [[ "$mode" == "cleanapps" || "$mode" == "cleanall" ]]; then
-        if is_cluster_accessible; then
-            # Cluster is up — delete namespaces and helm releases cleanly
-            if [[ "$mode" == "cleanapps" ]]; then
-                : # app deletion handled by deleteApps called from commandline.sh
-            else
-                log_step "Removing ingress-nginx"
-                run_as_user "helm uninstall ingress-nginx -n default" >/dev/null 2>&1 || true
-                log_ok
-            fi
-        else
-            if [[ "$mode" == "cleanapps" ]]; then
-                printf "** Error: Kubernetes cluster is NOT accessible\n\n"
-                exit 1
-            else
-                printf "    Warning: Kubernetes cluster is not accessible — skipping namespace cleanup\n"
-            fi
-        fi
-        remove_hosts
-        if [[ "$mode" == "cleanall" ]]; then
-            # Delete the Colima VM entirely — full wipe of k3s state and images.
-            # colima delete stops the VM first if running, then removes the disk.
-            local colima
-            if colima=$(_find_colima); then
-                log_step "Deleting Colima VM (full cleanall)"
-                # --yes skips the interactive confirmation prompt.
-                # Stop first (ignoring errors if already stopped) so containerd
-                # shuts down cleanly before delete removes the disk; this avoids
-                # the ttrpc/JSON errors that occur when delete tries to stop a
-                # partially-running VM itself.
-                sudo -u "$k8s_user" "$colima" stop 2>/dev/null || true
-                sudo -u "$k8s_user" "$colima" delete --yes 2>/dev/null || true
-                # colima delete leaves behind ~/.colima (named disks, Lima config, SSH
-                # config) which can hold 20-30 GB of disk images. Remove the entire
-                # directory for a true cleanall — Colima recreates it on next start.
-                rm -rf "$k8s_user_home/.colima" 2>/dev/null || true
-                log_ok
-                # Remove stale kubeconfig and Docker contexts left by the deleted VM.
-                su - "$k8s_user" -c "kubectl config delete-context colima" >/dev/null 2>&1 || true
-                sudo -u "$k8s_user" docker context rm colima >/dev/null 2>&1 || true
-            fi
-        fi
-    else
-        showUsage
-        exit 1
-    fi
-}
-
-function env_setup_main() {
+env_setup_main() {
     local mode="$1"
 
     check_sudo
@@ -806,23 +406,3 @@ function env_setup_main() {
     fi
 } 
 
-# Getting rid of the fsnotify too many open files errors for local k3s install do this 
-# # 1. Automate Kernel Parameter Configuration
-# echo "Configuring Linux kernel parameters for K3s..."
-
-# sudo tee /etc/sysctl.d/99-k3s.conf <<EOF
-# fs.inotify.max_user_watches = 524288
-# fs.inotify.max_user_instances = 1024
-# fs.file-max = 2097152
-# EOF
-
-# # Load the new settings immediately
-# sudo sysctl --system
-
-# # 2. Install K3s (This command will install and start the service)
-# echo "Installing K3s..."
-# curl -sfL https://get.k3s.io | sh -
-
-# # 3. Verify K3s status
-# echo "K3s installation complete. Checking status..."
-# sudo systemctl status k3s --no-pager

--- a/src/environmentSetup/environmentSetup.sh
+++ b/src/environmentSetup/environmentSetup.sh
@@ -9,7 +9,21 @@ source "$RUN_DIR/src/environmentSetup/k8s.sh" || { echo "FATAL: Could not source
 # Description: Installs required operating system packages if they are not already installed.
 #------------------------------------------------------------------------------
 function install_os_prerequisites {
-    printf "\n\r==> Check & install operating system packages" 
+    printf "\n\r==> Check & install operating system packages"
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+        if ! command -v brew &>/dev/null; then
+            printf "\n** Error: Homebrew is required on macOS. Install from https://brew.sh **\n"
+            exit 1
+        fi
+        if ! command -v jq &>/dev/null; then
+            logWithVerboseCheck "$debug" debug "jq is not installed. Installing via brew..."
+            brew install jq >/dev/null 2>&1
+        else
+            logWithVerboseCheck "$debug" debug "jq is already installed\n"
+        fi
+        printf "       [ok]\n"
+        return 0
+    fi
     if ! command -v docker &> /dev/null; then
         logWithVerboseCheck "$debug" debug "Docker is not installed. Installing Docker..."
         apt update >> /dev/null 2>&1
@@ -47,7 +61,7 @@ function install_os_prerequisites {
 # Description: Updates the local /etc/hosts file with entries for Mifos Gazelle services when using a local cluster.
 #------------------------------------------------------------------------------
 function add_hosts {
-    if [[ "$environment" == "local" ]]; then
+    if [[ "$environment" == "local" || "$environment" == "mac" ]]; then
         printf "==> Mifos-gazelle: update local hosts file  "
         
         # Use GAZELLE_DOMAIN variable, with fallback to default
@@ -122,33 +136,49 @@ function print_remote_cluster_start_message {
 # Description: Configures the shell environment for the Kubernetes user.
 #------------------------------------------------------------------------------
 function configure_k8s_user_env {
+    local shell_rc shell_profile completion_cmd complete_cmd
     start_message="# GAZELLE_START start of config added by mifos-gazelle #"
     end_message="#GAZELLE_END end of config added by mifos-gazelle #"
-    # config .bashrc for k8s_user
-    grep "start of config added by mifos-gazelle" "$k8s_user_home/.bashrc" >/dev/null 2>&1
+
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+        shell_rc="$k8s_user_home/.zshrc"
+        shell_profile="$k8s_user_home/.zprofile"
+        completion_cmd="source <(kubectl completion zsh)"
+        complete_cmd="compdef k=kubectl"
+    else
+        shell_rc="$k8s_user_home/.bashrc"
+        shell_profile="$k8s_user_home/.bash_profile"
+        completion_cmd="source <(kubectl completion bash)"
+        complete_cmd="complete -F __start_kubectl k"
+    fi
+
+    grep "start of config added by mifos-gazelle" "$shell_rc" >/dev/null 2>&1
     if [[ $? -ne 0 ]]; then
-        printf "==> Configure users .bashrc for kubernetes " 
-        printf "%s\n" "$start_message" >> "$k8s_user_home/.bashrc"
-        echo "source <(kubectl completion bash)" >> "$k8s_user_home/.bashrc"
-        echo "alias k=kubectl " >> "$k8s_user_home/.bashrc"
-        echo "complete -F __start_kubectl k " >> "$k8s_user_home/.bashrc"
-        echo "alias ksetns=\"kubectl config set-context --current --namespace\" " >> "$k8s_user_home/.bashrc"
-        echo "alias ksetuser=\"kubectl config set-context --current --user\" " >> "$k8s_user_home/.bashrc"
-        echo "alias cdg=\"cd $k8s_user_home/mifos-gazelle\" " >> "$k8s_user_home/.bashrc"
-        echo "export PATH=\$PATH:/usr/local/bin" >> "$k8s_user_home/.bashrc"
-        echo "export KUBECONFIG=$kubeconfig_path" >> "$k8s_user_home/.bashrc"
-        printf "%s\n" "$end_message" >> "$k8s_user_home/.bashrc"
+        printf "==> Configure user shell for kubernetes "
+        printf "%s\n" "$start_message" >> "$shell_rc"
+        echo "$completion_cmd" >> "$shell_rc"
+        echo "alias k=kubectl " >> "$shell_rc"
+        echo "$complete_cmd" >> "$shell_rc"
+        echo "alias ksetns=\"kubectl config set-context --current --namespace\" " >> "$shell_rc"
+        echo "alias ksetuser=\"kubectl config set-context --current --user\" " >> "$shell_rc"
+        echo "alias cdg=\"cd $k8s_user_home/mifos-gazelle\" " >> "$shell_rc"
+        echo "export PATH=\$PATH:/usr/local/bin" >> "$shell_rc"
+        echo "export KUBECONFIG=$kubeconfig_path" >> "$shell_rc"
+        printf "%s\n" "$end_message" >> "$shell_rc"
 
-        # config .bash_profile for k8s_user
-        perl -p -i.bak -e 's/^.*KUBECONFIG.*\n?//g' "$k8s_user_home/.bash_profile"
-        perl -p -i.bak -e 's/^.*bashrc.*\n?//g' "$k8s_user_home/.bash_profile"
-        echo "source ~/.bashrc" >> "$k8s_user_home/.bash_profile"
-        echo "export KUBECONFIG=$kubeconfig_path" >> "$k8s_user_home/.bash_profile"
+        perl -p -i.bak -e 's/^.*KUBECONFIG.*\n?//g' "$shell_profile"
+        if [[ "$(uname -s)" == "Darwin" ]]; then
+            echo "export KUBECONFIG=$kubeconfig_path" >> "$shell_profile"
+        else
+            perl -p -i.bak -e 's/^.*bashrc.*\n?//g' "$shell_profile"
+            echo "source ~/.bashrc" >> "$shell_profile"
+            echo "export KUBECONFIG=$kubeconfig_path" >> "$shell_profile"
+        fi
 
-        chown "$k8s_user":"$k8s_user" "$k8s_user_home/.bashrc" "$k8s_user_home/.bash_profile"
+        chown "$k8s_user":"$k8s_user" "$shell_rc" "$shell_profile"
         printf "         [ok]\n"
     else
-        printf "\r==> user's .bashrc already configured for k8s       [skipping]\n"
+        printf "\r==> user's shell already configured for k8s       [skipping]\n"
     fi
 }
 
@@ -247,6 +277,108 @@ function env_setup_local_cluster {
     fi
 }   
 
+#------------------------------------------------------------------------------
+# Function: install_mac_k8s
+# Description: Ensures a local Kubernetes cluster is running on macOS.
+#              Prefers OrbStack; falls back to Rancher Desktop / Docker Desktop.
+#              Installs OrbStack via Homebrew if nothing is found.
+#------------------------------------------------------------------------------
+function install_mac_k8s {
+    printf "\r==> Checking macOS Kubernetes provider     "
+
+    # Already running — nothing to do
+    if is_cluster_accessible; then
+        printf "                  [ok]\n"
+        return 0
+    fi
+
+    # Docker Desktop — most common on Mac, try first
+    if [[ -d "/Applications/Docker.app" ]]; then
+        printf "\n    Docker Desktop found"
+        # Only use it if already running — don't start it, fall through to OrbStack if not
+        if su - "$k8s_user" -c "docker info" >/dev/null 2>&1; then
+            printf ", checking Kubernetes...\n"
+            if su - "$k8s_user" -c "kubectl config get-contexts docker-desktop" >/dev/null 2>&1; then
+                su - "$k8s_user" -c "kubectl config use-context docker-desktop" >/dev/null 2>&1
+                if is_cluster_accessible; then
+                    printf "    Docker Desktop Kubernetes is ready         [ok]\n"
+                    return 0
+                fi
+            fi
+            printf "    Docker Desktop Kubernetes is not enabled — falling back to OrbStack.\n"
+            printf "    (To use Docker Desktop instead: Settings → Kubernetes → Enable Kubernetes → Apply)\n"
+        else
+            printf " (not running) — trying OrbStack.\n"
+        fi
+    fi
+
+    # OrbStack installed
+    if command -v orb &>/dev/null || [[ -d "/Applications/OrbStack.app" ]]; then
+        printf "\n    OrbStack found, starting Kubernetes engine...\n"
+        su - "$k8s_user" -c "orb start" >/dev/null 2>&1
+        local waited=0
+        while ! is_cluster_accessible && [[ $waited -lt 60 ]]; do
+            sleep 5; (( waited += 5 ))
+            printf "\r    Waiting for OrbStack Kubernetes (%ds)..." "$waited"
+        done
+        printf "\n"
+        if is_cluster_accessible; then
+            printf "    OrbStack Kubernetes is ready               [ok]\n"
+            return 0
+        fi
+        printf "** Error: OrbStack did not become ready.\n"
+        printf "   Open OrbStack → Settings → Kubernetes and ensure it is enabled.\n"
+        exit 1
+    fi
+
+    # Nothing found — install OrbStack via brew
+    printf "\n    No Kubernetes provider found. Installing OrbStack via Homebrew...\n"
+    if ! command -v brew &>/dev/null; then
+        printf "** Error: Homebrew is required. Install from https://brew.sh **\n"
+        exit 1
+    fi
+    su - "$k8s_user" -c "brew install --cask orbstack" >/dev/null 2>&1
+    if [[ $? -ne 0 ]]; then
+        printf "** Error: OrbStack installation failed. Install manually from https://orbstack.dev **\n"
+        exit 1
+    fi
+    su - "$k8s_user" -c "open -a OrbStack" 2>/dev/null
+    printf "\n"
+    printf "    OrbStack installed. Please complete these one-time steps:\n"
+    printf "      1. OrbStack will open — accept any permission prompts\n"
+    printf "      2. In OrbStack Settings, ensure Kubernetes is enabled\n"
+    printf "      3. Re-run: sudo ./run.sh\n\n"
+    exit 0
+}
+
+#------------------------------------------------------------------------------
+# Function: env_setup_mac_cluster
+# Description: Sets up Gazelle on a macOS host using OrbStack / Rancher Desktop /
+#              Docker Desktop as the local Kubernetes provider.
+# Parameters:
+#   $1 - Mode of operation: "deploy", "cleanapps", or "cleanall"
+#------------------------------------------------------------------------------
+function env_setup_mac_cluster {
+    local mode="$1"
+    if [[ "$mode" == "deploy" ]]; then
+        check_resources_ok
+        install_mac_k8s
+        add_hosts
+        check_and_load_helm_repos
+        install_nginx_local_cluster
+        printf "\r==> macOS kubernetes cluster configured for %s\n" "$k8s_user"
+        print_end_message
+    elif [[ "$mode" == "cleanapps" || "$mode" == "cleanall" ]]; then
+        if ! is_cluster_accessible; then
+            printf "** Error: Kubernetes cluster is NOT accessible\n\n"
+            exit 1
+        fi
+    else
+        showUsage
+        exit 1
+    fi
+}
+
 function env_setup_main() {
     local mode="$1"
 
@@ -263,8 +395,10 @@ function env_setup_main() {
     elif [[ "$environment" == "remote" ]]; then
         print_remote_cluster_start_message
         env_setup_remote_cluster "$mode"
+    elif [[ "$environment" == "mac" ]]; then
+        env_setup_mac_cluster "$mode"
     else
-        printf "** Error: Invalid environment type specified: %s. Must be 'local' or 'remote'. **\n" "$environment"
+        printf "** Error: Invalid environment type specified: %s. Must be 'local', 'remote', or 'mac'. **\n" "$environment"
         exit 1
     fi
 } 

--- a/src/environmentSetup/environmentSetup.sh
+++ b/src/environmentSetup/environmentSetup.sh
@@ -140,20 +140,32 @@ function add_hosts {
         local MIFOSXHOSTS=( mifos.$DOMAIN )
         local ALL_GAZELLE_HOSTS=( "${MIFOSXHOSTS[@]}" "${PHEEHOSTS[@]}" "${VNEXTHOSTS[@]}" )
 
-        # Determine which IP to use:
-        #   mac  — Lima VM has its own routable IP; detect it from the k8s node.
-        #   local — k3s runs on the Ubuntu host itself, so 127.0.0.1 is correct.
-        local NODE_IP="127.0.0.1"
-        if [[ "$environment" == "mac" ]]; then
-            local detected_ip
-            detected_ip=$(sudo -u "$k8s_user" kubectl get nodes \
-                -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}' \
-                2>/dev/null)
-            [[ -n "$detected_ip" ]] && NODE_IP="$detected_ip"
-        fi
+        # Determine which IP to use.
+        #
+        # On macOS (Rancher Desktop / Lima), the VM has two external interfaces:
+        #   eth0  — socket_vmnet shared network (e.g. 192.168.5.15) — directly
+        #           routable from the Mac to the VM. This is the correct IP.
+        #   vznat — VZ NAT for outbound internet (e.g. 192.168.68.4) — may
+        #           overlap with the physical LAN and is NOT the right address.
+        #
+        # kubectl get nodes InternalIP returns the eth0 address, which is correct.
+        # Do NOT use the ingress-nginx LoadBalancer IP — k3s svclb picks up vznat
+        # as the external IP, which routes to the wrong place on many networks.
+        #
+        # On Ubuntu (local k3s) the node IS the host, so InternalIP == 127.0.0.1.
+        local NODE_IP
+        NODE_IP=$(sudo -u "$k8s_user" kubectl get nodes \
+            -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}' \
+            2>/dev/null)
+        NODE_IP="${NODE_IP:-127.0.0.1}"
 
         # Remove any existing Gazelle block (idempotent; handles IP changes).
         remove_hosts
+
+        # Also strip any legacy unmarked lines that contain gazelle hostnames
+        # (written by older versions of this script before the marker approach).
+        export GAZELLE_DOMAIN_SUFFIX="$DOMAIN"
+        perl -pi -e 'next if /\Q$ENV{GAZELLE_DOMAIN_SUFFIX}\E/ && !/^#/' /etc/hosts
 
         # Append a fresh, clearly-marked block.  Nothing else in /etc/hosts
         # is read or modified.
@@ -391,6 +403,85 @@ function _configure_mac_vm_limits {
 }
 
 #------------------------------------------------------------------------------
+# Function: _configure_mac_k3s_node_ip
+# Description: Configures k3s inside the Rancher Desktop Lima VM to bind to
+#              the socket_vmnet (eth0) interface rather than the vznat interface.
+#
+#              Lima has two external interfaces:
+#                eth0  (192.168.5.x) — socket_vmnet, directly routable from Mac
+#                vznat (192.168.68.x) — VZ NAT for internet; overlaps with many
+#                                       physical LAN subnets, causing routing
+#                                       ambiguity on the Mac side.
+#
+#              Without this fix, k3s svclb binds to the vznat IP which the Mac
+#              may route to a physical LAN device instead of the Lima VM.
+#
+#              Writes /etc/rancher/k3s/config.yaml inside the VM (persists on
+#              the VM disk across restarts) and restarts k3s.  Idempotent.
+#------------------------------------------------------------------------------
+function _configure_mac_k3s_node_ip {
+    local rdctl
+    if ! rdctl=$(_find_rdctl); then
+        printf "    Warning: rdctl not found — skipping k3s node-ip config\n"
+        return 0
+    fi
+
+    # Detect eth0 IP inside the Lima VM (socket_vmnet, directly reachable from Mac)
+    local eth0_ip
+    eth0_ip=$(sudo -u "$k8s_user" "$rdctl" shell ip -4 addr show eth0 2>/dev/null \
+        | awk '/inet /{print $2}' | cut -d'/' -f1)
+
+    if [[ -z "$eth0_ip" ]]; then
+        printf "    Warning: could not detect Lima VM eth0 IP — skipping k3s node-ip config\n"
+        return 0
+    fi
+
+    printf "    Configuring k3s node-ip to %s (socket_vmnet eth0)...\n" "$eth0_ip"
+
+    # Idempotent: skip if already configured with this IP
+    local current_ip
+    current_ip=$(sudo -u "$k8s_user" "$rdctl" shell \
+        sudo sh -c 'grep -E "^node-ip:" /etc/rancher/k3s/config.yaml 2>/dev/null' \
+        | awk -F'"' '{print $2}')
+    if [[ "$current_ip" == "$eth0_ip" ]]; then
+        printf "    k3s node-ip already set to %s   [ok]\n" "$eth0_ip"
+        return 0
+    fi
+
+    # Write the config file inside the Lima VM
+    sudo -u "$k8s_user" "$rdctl" shell sudo sh -c \
+        "mkdir -p /etc/rancher/k3s && printf 'node-ip: \"%s\"\nnode-external-ip: \"%s\"\n' '$eth0_ip' '$eth0_ip' > /etc/rancher/k3s/config.yaml" \
+        >/dev/null 2>&1
+
+    # Restart k3s so it picks up the new node-ip config.
+    # Try each init mechanism in turn; fall back to a full VM restart via rdctl.
+    printf "    Restarting k3s...\n"
+    local restarted=false
+    if sudo -u "$k8s_user" "$rdctl" shell sudo rc-service k3s restart >/dev/null 2>&1; then
+        # OpenRC (Alpine Linux — Rancher Desktop Lima VM)
+        restarted=true
+    elif sudo -u "$k8s_user" "$rdctl" shell sudo service k3s restart >/dev/null 2>&1; then
+        restarted=true
+    elif sudo -u "$k8s_user" "$rdctl" shell sudo dinitctl restart k3s >/dev/null 2>&1; then
+        restarted=true
+    else
+        # No init service found — restart the whole VM via rdctl (slowest but reliable)
+        printf "    No k3s service manager found — restarting Rancher Desktop VM...\n"
+        sudo -u "$k8s_user" "$rdctl" shutdown >/dev/null 2>&1 || true
+        sleep 5
+        _start_rancher_desktop
+        restarted=true
+    fi
+
+    # Wait for the cluster to recover
+    if [[ "$restarted" == true ]] && _wait_for_k8s 180; then
+        printf "    k3s node-ip configured              [ok]\n"
+    else
+        printf "    Warning: k3s did not recover within 3 minutes after restart\n"
+    fi
+}
+
+#------------------------------------------------------------------------------
 # Function: _wait_for_k8s
 # Description: Polls until the cluster is accessible or timeout is reached.
 # Parameters:
@@ -526,6 +617,7 @@ function env_setup_mac_cluster {
         check_resources_ok
         install_mac_k8s
         _configure_mac_vm_limits
+        _configure_mac_k3s_node_ip
         ensure_python_venv
         add_hosts
         check_and_load_helm_repos
@@ -533,11 +625,33 @@ function env_setup_mac_cluster {
         printf "\r==> macOS kubernetes cluster configured for %s\n" "$k8s_user"
         print_end_message
     elif [[ "$mode" == "cleanapps" || "$mode" == "cleanall" ]]; then
-        if ! is_cluster_accessible; then
-            printf "** Error: Kubernetes cluster is NOT accessible\n\n"
-            exit 1
+        if is_cluster_accessible; then
+            # Cluster is up — delete namespaces and helm releases cleanly
+            if [[ "$mode" == "cleanapps" ]]; then
+                : # app deletion handled by deleteApps called from commandline.sh
+            else
+                log_step "Removing ingress-nginx"
+                run_as_user "helm uninstall ingress-nginx -n default" >/dev/null 2>&1 || true
+                log_ok
+            fi
+        else
+            if [[ "$mode" == "cleanapps" ]]; then
+                printf "** Error: Kubernetes cluster is NOT accessible\n\n"
+                exit 1
+            else
+                printf "    Warning: Kubernetes cluster is not accessible — skipping namespace cleanup\n"
+            fi
         fi
         remove_hosts
+        if [[ "$mode" == "cleanall" ]]; then
+            # Shut down the Rancher Desktop VM cleanly regardless of cluster state
+            local rdctl
+            if rdctl=$(_find_rdctl); then
+                log_step "Shutting down Rancher Desktop"
+                sudo -u "$k8s_user" "$rdctl" shutdown >/dev/null 2>&1 || true
+                log_ok
+            fi
+        fi
     else
         showUsage
         exit 1

--- a/src/environmentSetup/environmentSetup.sh
+++ b/src/environmentSetup/environmentSetup.sh
@@ -11,10 +11,7 @@ source "$RUN_DIR/src/environmentSetup/k8s.sh" || { echo "FATAL: Could not source
 function install_os_prerequisites {
     printf "\n\r==> Check & install operating system packages"
     if [[ "$(uname -s)" == "Darwin" ]]; then
-        if ! brew_available; then
-            printf "\n** Error: Homebrew is required on macOS. Install from https://brew.sh **\n"
-            exit 1
-        fi
+        _ensure_homebrew
         if ! command -v jq &>/dev/null; then
             logWithVerboseCheck "$debug" debug "jq is not installed. Installing via brew..."
             run_brew install jq >/dev/null 2>&1
@@ -142,33 +139,23 @@ function add_hosts {
 
         # Determine which IP to use.
         #
-        # On macOS (Rancher Desktop / Lima): use the vznat IP (192.168.68.x).
-        #   klipper-lb (k3s's built-in LoadBalancer) uses iptables DNAT to route
-        #   ports 80 and 443 inside the VM — no process actually binds 0.0.0.0:80/443.
-        #   Lima's guestIPMustBeZero=true auto-forwarding therefore never triggers for
-        #   those ports, so 127.0.0.1 does NOT work.
-        #   The vznat interface (192.168.68.x) IS directly reachable from the Mac host
-        #   (including with corporate VPN) and iptables routes port 80/443 traffic
-        #   correctly to the nginx ingress controller.
-        #   socket_vmnet IP (192.168.5.x) is unreliable — blocked by many VPNs.
-        #
-        # On Ubuntu (local k3s): the node IS the host, so InternalIP == 127.0.0.1
-        #   anyway, but we read it from kubectl to be explicit.
+        # For both mac (Colima) and local (k3s on Linux): read the node's InternalIP
+        # directly from kubectl — this is the ground truth for what klipper-lb binds the
+        # nginx LoadBalancer service to.  127.0.0.1 does NOT work on mac because
+        # klipper-lb uses iptables DNAT for ports 80/443, bypassing Lima's port-forwarding.
+        # Asking kubectl is more reliable than inspecting VM interface names, which vary
+        # across Lima/Colima versions and network backends.
         local NODE_IP
+        # The node may have both IPv4 and IPv6 InternalIP addresses; the jsonpath
+        # returns both space-separated.  Filter to the first IPv4 address only.
+        NODE_IP=$(sudo -u "$k8s_user" kubectl get nodes \
+            --kubeconfig "$kubeconfig_path" \
+            -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}' \
+            2>/dev/null \
+            | tr ' ' '\n' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
         if [[ "$environment" == "mac" ]]; then
-            # Get the vznat IP dynamically from the Lima VM.
-            local rdctl
-            rdctl=$(_find_rdctl 2>/dev/null || true)
-            if [[ -n "$rdctl" ]]; then
-                NODE_IP=$(sudo -u "$k8s_user" "$rdctl" shell -- \
-                    ip addr show vznat 2>/dev/null \
-                    | grep 'inet ' | awk '{print $2}' | cut -d/ -f1 2>/dev/null || true)
-            fi
-            NODE_IP="${NODE_IP:-192.168.68.4}"  # fallback to default vznat address
+            NODE_IP="${NODE_IP:-192.168.5.1}"   # fallback: common Colima socket_vmnet node IP
         else
-            NODE_IP=$(sudo -u "$k8s_user" kubectl get nodes \
-                -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}' \
-                2>/dev/null)
             NODE_IP="${NODE_IP:-127.0.0.1}"
         fi
 
@@ -396,30 +383,28 @@ function env_setup_local_cluster {
 #------------------------------------------------------------------------------
 # Function: _configure_mac_vm_limits
 # Description: Increases inotify and file-descriptor kernel limits inside the
-#              Rancher Desktop Lima VM.  Without this, Java/Spring-Boot pods that
+#              Colima Lima VM.  Without this, Java/Spring-Boot pods that
 #              open many fsnotify watchers (bulk-processor, zeebe-broker, etc.)
 #              hit "too many open files" errors.  Settings are applied immediately
 #              and written to /etc/sysctl.d/99-gazelle.conf so they survive Lima
 #              VM restarts.  Idempotent: safe to call on every run.
 #------------------------------------------------------------------------------
 function _configure_mac_vm_limits {
-    local rdctl
-    if ! rdctl=$(_find_rdctl); then
-        printf "    Warning: rdctl not found — skipping VM kernel limit tuning\n"
+    local colima
+    if ! colima=$(_find_colima); then
+        printf "    Warning: colima not found — skipping VM kernel limit tuning\n"
         return 0
     fi
 
     printf "    Configuring VM kernel limits (inotify / file descriptors)...\n"
 
     # Apply immediately (takes effect for all running and new processes).
-    # rdctl shell passes remaining args directly to the VM shell — no -- separator.
-    sudo -u "$k8s_user" "$rdctl" shell sudo sysctl -w fs.inotify.max_user_watches=1048576  >/dev/null 2>&1 || true
-    sudo -u "$k8s_user" "$rdctl" shell sudo sysctl -w fs.inotify.max_user_instances=8192   >/dev/null 2>&1 || true
-    sudo -u "$k8s_user" "$rdctl" shell sudo sysctl -w fs.file-max=2097152                  >/dev/null 2>&1 || true
+    sudo -u "$k8s_user" "$colima" exec -- sudo sysctl -w fs.inotify.max_user_watches=1048576  >/dev/null 2>&1 || true
+    sudo -u "$k8s_user" "$colima" exec -- sudo sysctl -w fs.inotify.max_user_instances=8192   >/dev/null 2>&1 || true
+    sudo -u "$k8s_user" "$colima" exec -- sudo sysctl -w fs.file-max=2097152                  >/dev/null 2>&1 || true
 
     # Persist across Lima VM restarts (idempotent: only write if not already present).
-    # Use a quoted sh -c string so the embedded newlines and redirection stay intact.
-    sudo -u "$k8s_user" "$rdctl" shell sudo sh -c \
+    sudo -u "$k8s_user" "$colima" exec -- sudo sh -c \
         'grep -q max_user_watches /etc/sysctl.d/99-gazelle.conf 2>/dev/null || printf "fs.inotify.max_user_watches=1048576\nfs.inotify.max_user_instances=8192\nfs.file-max=2097152\n" > /etc/sysctl.d/99-gazelle.conf' \
         >/dev/null 2>&1 || true
 
@@ -428,7 +413,7 @@ function _configure_mac_vm_limits {
 
 #------------------------------------------------------------------------------
 # Function: _configure_mac_k3s_node_ip
-# Description: Configures k3s inside the Rancher Desktop Lima VM to bind to
+# Description: Configures k3s inside the Colima Lima VM to bind to
 #              the socket_vmnet (eth0) interface rather than the vznat interface.
 #
 #              Lima has two external interfaces:
@@ -444,15 +429,15 @@ function _configure_mac_vm_limits {
 #              the VM disk across restarts) and restarts k3s.  Idempotent.
 #------------------------------------------------------------------------------
 function _configure_mac_k3s_node_ip {
-    local rdctl
-    if ! rdctl=$(_find_rdctl); then
-        printf "    Warning: rdctl not found — skipping k3s node-ip config\n"
+    local colima
+    if ! colima=$(_find_colima); then
+        printf "    Warning: colima not found — skipping k3s node-ip config\n"
         return 0
     fi
 
     # Detect eth0 IP inside the Lima VM (socket_vmnet, directly reachable from Mac)
     local eth0_ip
-    eth0_ip=$(sudo -u "$k8s_user" "$rdctl" shell ip -4 addr show eth0 2>/dev/null \
+    eth0_ip=$(sudo -u "$k8s_user" "$colima" exec -- ip -4 addr show eth0 2>/dev/null \
         | awk '/inet /{print $2}' | cut -d'/' -f1)
 
     if [[ -z "$eth0_ip" ]]; then
@@ -464,7 +449,7 @@ function _configure_mac_k3s_node_ip {
 
     # Idempotent: skip if already configured with this IP
     local current_ip
-    current_ip=$(sudo -u "$k8s_user" "$rdctl" shell \
+    current_ip=$(sudo -u "$k8s_user" "$colima" exec -- \
         sudo sh -c 'grep -E "^node-ip:" /etc/rancher/k3s/config.yaml 2>/dev/null' \
         | awk -F'"' '{print $2}')
     if [[ "$current_ip" == "$eth0_ip" ]]; then
@@ -473,27 +458,27 @@ function _configure_mac_k3s_node_ip {
     fi
 
     # Write the config file inside the Lima VM
-    sudo -u "$k8s_user" "$rdctl" shell sudo sh -c \
+    sudo -u "$k8s_user" "$colima" exec -- sudo sh -c \
         "mkdir -p /etc/rancher/k3s && printf 'node-ip: \"%s\"\nnode-external-ip: \"%s\"\n' '$eth0_ip' '$eth0_ip' > /etc/rancher/k3s/config.yaml" \
         >/dev/null 2>&1
 
     # Restart k3s so it picks up the new node-ip config.
-    # Try each init mechanism in turn; fall back to a full VM restart via rdctl.
+    # Try each init mechanism in turn; fall back to a full VM restart.
     printf "    Restarting k3s...\n"
     local restarted=false
-    if sudo -u "$k8s_user" "$rdctl" shell sudo rc-service k3s restart >/dev/null 2>&1; then
-        # OpenRC (Alpine Linux — Rancher Desktop Lima VM)
+    if sudo -u "$k8s_user" "$colima" exec -- sudo rc-service k3s restart >/dev/null 2>&1; then
+        # OpenRC (Alpine Linux — Colima Lima VM)
         restarted=true
-    elif sudo -u "$k8s_user" "$rdctl" shell sudo service k3s restart >/dev/null 2>&1; then
+    elif sudo -u "$k8s_user" "$colima" exec -- sudo service k3s restart >/dev/null 2>&1; then
         restarted=true
-    elif sudo -u "$k8s_user" "$rdctl" shell sudo dinitctl restart k3s >/dev/null 2>&1; then
+    elif sudo -u "$k8s_user" "$colima" exec -- sudo dinitctl restart k3s >/dev/null 2>&1; then
         restarted=true
     else
-        # No init service found — restart the whole VM via rdctl (slowest but reliable)
-        printf "    No k3s service manager found — restarting Rancher Desktop VM...\n"
-        sudo -u "$k8s_user" "$rdctl" shutdown >/dev/null 2>&1 || true
+        # No init service found — restart the whole VM (slowest but reliable)
+        printf "    No k3s service manager found — restarting Colima VM...\n"
+        sudo -u "$k8s_user" "$colima" stop >/dev/null 2>&1 || true
         sleep 5
-        _start_rancher_desktop
+        _start_colima
         restarted=true
     fi
 
@@ -508,8 +493,8 @@ function _configure_mac_k3s_node_ip {
 #------------------------------------------------------------------------------
 # Function: _wait_for_k8s
 # Description: Polls until the cluster is accessible or timeout is reached.
-#              Also retries 'kubectl config use-context rancher-desktop' on each
-#              iteration because Rancher Desktop writes its kubeconfig entry
+#              Also retries 'kubectl config use-context colima' on each
+#              iteration because Colima writes its kubeconfig entry
 #              asynchronously after starting — the context may not exist when
 #              the loop begins.
 # Parameters:
@@ -519,9 +504,9 @@ function _wait_for_k8s {
     local timeout="${1:-240}"
     local waited=0
     while ! is_cluster_accessible && [[ $waited -lt $timeout ]]; do
-        su - "$k8s_user" -c "kubectl config use-context rancher-desktop" >/dev/null 2>&1 || true
+        su - "$k8s_user" -c "kubectl config use-context colima" >/dev/null 2>&1 || true
         sleep 5; (( waited += 5 ))
-        printf "\r    Waiting for Rancher Desktop Kubernetes (%ds/%ds)..." "$waited" "$timeout"
+        printf "\r    Waiting for Colima Kubernetes (%ds/%ds)..." "$waited" "$timeout"
     done
     printf "\n"
     is_cluster_accessible
@@ -529,182 +514,208 @@ function _wait_for_k8s {
 
 #------------------------------------------------------------------------------
 # Function: _recover_mac_k8s
-# Description: Attempts automatic recovery when the Rancher Desktop VM is
+# Description: Attempts automatic recovery when the Colima VM is
 #              running but the k3s cluster is not reachable.
 #
 #              Tier 1 (fast ~15s): removes any stale /etc/rancher/k3s/config.yaml
-#              written by previous gazelle runs (a leftover causes a duplicate
-#              --node-ip that crashes the kubelet) and restarts k3s in place.
+#              written by previous gazelle runs and restarts k3s in place.
 #
 #              Tier 2 (slower ~2min): if k3s is still unreachable, performs a
-#              full rdctl shutdown + start to reset the VM cleanly.
+#              full colima stop + start to reset the VM cleanly.
 #
 # Returns: 0 if cluster becomes accessible, 1 if recovery failed.
 #------------------------------------------------------------------------------
 function _recover_mac_k8s {
-    local rdctl
-    if ! rdctl=$(_find_rdctl); then
-        printf "    Warning: rdctl not found — cannot attempt auto-recovery\n"
+    local colima
+    if ! colima=$(_find_colima); then
+        printf "    Warning: colima not found — cannot attempt auto-recovery\n"
         return 1
     fi
 
     # ---- Tier 1: clean stale config artifact + in-place k3s restart ----
     printf "    Auto-recovery tier 1: restarting k3s inside the VM...\n"
-    sudo -u "$k8s_user" "$rdctl" shell sudo rm -f /etc/rancher/k3s/config.yaml >/dev/null 2>&1 || true
-    sudo -u "$k8s_user" "$rdctl" shell sudo rc-service k3s restart >/dev/null 2>&1 || \
-        sudo -u "$k8s_user" "$rdctl" shell sudo service k3s restart >/dev/null 2>&1 || true
+    sudo -u "$k8s_user" "$colima" exec -- sudo rm -f /etc/rancher/k3s/config.yaml >/dev/null 2>&1 || true
+    sudo -u "$k8s_user" "$colima" exec -- sudo rc-service k3s restart >/dev/null 2>&1 || \
+        sudo -u "$k8s_user" "$colima" exec -- sudo service k3s restart >/dev/null 2>&1 || true
 
-    su - "$k8s_user" -c "kubectl config use-context rancher-desktop" >/dev/null 2>&1 || true
+    su - "$k8s_user" -c "kubectl config use-context colima" >/dev/null 2>&1 || true
     if _wait_for_k8s 60; then
         printf "    Auto-recovery tier 1 succeeded              [ok]\n"
         return 0
     fi
 
-    # ---- Tier 2: full VM restart via rdctl ----
-    printf "    Auto-recovery tier 2: restarting Rancher Desktop VM...\n"
-    sudo -u "$k8s_user" "$rdctl" shutdown >/dev/null 2>&1 || true
+    # ---- Tier 2: full VM restart ----
+    printf "    Auto-recovery tier 2: restarting Colima VM...\n"
+    sudo -u "$k8s_user" "$colima" stop >/dev/null 2>&1 || true
     sleep 5
-    _start_rancher_desktop
-    su - "$k8s_user" -c "kubectl config use-context rancher-desktop" >/dev/null 2>&1 || true
+    _start_colima
+    su - "$k8s_user" -c "kubectl config use-context colima" >/dev/null 2>&1 || true
     if _wait_for_k8s 240; then
         printf "    Auto-recovery tier 2 succeeded              [ok]\n"
         return 0
     fi
 
     printf "** Auto-recovery failed. Try:\n"
-    printf "   1. Open Rancher Desktop and check for error messages.\n"
-    printf "   2. If the problem persists, reset Rancher Desktop from its Troubleshooting menu.\n"
+    printf "   1. Run: colima stop && colima start --kubernetes --kubernetes-version v1.30.0+k3s1 --runtime containerd --memory 16 --cpu 4\n"
+    printf "   2. If the problem persists, run: colima delete && re-run ./run.sh\n"
     return 1
 }
 
 #------------------------------------------------------------------------------
 # Function: install_mac_k8s
-# Description: Ensures Rancher Desktop (k3s) is running on macOS.
-#              Rancher Desktop is the only supported provider — it uses k3s,
+# Description: Ensures Colima (k3s) is running on macOS.
+#              Colima is the supported provider — it uses k3s via Lima,
 #              matching the Ubuntu environment and avoiding image pull issues.
 #              Errors if another Kubernetes provider is found running.
 #------------------------------------------------------------------------------
 #------------------------------------------------------------------------------
-# Function: _find_rdctl
-# Description: Locates the rdctl binary at known macOS install paths.
-#              Rancher Desktop puts rdctl inside the app bundle and symlinks
-#              it to ~/.rd/bin, but neither is on PATH when running via sudo.
+# Function: _ensure_homebrew
+# Description: Auto-installs Homebrew if not present. Safe to call as root
+#              (uses sudo -u $k8s_user internally). Exits on failure.
 #------------------------------------------------------------------------------
-function _find_rdctl {
-    local user_home
-    user_home=$(eval echo "~$k8s_user")
+function _ensure_homebrew {
+    if brew_available; then
+        return 0
+    fi
+    printf "    Homebrew not found — installing (this may take a few minutes)...\n"
+    sudo -u "$k8s_user" /bin/bash -c \
+        "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)" \
+        </dev/null
+    export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
+    if ! brew_available; then
+        printf "** Error: Homebrew installation failed. Install manually from https://brew.sh **\n"
+        exit 1
+    fi
+    printf "    Homebrew installed                       [ok]\n"
+}
+
+#------------------------------------------------------------------------------
+# Function: _find_colima
+# Description: Locates the colima binary at known macOS install paths.
+#              colima is not on PATH when running via sudo, so we check
+#              known Homebrew locations explicitly.
+#------------------------------------------------------------------------------
+function _find_colima {
     for candidate in \
-        "$user_home/.rd/bin/rdctl" \
-        "/Applications/Rancher Desktop.app/Contents/Resources/resources/darwin/bin/rdctl" \
-        "/usr/local/bin/rdctl" \
-        "/opt/homebrew/bin/rdctl"; do
+        "/opt/homebrew/bin/colima" \
+        "/usr/local/bin/colima"; do
         if [[ -x "$candidate" ]]; then
             printf '%s' "$candidate"
             return 0
         fi
     done
+    if command -v colima &>/dev/null; then
+        command -v colima; return 0
+    fi
     return 1
 }
 
 #------------------------------------------------------------------------------
-# Function: _start_rancher_desktop
-# Description: Starts Rancher Desktop via rdctl with standard Gazelle settings.
+# Function: _start_colima
+# Description: Starts Colima with k3s and containerd for standard Gazelle use.
+#              k3s version matches the Ubuntu local environment.
+#              containerd is used (not Docker) for consistency.
 #------------------------------------------------------------------------------
-function _start_rancher_desktop {
-    local rdctl
-    if ! rdctl=$(_find_rdctl); then
-        printf "** Error: rdctl not found. Rancher Desktop may not have installed correctly.\n"
+function _start_colima {
+    local colima
+    if ! colima=$(_find_colima); then
+        printf "** Error: colima not found. Install with: brew install colima\n"
         exit 1
     fi
-    # --kubernetes.options.traefik=false: Rancher Desktop ships Traefik by default
-    # but it binds ports 80/443, conflicting with the ingress-nginx the script installs.
-    sudo -u "$k8s_user" "$rdctl" start \
-        --application.start-in-background \
-        --kubernetes.enabled \
-        --kubernetes.version "1.30.0" \
-        --container-engine.name containerd \
-        --virtual-machine.memory-in-gb 16 \
-        --virtual-machine.number-cpus 4 \
-        --kubernetes.options.traefik=false
+    # Pass Homebrew PATH explicitly — sudo strips PATH so colima's internal
+    # kubectl dependency check fails without it.
+    sudo -u "$k8s_user" env PATH="/opt/homebrew/bin:/usr/local/bin:$PATH" \
+        "$colima" start \
+        --kubernetes \
+        --kubernetes-version "v1.30.0+k3s1" \
+        --runtime docker \
+        --memory 16 \
+        --cpu 4 \
+        --network-address
 }
 
 function install_mac_k8s {
     printf "\r==> Checking macOS Kubernetes provider\n"
+    _ensure_homebrew
 
-    # Ensure kubeconfig context is rancher-desktop if available (may be stale from prior provider)
-    su - "$k8s_user" -c "kubectl config use-context rancher-desktop" >/dev/null 2>&1 || true
+    # socket_vmnet sudoers: required for colima --network-address to get a routable VM IP.
+    # colima sudoers emits the necessary /etc/sudoers.d snippet; idempotent on every run.
+    local colima_bin
+    if colima_bin=$(_find_colima); then
+        sudo -u "$k8s_user" "$colima_bin" sudoers 2>/dev/null \
+            | tee /etc/sudoers.d/colima >/dev/null 2>&1 || true
+    fi
 
-    # If cluster is accessible, verify it is Rancher Desktop
+    # Ensure kubeconfig context is colima if available (may be stale from prior provider)
+    su - "$k8s_user" -c "kubectl config use-context colima" >/dev/null 2>&1 || true
+
+    # If cluster is accessible, verify it is Colima
     if is_cluster_accessible; then
         local current_context
         current_context=$(su - "$k8s_user" -c "kubectl config current-context" 2>/dev/null)
-        if [[ "$current_context" != "rancher-desktop" ]]; then
-            printf "** Error: A Kubernetes cluster is already running but it is not Rancher Desktop.\n"
+        if [[ "$current_context" != "colima" ]]; then
+            printf "** Error: A Kubernetes cluster is already running but it is not Colima.\n"
             printf "   Current context: %s\n" "$current_context"
-            printf "   mifos-gazelle requires Rancher Desktop on macOS.\n"
+            printf "   mifos-gazelle requires Colima on macOS.\n"
             printf "   Please stop the other provider and re-run.\n"
             exit 1
         fi
-        printf "    Rancher Desktop Kubernetes is ready        [ok]\n"
+        printf "    Colima Kubernetes is ready                 [ok]\n"
         return 0
     fi
 
     # VM may already be running in a broken state (e.g. kubelet crashed due to a
     # stale config artifact from a previous run).  Try auto-recovery before
     # attempting a full start, so we don't waste time shutting down a live VM.
-    local rdctl
-    if rdctl=$(_find_rdctl); then
+    local colima
+    if colima=$(_find_colima); then
         local vm_state
-        vm_state=$(sudo -u "$k8s_user" "$rdctl" api /v1/backend_state 2>/dev/null \
-            | python3 -c "import sys,json; print(json.load(sys.stdin).get('vmState',''))" 2>/dev/null || true)
-        if [[ "$vm_state" == "STARTED" ]]; then
+        vm_state=$(sudo -u "$k8s_user" "$colima" list --json 2>/dev/null \
+            | python3 -c "import sys,json; items=json.load(sys.stdin); print(items[0].get('status','') if items else '')" 2>/dev/null || true)
+        if [[ "$vm_state" == "Running" ]]; then
             printf "    VM is running but cluster is unreachable — attempting auto-recovery...\n"
             if _recover_mac_k8s; then
-                printf "    Rancher Desktop Kubernetes is ready        [ok]\n"
+                printf "    Colima Kubernetes is ready                 [ok]\n"
                 return 0
             fi
             # Recovery failed — fall through to a clean start below
         fi
     fi
 
-    # Rancher Desktop installed but not running (or recovery failed) — start it
-    if [[ -d "/Applications/Rancher Desktop.app" ]]; then
-        printf "    Rancher Desktop found, starting...\n"
-        _start_rancher_desktop
-        # Ensure kubeconfig points at rancher-desktop (may be stale from a previous provider)
-        su - "$k8s_user" -c "kubectl config use-context rancher-desktop" >/dev/null 2>&1 || true
+    # Colima installed but not running (or recovery failed) — start it
+    if colima=$(_find_colima); then
+        printf "    Colima found, starting...\n"
+        _start_colima
+        # Ensure kubeconfig points at colima (may be stale from a previous provider)
+        su - "$k8s_user" -c "kubectl config use-context colima" >/dev/null 2>&1 || true
         if _wait_for_k8s 240; then
-            printf "    Rancher Desktop Kubernetes is ready        [ok]\n"
+            printf "    Colima Kubernetes is ready                 [ok]\n"
             return 0
         fi
-        printf "** Error: Rancher Desktop did not become ready.\n"
-        printf "   Open Rancher Desktop and check for errors.\n"
+        printf "** Error: Colima did not become ready.\n"
+        printf "   Run: colima list    and check for errors.\n"
         exit 1
     fi
 
-    # Not installed — install via Homebrew then start
-    printf "    Rancher Desktop not found. Installing via Homebrew...\n"
-    if ! brew_available; then
-        printf "** Error: Homebrew is required. Install from https://brew.sh **\n"
+    # Not installed — install Colima + Docker tooling via Homebrew then start
+    printf "    Colima not found. Installing via Homebrew (this may take a few minutes)...\n"
+    if ! sudo -u "$k8s_user" brew install colima docker docker-compose; then
+        printf "** Error: Colima installation failed.\n"
         exit 1
     fi
-    if ! sudo -u "$k8s_user" brew install --cask rancher; then
-        printf "** Error: Rancher Desktop installation failed.\n"
+    printf "    Starting Colima with Kubernetes (this may take a few minutes)...\n"
+    _start_colima
+    if ! _wait_for_k8s 300; then
+        printf "** Error: Colima did not become ready.\n"
         exit 1
     fi
-    printf "    Configuring and starting Rancher Desktop (this may take a few minutes)...\n"
-    _start_rancher_desktop
-    if ! _wait_for_k8s 240; then
-        printf "** Error: Rancher Desktop did not become ready.\n"
-        exit 1
-    fi
-    printf "    Rancher Desktop Kubernetes is ready        [ok]\n"
+    printf "    Colima Kubernetes is ready                 [ok]\n"
 }
 
 #------------------------------------------------------------------------------
 # Function: env_setup_mac_cluster
-# Description: Sets up Gazelle on a macOS host using Rancher Desktop (k3s) as
-#              the preferred Kubernetes provider, with Docker Desktop as fallback.
+# Description: Sets up Gazelle on a macOS host using Colima (k3s) as the
+#              Kubernetes provider.
 # Parameters:
 #   $1 - Mode of operation: "deploy", "cleanapps", or "cleanall"
 #------------------------------------------------------------------------------
@@ -715,9 +726,8 @@ function env_setup_mac_cluster {
         install_mac_k8s
         _configure_mac_vm_limits
         # NOTE: _configure_mac_k3s_node_ip is intentionally NOT called here.
-        # Rancher Desktop already sets --node-ip via /etc/conf.d/k3s ADDITIONAL_ARGS.
-        # Writing node-ip again to /etc/rancher/k3s/config.yaml produces a duplicate
-        # "192.168.x.x,192.168.x.x" value that causes the kubelet to crash.
+        # The default Colima k3s setup works correctly without explicit node-ip binding.
+        # The function exists and is updated for potential future use if needed.
         ensure_python_venv
         add_hosts
         check_and_load_helm_repos
@@ -744,14 +754,26 @@ function env_setup_mac_cluster {
         fi
         remove_hosts
         if [[ "$mode" == "cleanall" ]]; then
-            # Remove the k3s config.yaml written by previous gazelle runs so that a
-            # subsequent deploy starts with a clean slate (no stale node-ip override).
-            local rdctl
-            if rdctl=$(_find_rdctl); then
-                sudo -u "$k8s_user" "$rdctl" shell sudo rm -f /etc/rancher/k3s/config.yaml >/dev/null 2>&1 || true
-                log_step "Shutting down Rancher Desktop"
-                sudo -u "$k8s_user" "$rdctl" shutdown >/dev/null 2>&1 || true
+            # Delete the Colima VM entirely — full wipe of k3s state and images.
+            # colima delete stops the VM first if running, then removes the disk.
+            local colima
+            if colima=$(_find_colima); then
+                log_step "Deleting Colima VM (full cleanall)"
+                # --yes skips the interactive confirmation prompt.
+                # Stop first (ignoring errors if already stopped) so containerd
+                # shuts down cleanly before delete removes the disk; this avoids
+                # the ttrpc/JSON errors that occur when delete tries to stop a
+                # partially-running VM itself.
+                sudo -u "$k8s_user" "$colima" stop 2>/dev/null || true
+                sudo -u "$k8s_user" "$colima" delete --yes 2>/dev/null || true
+                # colima delete leaves behind ~/.colima (named disks, Lima config, SSH
+                # config) which can hold 20-30 GB of disk images. Remove the entire
+                # directory for a true cleanall — Colima recreates it on next start.
+                rm -rf "$k8s_user_home/.colima" 2>/dev/null || true
                 log_ok
+                # Remove stale kubeconfig and Docker contexts left by the deleted VM.
+                su - "$k8s_user" -c "kubectl config delete-context colima" >/dev/null 2>&1 || true
+                sudo -u "$k8s_user" docker context rm colima >/dev/null 2>&1 || true
             fi
         fi
     else

--- a/src/environmentSetup/environmentSetup.sh
+++ b/src/environmentSetup/environmentSetup.sh
@@ -57,34 +57,112 @@ function install_os_prerequisites {
 }
 
 #------------------------------------------------------------------------------
-# Function: add_hosts   
+# Function: ensure_python_venv
+# Description: Creates a project-local Python virtualenv at $RUN_DIR/.venv and
+#              installs the packages listed in src/utils/data-loading/requirements.txt.
+#              Uses the venv for all data-loading scripts so no system or
+#              Homebrew Python packages are modified.
+#              Idempotent: skips creation/install if already up to date.
+#------------------------------------------------------------------------------
+function ensure_python_venv {
+    local venv_dir="$RUN_DIR/.venv"
+    local requirements="$RUN_DIR/src/utils/data-loading/requirements.txt"
+
+    printf "\r==> Python virtualenv for data-loading scripts  "
+
+    # Create the venv as the k8s_user so they can run scripts without sudo
+    if [[ ! -x "$venv_dir/bin/python3" ]]; then
+        run_as_user "python3 -m venv \"$venv_dir\""
+        if [[ $? -ne 0 ]]; then
+            printf "\n** Error: failed to create Python venv at $venv_dir\n"
+            exit 1
+        fi
+    fi
+
+    # Install/upgrade requirements (pip will skip packages already at the right version)
+    run_as_user "\"$venv_dir/bin/pip\" install --quiet --upgrade pip"
+    run_as_user "\"$venv_dir/bin/pip\" install --quiet -r \"$requirements\""
+    if [[ $? -ne 0 ]]; then
+        printf "\n** Error: failed to install Python requirements\n"
+        exit 1
+    fi
+
+    printf "        [ok]\n"
+}
+
+#------------------------------------------------------------------------------
+# Function: add_hosts
 # Description: Updates the local /etc/hosts file with entries for Mifos Gazelle services when using a local cluster.
+#------------------------------------------------------------------------------
+# Marker used to bracket all Gazelle-managed /etc/hosts entries.
+# The remove_hosts function deletes everything between these two lines.
+GAZELLE_HOSTS_BEGIN="# BEGIN mifos-gazelle"
+GAZELLE_HOSTS_END="# END mifos-gazelle"
+
+#------------------------------------------------------------------------------
+# Function: remove_hosts
+# Description: Removes the mifos-gazelle block from /etc/hosts.
+#              Safe to call even if the block is not present.
+#------------------------------------------------------------------------------
+function remove_hosts {
+    perl -i -ne '
+        if (/^\Q'"$GAZELLE_HOSTS_BEGIN"'\E/) { $skip=1 }
+        print unless $skip;
+        if (/^\Q'"$GAZELLE_HOSTS_END"'\E/)   { $skip=0 }
+    ' /etc/hosts
+}
+
+#------------------------------------------------------------------------------
+# Function: add_hosts
+# Description: Writes a clearly-marked block of Gazelle service hostnames into
+#              /etc/hosts.  Any existing block is replaced so the function is
+#              idempotent and handles IP changes (e.g. after a VM restart).
+#              The block is self-contained — no other lines are touched.
 #------------------------------------------------------------------------------
 function add_hosts {
     if [[ "$environment" == "local" || "$environment" == "mac" ]]; then
         printf "==> Mifos-gazelle: update local hosts file  "
-        
-        # Use GAZELLE_DOMAIN variable, with fallback to default
-        DOMAIN="${GAZELLE_DOMAIN:-mifos.gazelle.test}"
-        
-        VNEXTHOSTS=( mongohost.$DOMAIN mongo-express.$DOMAIN \
-        vnextadmin.$DOMAIN elasticsearch.$DOMAIN kibana.$DOMAIN redpanda-console.$DOMAIN \
-        mongoexpress.$DOMAIN fspiop.$DOMAIN bluebank.$DOMAIN greenbank.$DOMAIN  )
-        
-        PHEEHOSTS=( ops.$DOMAIN ops-bk.$DOMAIN \
-        bulk-processor.$DOMAIN connector-bulk.$DOMAIN messagegateway.$DOMAIN \
-        minio-console.$DOMAIN bill-pay.$DOMAIN channel.$DOMAIN \
-        channel-gsma.$DOMAIN crm.$DOMAIN mockpayment.$DOMAIN \
-        mojaloop.$DOMAIN identity-mapper.$DOMAIN vouchers.$DOMAIN \
-        zeebeops.$DOMAIN zeebe-operate.$DOMAIN zeebe-gateway.$DOMAIN \
-        notifications.$DOMAIN )
-        
-        MIFOSXHOSTS=( mifos.$DOMAIN )
-        
-        ALLHOSTS=( "127.0.0.1" "localhost" "${MIFOSXHOSTS[@]}" "${PHEEHOSTS[@]}" "${VNEXTHOSTS[@]}" )
-        export ENDPOINTS=`echo ${ALLHOSTS[*]}`
-        perl -pi -e 's/^(127\.0\.0\.1\s+)(.*)/$1localhost/' /etc/hosts
-        perl -p -i.bak -e 's/127\.0\.0\.1.*localhost.*$/$ENV{ENDPOINTS} /' /etc/hosts
+
+        local DOMAIN="${GAZELLE_DOMAIN:-mifos.gazelle.test}"
+
+        local VNEXTHOSTS=( mongohost.$DOMAIN mongo-express.$DOMAIN \
+            vnextadmin.$DOMAIN elasticsearch.$DOMAIN kibana.$DOMAIN redpanda-console.$DOMAIN \
+            mongoexpress.$DOMAIN fspiop.$DOMAIN bluebank.$DOMAIN greenbank.$DOMAIN )
+
+        local PHEEHOSTS=( ops.$DOMAIN ops-bk.$DOMAIN \
+            bulk-processor.$DOMAIN connector-bulk.$DOMAIN messagegateway.$DOMAIN \
+            minio-console.$DOMAIN bill-pay.$DOMAIN channel.$DOMAIN \
+            channel-gsma.$DOMAIN crm.$DOMAIN mockpayment.$DOMAIN \
+            mojaloop.$DOMAIN identity-mapper.$DOMAIN vouchers.$DOMAIN \
+            zeebeops.$DOMAIN zeebe-operate.$DOMAIN zeebe-gateway.$DOMAIN \
+            notifications.$DOMAIN )
+
+        local MIFOSXHOSTS=( mifos.$DOMAIN )
+        local ALL_GAZELLE_HOSTS=( "${MIFOSXHOSTS[@]}" "${PHEEHOSTS[@]}" "${VNEXTHOSTS[@]}" )
+
+        # Determine which IP to use:
+        #   mac  — Lima VM has its own routable IP; detect it from the k8s node.
+        #   local — k3s runs on the Ubuntu host itself, so 127.0.0.1 is correct.
+        local NODE_IP="127.0.0.1"
+        if [[ "$environment" == "mac" ]]; then
+            local detected_ip
+            detected_ip=$(sudo -u "$k8s_user" kubectl get nodes \
+                -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}' \
+                2>/dev/null)
+            [[ -n "$detected_ip" ]] && NODE_IP="$detected_ip"
+        fi
+
+        # Remove any existing Gazelle block (idempotent; handles IP changes).
+        remove_hosts
+
+        # Append a fresh, clearly-marked block.  Nothing else in /etc/hosts
+        # is read or modified.
+        {
+            printf '\n%s\n' "$GAZELLE_HOSTS_BEGIN"
+            printf '%s %s\n' "$NODE_IP" "${ALL_GAZELLE_HOSTS[*]}"
+            printf '%s\n' "$GAZELLE_HOSTS_END"
+        } >> /etc/hosts
+
     else
         printf "==> Skipping /etc/hosts modification for remote cluster \n"
     fi
@@ -241,6 +319,7 @@ function env_setup_local_cluster {
     if [[ "$mode" == "deploy" ]]; then
         check_resources_ok
         install_os_prerequisites
+        ensure_python_venv
         add_hosts
 
         if ! is_local_cluster_installed; then
@@ -270,12 +349,46 @@ function env_setup_local_cluster {
             exit 0
         fi
         delete_k8s_local_cluster
+        remove_hosts
         print_end_message_delete
     else
         showUsage
         exit 1
     fi
 }   
+
+#------------------------------------------------------------------------------
+# Function: _configure_mac_vm_limits
+# Description: Increases inotify and file-descriptor kernel limits inside the
+#              Rancher Desktop Lima VM.  Without this, Java/Spring-Boot pods that
+#              open many fsnotify watchers (bulk-processor, zeebe-broker, etc.)
+#              hit "too many open files" errors.  Settings are applied immediately
+#              and written to /etc/sysctl.d/99-gazelle.conf so they survive Lima
+#              VM restarts.  Idempotent: safe to call on every run.
+#------------------------------------------------------------------------------
+function _configure_mac_vm_limits {
+    local rdctl
+    if ! rdctl=$(_find_rdctl); then
+        printf "    Warning: rdctl not found — skipping VM kernel limit tuning\n"
+        return 0
+    fi
+
+    printf "    Configuring VM kernel limits (inotify / file descriptors)...\n"
+
+    # Apply immediately (takes effect for all running and new processes).
+    # rdctl shell passes remaining args directly to the VM shell — no -- separator.
+    sudo -u "$k8s_user" "$rdctl" shell sudo sysctl -w fs.inotify.max_user_watches=1048576  >/dev/null 2>&1 || true
+    sudo -u "$k8s_user" "$rdctl" shell sudo sysctl -w fs.inotify.max_user_instances=8192   >/dev/null 2>&1 || true
+    sudo -u "$k8s_user" "$rdctl" shell sudo sysctl -w fs.file-max=2097152                  >/dev/null 2>&1 || true
+
+    # Persist across Lima VM restarts (idempotent: only write if not already present).
+    # Use a quoted sh -c string so the embedded newlines and redirection stay intact.
+    sudo -u "$k8s_user" "$rdctl" shell sudo sh -c \
+        'grep -q max_user_watches /etc/sysctl.d/99-gazelle.conf 2>/dev/null || printf "fs.inotify.max_user_watches=1048576\nfs.inotify.max_user_instances=8192\nfs.file-max=2097152\n" > /etc/sysctl.d/99-gazelle.conf' \
+        >/dev/null 2>&1 || true
+
+    printf "    VM kernel limits configured            [ok]\n"
+}
 
 #------------------------------------------------------------------------------
 # Function: _wait_for_k8s
@@ -333,17 +446,23 @@ function _start_rancher_desktop {
         printf "** Error: rdctl not found. Rancher Desktop may not have installed correctly.\n"
         exit 1
     fi
+    # --kubernetes.options.traefik=false: Rancher Desktop ships Traefik by default
+    # but it binds ports 80/443, conflicting with the ingress-nginx the script installs.
     sudo -u "$k8s_user" "$rdctl" start \
         --application.start-in-background \
         --kubernetes.enabled \
         --kubernetes.version "1.30.0" \
         --container-engine.name containerd \
         --virtual-machine.memory-in-gb 16 \
-        --virtual-machine.number-cpus 4
+        --virtual-machine.number-cpus 4 \
+        --kubernetes.options.traefik=false
 }
 
 function install_mac_k8s {
     printf "\r==> Checking macOS Kubernetes provider\n"
+
+    # Ensure kubeconfig context is rancher-desktop if available (may be stale from prior provider)
+    su - "$k8s_user" -c "kubectl config use-context rancher-desktop" >/dev/null 2>&1 || true
 
     # If cluster is accessible, verify it is Rancher Desktop
     if is_cluster_accessible; then
@@ -364,6 +483,8 @@ function install_mac_k8s {
     if [[ -d "/Applications/Rancher Desktop.app" ]]; then
         printf "    Rancher Desktop found, starting...\n"
         _start_rancher_desktop
+        # Ensure kubeconfig points at rancher-desktop (may be stale from a previous provider)
+        su - "$k8s_user" -c "kubectl config use-context rancher-desktop" >/dev/null 2>&1 || true
         if _wait_for_k8s 180; then
             printf "    Rancher Desktop Kubernetes is ready        [ok]\n"
             return 0
@@ -404,6 +525,8 @@ function env_setup_mac_cluster {
     if [[ "$mode" == "deploy" ]]; then
         check_resources_ok
         install_mac_k8s
+        _configure_mac_vm_limits
+        ensure_python_venv
         add_hosts
         check_and_load_helm_repos
         install_nginx_local_cluster
@@ -414,6 +537,7 @@ function env_setup_mac_cluster {
             printf "** Error: Kubernetes cluster is NOT accessible\n\n"
             exit 1
         fi
+        remove_hosts
     else
         showUsage
         exit 1

--- a/src/environmentSetup/environmentSetup.sh
+++ b/src/environmentSetup/environmentSetup.sh
@@ -142,36 +142,60 @@ function add_hosts {
 
         # Determine which IP to use.
         #
-        # On macOS (Rancher Desktop / Lima), the VM has two external interfaces:
-        #   eth0  — socket_vmnet shared network (e.g. 192.168.5.15) — directly
-        #           routable from the Mac to the VM. This is the correct IP.
-        #   vznat — VZ NAT for outbound internet (e.g. 192.168.68.4) — may
-        #           overlap with the physical LAN and is NOT the right address.
+        # On macOS (Rancher Desktop / Lima): use the vznat IP (192.168.68.x).
+        #   klipper-lb (k3s's built-in LoadBalancer) uses iptables DNAT to route
+        #   ports 80 and 443 inside the VM — no process actually binds 0.0.0.0:80/443.
+        #   Lima's guestIPMustBeZero=true auto-forwarding therefore never triggers for
+        #   those ports, so 127.0.0.1 does NOT work.
+        #   The vznat interface (192.168.68.x) IS directly reachable from the Mac host
+        #   (including with corporate VPN) and iptables routes port 80/443 traffic
+        #   correctly to the nginx ingress controller.
+        #   socket_vmnet IP (192.168.5.x) is unreliable — blocked by many VPNs.
         #
-        # kubectl get nodes InternalIP returns the eth0 address, which is correct.
-        # Do NOT use the ingress-nginx LoadBalancer IP — k3s svclb picks up vznat
-        # as the external IP, which routes to the wrong place on many networks.
-        #
-        # On Ubuntu (local k3s) the node IS the host, so InternalIP == 127.0.0.1.
+        # On Ubuntu (local k3s): the node IS the host, so InternalIP == 127.0.0.1
+        #   anyway, but we read it from kubectl to be explicit.
         local NODE_IP
-        NODE_IP=$(sudo -u "$k8s_user" kubectl get nodes \
-            -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}' \
-            2>/dev/null)
-        NODE_IP="${NODE_IP:-127.0.0.1}"
+        if [[ "$environment" == "mac" ]]; then
+            # Get the vznat IP dynamically from the Lima VM.
+            local rdctl
+            rdctl=$(_find_rdctl 2>/dev/null || true)
+            if [[ -n "$rdctl" ]]; then
+                NODE_IP=$(sudo -u "$k8s_user" "$rdctl" shell -- \
+                    ip addr show vznat 2>/dev/null \
+                    | grep 'inet ' | awk '{print $2}' | cut -d/ -f1 2>/dev/null || true)
+            fi
+            NODE_IP="${NODE_IP:-192.168.68.4}"  # fallback to default vznat address
+        else
+            NODE_IP=$(sudo -u "$k8s_user" kubectl get nodes \
+                -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}' \
+                2>/dev/null)
+            NODE_IP="${NODE_IP:-127.0.0.1}"
+        fi
 
         # Remove any existing Gazelle block (idempotent; handles IP changes).
         remove_hosts
 
         # Also strip any legacy unmarked lines that contain gazelle hostnames
         # (written by older versions of this script before the marker approach).
+        # We remove only the gazelle tokens from each line; if other hostnames
+        # (e.g. localhost) are on the same line they are preserved.  Lines that
+        # become just an IP address after stripping are removed entirely.
         export GAZELLE_DOMAIN_SUFFIX="$DOMAIN"
-        perl -pi -e 'next if /\Q$ENV{GAZELLE_DOMAIN_SUFFIX}\E/ && !/^#/' /etc/hosts
+        perl -pi -e '
+            if (/\Q$ENV{GAZELLE_DOMAIN_SUFFIX}\E/ && !/^#/) {
+                s/\s+\S*\Q$ENV{GAZELLE_DOMAIN_SUFFIX}\E\S*//g;
+                $_ = "" if /^\s*[\d.:a-fA-F]+\s*[\r\n]*$/;
+            }
+        ' /etc/hosts
 
         # Append a fresh, clearly-marked block.  Nothing else in /etc/hosts
-        # is read or modified.
+        # is read or modified.  One hostname per line avoids the ~1024-char
+        # per-line limit on macOS which silently drops entries beyond that point.
         {
             printf '\n%s\n' "$GAZELLE_HOSTS_BEGIN"
-            printf '%s %s\n' "$NODE_IP" "${ALL_GAZELLE_HOSTS[*]}"
+            for _host in "${ALL_GAZELLE_HOSTS[@]}"; do
+                printf '%s %s\n' "$NODE_IP" "$_host"
+            done
             printf '%s\n' "$GAZELLE_HOSTS_END"
         } >> /etc/hosts
 
@@ -484,18 +508,73 @@ function _configure_mac_k3s_node_ip {
 #------------------------------------------------------------------------------
 # Function: _wait_for_k8s
 # Description: Polls until the cluster is accessible or timeout is reached.
+#              Also retries 'kubectl config use-context rancher-desktop' on each
+#              iteration because Rancher Desktop writes its kubeconfig entry
+#              asynchronously after starting — the context may not exist when
+#              the loop begins.
 # Parameters:
-#   $1 - timeout in seconds (default 180)
+#   $1 - timeout in seconds (default 240)
 #------------------------------------------------------------------------------
 function _wait_for_k8s {
-    local timeout="${1:-180}"
+    local timeout="${1:-240}"
     local waited=0
     while ! is_cluster_accessible && [[ $waited -lt $timeout ]]; do
+        su - "$k8s_user" -c "kubectl config use-context rancher-desktop" >/dev/null 2>&1 || true
         sleep 5; (( waited += 5 ))
         printf "\r    Waiting for Rancher Desktop Kubernetes (%ds/%ds)..." "$waited" "$timeout"
     done
     printf "\n"
     is_cluster_accessible
+}
+
+#------------------------------------------------------------------------------
+# Function: _recover_mac_k8s
+# Description: Attempts automatic recovery when the Rancher Desktop VM is
+#              running but the k3s cluster is not reachable.
+#
+#              Tier 1 (fast ~15s): removes any stale /etc/rancher/k3s/config.yaml
+#              written by previous gazelle runs (a leftover causes a duplicate
+#              --node-ip that crashes the kubelet) and restarts k3s in place.
+#
+#              Tier 2 (slower ~2min): if k3s is still unreachable, performs a
+#              full rdctl shutdown + start to reset the VM cleanly.
+#
+# Returns: 0 if cluster becomes accessible, 1 if recovery failed.
+#------------------------------------------------------------------------------
+function _recover_mac_k8s {
+    local rdctl
+    if ! rdctl=$(_find_rdctl); then
+        printf "    Warning: rdctl not found — cannot attempt auto-recovery\n"
+        return 1
+    fi
+
+    # ---- Tier 1: clean stale config artifact + in-place k3s restart ----
+    printf "    Auto-recovery tier 1: restarting k3s inside the VM...\n"
+    sudo -u "$k8s_user" "$rdctl" shell sudo rm -f /etc/rancher/k3s/config.yaml >/dev/null 2>&1 || true
+    sudo -u "$k8s_user" "$rdctl" shell sudo rc-service k3s restart >/dev/null 2>&1 || \
+        sudo -u "$k8s_user" "$rdctl" shell sudo service k3s restart >/dev/null 2>&1 || true
+
+    su - "$k8s_user" -c "kubectl config use-context rancher-desktop" >/dev/null 2>&1 || true
+    if _wait_for_k8s 60; then
+        printf "    Auto-recovery tier 1 succeeded              [ok]\n"
+        return 0
+    fi
+
+    # ---- Tier 2: full VM restart via rdctl ----
+    printf "    Auto-recovery tier 2: restarting Rancher Desktop VM...\n"
+    sudo -u "$k8s_user" "$rdctl" shutdown >/dev/null 2>&1 || true
+    sleep 5
+    _start_rancher_desktop
+    su - "$k8s_user" -c "kubectl config use-context rancher-desktop" >/dev/null 2>&1 || true
+    if _wait_for_k8s 240; then
+        printf "    Auto-recovery tier 2 succeeded              [ok]\n"
+        return 0
+    fi
+
+    printf "** Auto-recovery failed. Try:\n"
+    printf "   1. Open Rancher Desktop and check for error messages.\n"
+    printf "   2. If the problem persists, reset Rancher Desktop from its Troubleshooting menu.\n"
+    return 1
 }
 
 #------------------------------------------------------------------------------
@@ -570,17 +649,35 @@ function install_mac_k8s {
         return 0
     fi
 
-    # Rancher Desktop installed but not running — start it
+    # VM may already be running in a broken state (e.g. kubelet crashed due to a
+    # stale config artifact from a previous run).  Try auto-recovery before
+    # attempting a full start, so we don't waste time shutting down a live VM.
+    local rdctl
+    if rdctl=$(_find_rdctl); then
+        local vm_state
+        vm_state=$(sudo -u "$k8s_user" "$rdctl" api /v1/backend_state 2>/dev/null \
+            | python3 -c "import sys,json; print(json.load(sys.stdin).get('vmState',''))" 2>/dev/null || true)
+        if [[ "$vm_state" == "STARTED" ]]; then
+            printf "    VM is running but cluster is unreachable — attempting auto-recovery...\n"
+            if _recover_mac_k8s; then
+                printf "    Rancher Desktop Kubernetes is ready        [ok]\n"
+                return 0
+            fi
+            # Recovery failed — fall through to a clean start below
+        fi
+    fi
+
+    # Rancher Desktop installed but not running (or recovery failed) — start it
     if [[ -d "/Applications/Rancher Desktop.app" ]]; then
         printf "    Rancher Desktop found, starting...\n"
         _start_rancher_desktop
         # Ensure kubeconfig points at rancher-desktop (may be stale from a previous provider)
         su - "$k8s_user" -c "kubectl config use-context rancher-desktop" >/dev/null 2>&1 || true
-        if _wait_for_k8s 180; then
+        if _wait_for_k8s 240; then
             printf "    Rancher Desktop Kubernetes is ready        [ok]\n"
             return 0
         fi
-        printf "** Error: Rancher Desktop did not become ready within 3 minutes.\n"
+        printf "** Error: Rancher Desktop did not become ready.\n"
         printf "   Open Rancher Desktop and check for errors.\n"
         exit 1
     fi
@@ -597,8 +694,8 @@ function install_mac_k8s {
     fi
     printf "    Configuring and starting Rancher Desktop (this may take a few minutes)...\n"
     _start_rancher_desktop
-    if ! _wait_for_k8s 180; then
-        printf "** Error: Rancher Desktop did not become ready within 3 minutes.\n"
+    if ! _wait_for_k8s 240; then
+        printf "** Error: Rancher Desktop did not become ready.\n"
         exit 1
     fi
     printf "    Rancher Desktop Kubernetes is ready        [ok]\n"
@@ -617,7 +714,10 @@ function env_setup_mac_cluster {
         check_resources_ok
         install_mac_k8s
         _configure_mac_vm_limits
-        _configure_mac_k3s_node_ip
+        # NOTE: _configure_mac_k3s_node_ip is intentionally NOT called here.
+        # Rancher Desktop already sets --node-ip via /etc/conf.d/k3s ADDITIONAL_ARGS.
+        # Writing node-ip again to /etc/rancher/k3s/config.yaml produces a duplicate
+        # "192.168.x.x,192.168.x.x" value that causes the kubelet to crash.
         ensure_python_venv
         add_hosts
         check_and_load_helm_repos
@@ -644,9 +744,11 @@ function env_setup_mac_cluster {
         fi
         remove_hosts
         if [[ "$mode" == "cleanall" ]]; then
-            # Shut down the Rancher Desktop VM cleanly regardless of cluster state
+            # Remove the k3s config.yaml written by previous gazelle runs so that a
+            # subsequent deploy starts with a clean slate (no stale node-ip override).
             local rdctl
             if rdctl=$(_find_rdctl); then
+                sudo -u "$k8s_user" "$rdctl" shell sudo rm -f /etc/rancher/k3s/config.yaml >/dev/null 2>&1 || true
                 log_step "Shutting down Rancher Desktop"
                 sudo -u "$k8s_user" "$rdctl" shutdown >/dev/null 2>&1 || true
                 log_ok

--- a/src/environmentSetup/environmentSetup.sh
+++ b/src/environmentSetup/environmentSetup.sh
@@ -11,13 +11,13 @@ source "$RUN_DIR/src/environmentSetup/k8s.sh" || { echo "FATAL: Could not source
 function install_os_prerequisites {
     printf "\n\r==> Check & install operating system packages"
     if [[ "$(uname -s)" == "Darwin" ]]; then
-        if ! command -v brew &>/dev/null; then
+        if ! brew_available; then
             printf "\n** Error: Homebrew is required on macOS. Install from https://brew.sh **\n"
             exit 1
         fi
         if ! command -v jq &>/dev/null; then
             logWithVerboseCheck "$debug" debug "jq is not installed. Installing via brew..."
-            brew install jq >/dev/null 2>&1
+            run_brew install jq >/dev/null 2>&1
         else
             logWithVerboseCheck "$debug" debug "jq is already installed\n"
         fi

--- a/src/environmentSetup/helpers.sh
+++ b/src/environmentSetup/helpers.sh
@@ -80,7 +80,7 @@ check_os_ok() {
         exit 1
     fi
     echo "    Linux OS is $LINUX_OS and version $LINUX_VERSION"
-    echo "    Supported Ubuntu versions are: ${ubuntu_ok_versions_list[*]}"
+    echo "    Tested Ubuntu versions are: ${ubuntu_ok_versions_list[*]}"
     if [[ ! " ${ubuntu_ok_versions_list[*]} " =~ " ${LINUX_VERSION} " ]]; then
         printf "** Error, Mifos Gazelle is only tested with Ubuntu this time   **\n"
         exit 1

--- a/src/environmentSetup/helpers.sh
+++ b/src/environmentSetup/helpers.sh
@@ -10,8 +10,14 @@ function check_arch_ok {
 }
 
 function check_resources_ok {
-    total_ram=$(free -g | awk '/^Mem:/{print $2}')
-    free_space=$(df -BG ~ | awk '{print $4}' | tail -n 1 | sed 's/G//')
+    local total_ram free_space
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+        total_ram=$(( $(sysctl -n hw.memsize) / 1073741824 ))
+        free_space=$(df -k ~ | awk 'NR==2 {printf "%d", $4/1048576}')
+    else
+        total_ram=$(free -g | awk '/^Mem:/{print $2}')
+        free_space=$(df -BG ~ | awk '{print $4}' | tail -n 1 | sed 's/G//')
+    fi
     if [[ "$total_ram" -lt "$MIN_RAM" ]]; then
         printf " ** Error: mifos-gazelle currently requires $MIN_RAM GBs to run properly \n"
         printf "    Please increase RAM available before trying to run mifos-gazelle \n"
@@ -37,6 +43,13 @@ function set_linux_os_distro {
 
 function check_os_ok {
     printf "\r==> checking operating system is tested with mifos-gazelle\n"
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+        local mac_version
+        mac_version=$(sw_vers -productVersion 2>/dev/null)
+        printf "    macOS %s detected\n" "$mac_version"
+        printf "    Operating system check                         [ok]\n"
+        return 0
+    fi
     set_linux_os_distro
     # Only Linux OS supported at this time
     if [[ ! $LINUX_OS == "Ubuntu" ]]; then

--- a/src/environmentSetup/helpers.sh
+++ b/src/environmentSetup/helpers.sh
@@ -6,7 +6,7 @@
 # Locates the Homebrew binary at its known macOS install paths (sudo strips
 # PATH so 'command -v brew' fails) and runs it as the invoking non-root user.
 #------------------------------------------------------------------------------
-function run_brew {
+run_brew() {
     local brew_bin=""
     for candidate in /opt/homebrew/bin/brew /usr/local/bin/brew; do
         if [[ -x "$candidate" ]]; then brew_bin="$candidate"; break; fi
@@ -19,11 +19,11 @@ function run_brew {
     sudo -u "${SUDO_USER:-$k8s_user}" "$brew_bin" "$@"
 }
 
-function brew_available {
+brew_available() {
     [[ -x "/opt/homebrew/bin/brew" ]] || [[ -x "/usr/local/bin/brew" ]]
 }
 
-function check_arch_ok {
+check_arch_ok() {
     local arch=$(uname -m)
     if [[ "$arch" != "x86_64" && "$arch" != "arm64" && "$arch" != "aarch64" ]]; then
         printf " **** Error Unknown CPU architecture : mifos-gazelle only works properly with x86_64, arm64, or aarch64 architectures today  *****\n"
@@ -31,7 +31,7 @@ function check_arch_ok {
     fi
 }
 
-function check_resources_ok {
+check_resources_ok() {
     local total_ram free_space
     if [[ "$(uname -s)" == "Darwin" ]]; then
         total_ram=$(( $(sysctl -n hw.memsize) / 1073741824 ))
@@ -52,7 +52,7 @@ function check_resources_ok {
     fi
 }
 
-function set_linux_os_distro {
+set_linux_os_distro() {
     LINUX_VERSION="Unknown"
     if [ -x "/usr/bin/lsb_release" ]; then
         LINUX_OS=`lsb_release --d | perl -ne 'print if s/^.*Ubuntu.*(\d+).(\d+).*$/Ubuntu/' `
@@ -63,13 +63,14 @@ function set_linux_os_distro {
     #printf "\r     Linux OS is [%s] " "$LINUX_OS"
 }
 
-function check_os_ok {
+check_os_ok() {
     printf "\r==> checking operating system is tested with mifos-gazelle\n"
     if [[ "$(uname -s)" == "Darwin" ]]; then
         local mac_version
         mac_version=$(sw_vers -productVersion 2>/dev/null)
         printf "    macOS %s detected\n" "$mac_version"
-        printf "    Operating system check                         [ok]\n"
+        log_step "Operating system check"
+        log_ok
         return 0
     fi
     set_linux_os_distro
@@ -84,10 +85,11 @@ function check_os_ok {
         printf "** Error, Mifos Gazelle is only tested with Ubuntu this time   **\n"
         exit 1
     fi
-    printf "    Operating system and versions checks            [ok]\n"
+    log_step "Operating system check"
+    log_ok
 }
 
-function verify_user {
+verify_user() {
     if [ -z ${k8s_user+x} ]; then
         printf "** Error: The operating system user has not been specified with the -u flag \n"
         printf "          the user specified with the -u flag must exist and not be the root user \n"
@@ -109,7 +111,7 @@ function verify_user {
 }
 
 # check which kubernetes related tools are installed 
-function checkTools {
+check_tools() {
     # Set the default tools to check (helm and kubectl)
     local tools=("helm" "kubectl")
 
@@ -129,7 +131,7 @@ function checkTools {
     return 0 # Return 0 (success) if all tools were found
 }
 
-function is_local_cluster_installed () {
+is_local_cluster_installed()  {
     if [[ -f /usr/local/bin/k3s ]]; then
         #echo "local Kubernetes Cluster (k3s) is installed."
         return 0 # Success
@@ -139,7 +141,7 @@ function is_local_cluster_installed () {
 }
 
 
-function configure_k3s_kernel_params() {
+configure_k3s_kernel_params() {
     echo "Checking current kernel parameters for K3s..."
     
     # Define target values

--- a/src/environmentSetup/helpers.sh
+++ b/src/environmentSetup/helpers.sh
@@ -1,6 +1,28 @@
 #!/usr/bin/env bash
 # helper functions for OS and kubernetes environment setup
 
+#------------------------------------------------------------------------------
+# run_brew <args>
+# Locates the Homebrew binary at its known macOS install paths (sudo strips
+# PATH so 'command -v brew' fails) and runs it as the invoking non-root user.
+#------------------------------------------------------------------------------
+function run_brew {
+    local brew_bin=""
+    for candidate in /opt/homebrew/bin/brew /usr/local/bin/brew; do
+        if [[ -x "$candidate" ]]; then brew_bin="$candidate"; break; fi
+    done
+    if [[ -z "$brew_bin" ]]; then
+        printf "** Error: Homebrew not found at /opt/homebrew/bin or /usr/local/bin.\n"
+        printf "   Install from https://brew.sh then re-run.\n"
+        exit 1
+    fi
+    sudo -u "${SUDO_USER:-$k8s_user}" "$brew_bin" "$@"
+}
+
+function brew_available {
+    [[ -x "/opt/homebrew/bin/brew" ]] || [[ -x "/usr/local/bin/brew" ]]
+}
+
 function check_arch_ok {
     local arch=$(uname -m)
     if [[ "$arch" != "x86_64" && "$arch" != "arm64" && "$arch" != "aarch64" ]]; then

--- a/src/environmentSetup/k8s.sh
+++ b/src/environmentSetup/k8s.sh
@@ -182,14 +182,14 @@ function install_k8s_tools {
 
     # macOS: use Homebrew; kubectl is already provided by OrbStack/Docker Desktop
     if [[ "$(uname -s)" == "Darwin" ]]; then
-        if ! command -v brew &>/dev/null; then
+        if ! brew_available; then
             printf "\n** Error: Homebrew is required on macOS. Install from https://brew.sh **\n"
             exit 1
         fi
         local mac_tools=(helm k9s kubectx kustomize)
         for tool in "${mac_tools[@]}"; do
             if ! command -v "$tool" &>/dev/null; then
-                brew install "$tool" >/dev/null 2>&1
+                run_brew install "$tool" >/dev/null 2>&1
             fi
         done
         printf "   [ok]\n"

--- a/src/environmentSetup/k8s.sh
+++ b/src/environmentSetup/k8s.sh
@@ -191,13 +191,11 @@ function install_nginx_local_cluster {
 function install_k8s_tools {
     printf "\r==> Checking and installing Kubernetes tools     "
 
-    # macOS: use Homebrew; kubectl is already provided by OrbStack/Docker Desktop
+    # macOS: use Homebrew. kubectl, docker, and docker-compose are installed here;
+    # Colima does not bundle host-side binaries the way Rancher Desktop did.
     if [[ "$(uname -s)" == "Darwin" ]]; then
-        if ! brew_available; then
-            printf "\n** Error: Homebrew is required on macOS. Install from https://brew.sh **\n"
-            exit 1
-        fi
-        local mac_tools=(helm k9s kubectx kustomize)
+        _ensure_homebrew
+        local mac_tools=(helm k9s kubectx kustomize kubectl docker docker-compose socket_vmnet)
         for tool in "${mac_tools[@]}"; do
             local needs_install=false
             if ! command -v "$tool" &>/dev/null; then
@@ -211,6 +209,11 @@ function install_k8s_tools {
             if [[ "$needs_install" == true ]]; then
                 run_brew install "$tool" >/dev/null 2>&1
             fi
+            # Ensure the binary is linked into /opt/homebrew/bin — brew install
+            # can leave a formula in a broken-linked state if a previous tool
+            # (OrbStack, Rancher Desktop) removed its symlink without telling brew.
+            run_brew unlink "$tool" >/dev/null 2>&1 || true
+            run_brew link --overwrite "$tool" >/dev/null 2>&1 || true
         done
         printf "   [ok]\n"
         return 0

--- a/src/environmentSetup/k8s.sh
+++ b/src/environmentSetup/k8s.sh
@@ -45,6 +45,17 @@ function install_k3s {
     chmod 600 "$kubeconfig_path"
 
     logWithVerboseCheck "$debug" debug "k3s kubeconfig copied to $kubeconfig_path"
+
+    # Increase inotify and file-descriptor limits so Java/Spring-Boot pods (zeebe,
+    # bulk-processor, etc.) don't hit "too many open files" / fsnotify errors.
+    # Write to sysctl.d so the settings survive reboots.
+    printf "\r==> Configuring kernel limits for k3s (inotify / file descriptors)    "
+    tee /etc/sysctl.d/99-k3s.conf > /dev/null <<'EOF'
+fs.inotify.max_user_watches=1048576
+fs.inotify.max_user_instances=8192
+fs.file-max=2097152
+EOF
+    sysctl --system > /dev/null 2>&1
     printf "[ok]\n"
 
 }

--- a/src/environmentSetup/k8s.sh
+++ b/src/environmentSetup/k8s.sh
@@ -188,7 +188,16 @@ function install_k8s_tools {
         fi
         local mac_tools=(helm k9s kubectx kustomize)
         for tool in "${mac_tools[@]}"; do
+            local needs_install=false
             if ! command -v "$tool" &>/dev/null; then
+                needs_install=true
+            elif ! "$tool" version &>/dev/null && ! "$tool" --version &>/dev/null; then
+                # Binary exists but fails to execute (e.g. Linux ELF on macOS) — remove and reinstall
+                printf "\n    Replacing non-native '%s' binary with Homebrew version...\n" "$tool"
+                rm -f "$(command -v "$tool")"
+                needs_install=true
+            fi
+            if [[ "$needs_install" == true ]]; then
                 run_brew install "$tool" >/dev/null 2>&1
             fi
         done

--- a/src/environmentSetup/k8s.sh
+++ b/src/environmentSetup/k8s.sh
@@ -180,8 +180,24 @@ function install_nginx_local_cluster {
 function install_k8s_tools {
     printf "\r==> Checking and installing Kubernetes tools     "
 
+    # macOS: use Homebrew; kubectl is already provided by OrbStack/Docker Desktop
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+        if ! command -v brew &>/dev/null; then
+            printf "\n** Error: Homebrew is required on macOS. Install from https://brew.sh **\n"
+            exit 1
+        fi
+        local mac_tools=(helm k9s kubectx kustomize)
+        for tool in "${mac_tools[@]}"; do
+            if ! command -v "$tool" &>/dev/null; then
+                brew install "$tool" >/dev/null 2>&1
+            fi
+        done
+        printf "   [ok]\n"
+        return 0
+    fi
+
     # --- NOTE ON VERSIONING ---
-    # TODO 
+    # TODO
     # Define these versions globally (or ensure they are passed in)
     # local kubectl_version="v1.30.0"
     # local helm_version="v3.14.4"

--- a/src/environmentSetup/k8s.sh
+++ b/src/environmentSetup/k8s.sh
@@ -6,7 +6,7 @@
 # based on k3s check-config output parsing and removing ANSI escape codes if any
 # note this isn't used for k3s cluster health checking just installation verification
 #------------------------------------------------------------------------------
-function check_k3s_cluster_status {
+check_k3s_cluster_status() {
     status=$(
         k3s check-config 2>/dev/null | 
         perl -ne 's/\e\[[0-9;]*m//g; if (/STATUS: (pass|fail)/) { print "$1\n" }' | 
@@ -22,18 +22,18 @@ function check_k3s_cluster_status {
 #------------------------------------------------------------------------------
 # Install k3s lightweight Kubernetes cluster
 #------------------------------------------------------------------------------
-function install_k3s {
+install_k3s() {
     # TODO check this i.e. do we need to remove old kube config like this 
     rm -rf "$k8s_user_home/.kube" >> /dev/null 2>&1
-    printf "\r==> install local k3s cluster v%s user [%s]    " "$k8s_version" "$k8s_user"
+    log_step "install local k3s cluster v${k8s_version} user [${k8s_user}]"
     curl -sfL https://get.k3s.io | K3S_KUBECONFIG_MODE="644" \
                             INSTALL_K3S_CHANNEL="v$k8s_version" \
                             INSTALL_K3S_EXEC=" --disable traefik " sh > /dev/null 2>&1
 
     if ! check_k3s_cluster_status ; then
-        printf "[fail]\n"
-        printf "    ** Error: k3s check-config not reporting status of pass ** \n"
-        printf "    ** run sudo k3s check-config manually as user [%s] for more information   ** \n" "$k8s_user"
+        log_failed
+        log_error "k3s check-config not reporting status of pass"
+        log_error "run sudo k3s check-config manually as user [$k8s_user] for more information"
         exit 1
     fi
 
@@ -44,27 +44,27 @@ function install_k3s {
     chown "$k8s_user" "$kubeconfig_path"
     chmod 600 "$kubeconfig_path"
 
-    logWithVerboseCheck "$debug" debug "k3s kubeconfig copied to $kubeconfig_path"
+    log_with_verbose_check "$debug" debug "k3s kubeconfig copied to $kubeconfig_path"
 
     # Increase inotify and file-descriptor limits so Java/Spring-Boot pods (zeebe,
     # bulk-processor, etc.) don't hit "too many open files" / fsnotify errors.
     # Write to sysctl.d so the settings survive reboots.
-    printf "\r==> Configuring kernel limits for k3s (inotify / file descriptors)    "
+    log_step "Configuring kernel limits for k3s (inotify / file descriptors)"
     tee /etc/sysctl.d/99-k3s.conf > /dev/null <<'EOF'
 fs.inotify.max_user_watches=1048576
 fs.inotify.max_user_instances=8192
 fs.file-max=2097152
 EOF
     sysctl --system > /dev/null 2>&1
-    printf "[ok]\n"
+    log_ok
 
 }
 
 #------------------------------------------------------------------------------
-# Function: deployPhHelmChartFromDir
+# Function: deploy_ph_helm_chart_from_dir
 # Description: Deploys a Helm chart from a specified directory into a given namespace.
 #------------------------------------------------------------------------------
-function check_nginx_running {
+check_nginx_running() {
     nginx_pod_name=$(run_as_user "kubectl get pods -n default --no-headers -o custom-columns=\":metadata.name\"" | grep nginx | head -n 1)
     if [ -z "$nginx_pod_name" ]; then
         return 1
@@ -81,7 +81,7 @@ function check_nginx_running {
 # Function: get_ingress_ip
 # Description: Retrieves and displays the external IP or hostname of the NGINX Ingress Controller
 #------------------------------------------------------------------------------
-function get_ingress_ip {
+get_ingress_ip() {
     ingress_ip=$(kubectl get svc -n ingress-nginx ingress-nginx-controller -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null)
     if [ -z "$ingress_ip" ]; then
         ingress_ip=$(kubectl get svc -n ingress-nginx ingress-nginx-controller -o jsonpath='{.status.loadBalancer.ingress[0].hostname}' 2>/dev/null)
@@ -105,7 +105,7 @@ function get_ingress_ip {
 #              minimises updates and network traffic 
 #------------------------------------------------------------------------------
 check_and_load_helm_repos() {
-printf "\r==> Check and load Helm repositories    "
+log_step "Check and load Helm repositories"
   local updated=false
 
   # Gazelle Repos List (name and URL)
@@ -162,15 +162,15 @@ printf "\r==> Check and load Helm repositories    "
       exit 1
     fi
   fi
-  printf "            [ok]\n"
+  log_ok
 }
 
 #------------------------------------------------------------------------------
 # Description: Install NGINX ingress controller in a local cluster using Helm 
 #              if not already installed. Wait for it to be running.   
 #------------------------------------------------------------------------------ 
-function install_nginx_local_cluster {
-    printf "\r==> Installing NGINX to local cluster "
+install_nginx_local_cluster() {
+    log_step "Installing NGINX ingress controller"
     if ! check_nginx_running; then 
         run_as_user  "helm delete ingress-nginx -n default " > /dev/null 2>&1
         run_as_user  "helm install --wait --timeout 1200s ingress-nginx ingress-nginx \
@@ -178,9 +178,9 @@ function install_nginx_local_cluster {
                             -n default -f $NGINX_VALUES_FILE"  > /dev/null 2>&1
     fi 
     if check_nginx_running; then 
-        printf "              [ok]\n"
+        log_ok
     else
-        printf "** Error: Helm install of NGINX ingress controller failed, pod is not running **\n"
+        log_failed "Helm install of NGINX ingress controller failed, pod is not running"
         exit 1
     fi
 }
@@ -188,13 +188,13 @@ function install_nginx_local_cluster {
 #------------------------------------------------------------------------------
 # Install k8s related tools if not already installed
 #------------------------------------------------------------------------------
-function install_k8s_tools {
-    printf "\r==> Checking and installing Kubernetes tools     "
+install_k8s_tools() {
+    log_step "Checking and installing Kubernetes tools"
 
     # macOS: use Homebrew. kubectl, docker, and docker-compose are installed here;
     # Colima does not bundle host-side binaries the way Rancher Desktop did.
     if [[ "$(uname -s)" == "Darwin" ]]; then
-        _ensure_homebrew
+        ensure_homebrew
         local mac_tools=(helm k9s kubectx kustomize kubectl docker docker-compose socket_vmnet)
         for tool in "${mac_tools[@]}"; do
             local needs_install=false
@@ -215,7 +215,7 @@ function install_k8s_tools {
             run_brew unlink "$tool" >/dev/null 2>&1 || true
             run_brew link --overwrite "$tool" >/dev/null 2>&1 || true
         done
-        printf "   [ok]\n"
+        log_ok
         return 0
     fi
 
@@ -288,7 +288,7 @@ function install_k8s_tools {
             fi
         fi
     done
-    printf "   [ok]\n"
+    log_ok
 }
 
 
@@ -296,7 +296,7 @@ function install_k8s_tools {
 # Function : report_cluster_info
 # Description: Reports basic information about the Kubernetes cluster.
 #------------------------------------------------------------------------------
-function report_cluster_info {
+report_cluster_info() {
     #export KUBECONFIG="$kubeconfig_path"
     num_nodes=$(kubectl get nodes --no-headers | wc -l)
     k8s_version=$(kubectl version | grep Server | awk '{print $3}')

--- a/src/environmentSetup/mac_setup.sh
+++ b/src/environmentSetup/mac_setup.sh
@@ -1,0 +1,419 @@
+#!/usr/bin/env bash
+# mac_setup.sh -- macOS/Colima-specific environment setup. Sourced by environmentSetup.sh.
+
+#------------------------------------------------------------------------------
+# Activates the colima kubeconfig context. Silently ignores failure — the
+# context may not exist yet if Colima is still starting.
+#------------------------------------------------------------------------------
+use_colima_context() {
+    su - "$k8s_user" -c "kubectl config use-context colima" >/dev/null 2>&1 || true
+}
+
+#------------------------------------------------------------------------------
+# Function: configure_mac_vm_limits
+# Description: Increases inotify and file-descriptor kernel limits inside the
+#              Colima Lima VM.  Without this, Java/Spring-Boot pods that
+#              open many fsnotify watchers (bulk-processor, zeebe-broker, etc.)
+#              hit "too many open files" errors.  Settings are applied immediately
+#              and written to /etc/sysctl.d/99-gazelle.conf so they survive Lima
+#              VM restarts.  Idempotent: safe to call on every run.
+#------------------------------------------------------------------------------
+configure_mac_vm_limits() {
+    local colima
+    if ! colima=$(find_colima); then
+        log_warn "colima not found — skipping VM kernel limit tuning"
+        return 0
+    fi
+
+    log_step "Configuring VM kernel limits"
+
+    # Apply immediately (takes effect for all running and new processes).
+    sudo -u "$k8s_user" "$colima" exec -- sudo sysctl -w fs.inotify.max_user_watches=1048576  >/dev/null 2>&1 || true
+    sudo -u "$k8s_user" "$colima" exec -- sudo sysctl -w fs.inotify.max_user_instances=8192   >/dev/null 2>&1 || true
+    sudo -u "$k8s_user" "$colima" exec -- sudo sysctl -w fs.file-max=2097152                  >/dev/null 2>&1 || true
+
+    # Persist across Lima VM restarts (idempotent: only write if not already present).
+    sudo -u "$k8s_user" "$colima" exec -- sudo sh -c \
+        'grep -q max_user_watches /etc/sysctl.d/99-gazelle.conf 2>/dev/null || printf "fs.inotify.max_user_watches=1048576\nfs.inotify.max_user_instances=8192\nfs.file-max=2097152\n" > /etc/sysctl.d/99-gazelle.conf' \
+        >/dev/null 2>&1 || true
+
+    log_ok
+}
+
+#------------------------------------------------------------------------------
+# Function: configure_mac_k3s_node_ip
+# Description: Configures k3s inside the Colima Lima VM to bind to
+#              the socket_vmnet (eth0) interface rather than the vznat interface.
+#
+#              Lima has two external interfaces:
+#                eth0  (192.168.5.x) — socket_vmnet, directly routable from Mac
+#                vznat (192.168.68.x) — VZ NAT for internet; overlaps with many
+#                                       physical LAN subnets, causing routing
+#                                       ambiguity on the Mac side.
+#
+#              Without this fix, k3s svclb binds to the vznat IP which the Mac
+#              may route to a physical LAN device instead of the Lima VM.
+#
+#              Writes /etc/rancher/k3s/config.yaml inside the VM (persists on
+#              the VM disk across restarts) and restarts k3s.  Idempotent.
+#------------------------------------------------------------------------------
+configure_mac_k3s_node_ip() {
+    local colima
+    if ! colima=$(find_colima); then
+        log_warn "colima not found — skipping k3s node-ip config"
+        return 0
+    fi
+
+    # Detect eth0 IP inside the Lima VM (socket_vmnet, directly reachable from Mac)
+    local eth0_ip
+    eth0_ip=$(sudo -u "$k8s_user" "$colima" exec -- ip -4 addr show eth0 2>/dev/null \
+        | awk '/inet /{print $2}' | cut -d'/' -f1)
+
+    if [[ -z "$eth0_ip" ]]; then
+        log_warn "could not detect Lima VM eth0 IP — skipping k3s node-ip config"
+        return 0
+    fi
+
+    printf "    Configuring k3s node-ip to %s (socket_vmnet eth0)...\n" "$eth0_ip"
+
+    # Idempotent: skip if already configured with this IP
+    local current_ip
+    current_ip=$(sudo -u "$k8s_user" "$colima" exec -- \
+        sudo sh -c 'grep -E "^node-ip:" /etc/rancher/k3s/config.yaml 2>/dev/null' \
+        | awk -F'"' '{print $2}')
+    if [[ "$current_ip" == "$eth0_ip" ]]; then
+        printf "    k3s node-ip already set to %s   [ok]\n" "$eth0_ip"
+        return 0
+    fi
+
+    # Write the config file inside the Lima VM
+    sudo -u "$k8s_user" "$colima" exec -- sudo sh -c \
+        "mkdir -p /etc/rancher/k3s && printf 'node-ip: \"%s\"\nnode-external-ip: \"%s\"\n' '$eth0_ip' '$eth0_ip' > /etc/rancher/k3s/config.yaml" \
+        >/dev/null 2>&1
+
+    # Restart k3s so it picks up the new node-ip config.
+    # Try each init mechanism in turn; fall back to a full VM restart.
+    printf "    Restarting k3s...\n"
+    local restarted=false
+    if sudo -u "$k8s_user" "$colima" exec -- sudo rc-service k3s restart >/dev/null 2>&1; then
+        # OpenRC (Alpine Linux — Colima Lima VM)
+        restarted=true
+    elif sudo -u "$k8s_user" "$colima" exec -- sudo service k3s restart >/dev/null 2>&1; then
+        restarted=true
+    elif sudo -u "$k8s_user" "$colima" exec -- sudo dinitctl restart k3s >/dev/null 2>&1; then
+        restarted=true
+    else
+        # No init service found — restart the whole VM (slowest but reliable)
+        printf "    No k3s service manager found — restarting Colima VM...\n"
+        sudo -u "$k8s_user" "$colima" stop >/dev/null 2>&1 || true
+        sleep 5
+        start_colima
+        restarted=true
+    fi
+
+    # Wait for the cluster to recover
+    if [[ "$restarted" == true ]] && wait_for_k8s 180; then
+        printf "    k3s node-ip configured              [ok]\n"
+    else
+        log_warn "k3s did not recover within 3 minutes after restart"
+    fi
+}
+
+#------------------------------------------------------------------------------
+# Function: wait_for_k8s
+# Description: Polls until the cluster is accessible or timeout is reached.
+#              Also retries 'kubectl config use-context colima' on each
+#              iteration because Colima writes its kubeconfig entry
+#              asynchronously after starting — the context may not exist when
+#              the loop begins.
+# Parameters:
+#   $1 - timeout in seconds (default 240)
+#------------------------------------------------------------------------------
+wait_for_k8s() {
+    local timeout="${1:-240}"
+    local waited=0
+    while ! is_cluster_accessible && [[ $waited -lt $timeout ]]; do
+        use_colima_context
+        sleep 5; (( waited += 5 ))
+        printf "\r    Waiting for Colima Kubernetes (%ds/%ds)..." "$waited" "$timeout"
+    done
+    printf "\n"
+    is_cluster_accessible
+}
+
+#------------------------------------------------------------------------------
+# Function: recover_mac_k8s
+# Description: Attempts automatic recovery when the Colima VM is
+#              running but the k3s cluster is not reachable.
+#
+#              Tier 1 (fast ~15s): removes any stale /etc/rancher/k3s/config.yaml
+#              written by previous gazelle runs and restarts k3s in place.
+#
+#              Tier 2 (slower ~2min): if k3s is still unreachable, performs a
+#              full colima stop + start to reset the VM cleanly.
+#
+# Returns: 0 if cluster becomes accessible, 1 if recovery failed.
+#------------------------------------------------------------------------------
+recover_mac_k8s() {
+    local colima
+    if ! colima=$(find_colima); then
+        log_error "colima not found — cannot attempt auto-recovery"
+        return 1
+    fi
+
+    # ---- Tier 1: clean stale config artifact + in-place k3s restart ----
+    printf "    Auto-recovery tier 1: restarting k3s inside the VM...\n"
+    sudo -u "$k8s_user" "$colima" exec -- sudo rm -f /etc/rancher/k3s/config.yaml >/dev/null 2>&1 || true
+    sudo -u "$k8s_user" "$colima" exec -- sudo rc-service k3s restart >/dev/null 2>&1 || \
+        sudo -u "$k8s_user" "$colima" exec -- sudo service k3s restart >/dev/null 2>&1 || true
+
+    use_colima_context
+    if wait_for_k8s 60; then
+        log_step "Auto-recovery tier 1 succeeded"
+        log_ok
+        return 0
+    fi
+
+    # ---- Tier 2: full VM restart ----
+    printf "    Auto-recovery tier 2: restarting Colima VM...\n"
+    sudo -u "$k8s_user" "$colima" stop >/dev/null 2>&1 || true
+    sleep 5
+    start_colima
+    use_colima_context
+    if wait_for_k8s 240; then
+        log_step "Auto-recovery tier 2 succeeded"
+        log_ok
+        return 0
+    fi
+
+    log_error "Auto-recovery failed. Try:"
+    printf "   1. Run: colima stop && colima start --kubernetes --kubernetes-version v1.30.0+k3s1 --runtime containerd --memory 16 --cpu 4\n"
+    printf "   2. If the problem persists, run: colima delete && re-run ./run.sh\n"
+    return 1
+}
+
+#------------------------------------------------------------------------------
+# Function: ensure_homebrew
+# Description: Auto-installs Homebrew if not present. Safe to call as root
+#              (uses sudo -u $k8s_user internally). Exits on failure.
+#------------------------------------------------------------------------------
+ensure_homebrew() {
+    if brew_available; then
+        return 0
+    fi
+    printf "    Homebrew not found — installing (this may take a few minutes)...\n"
+    sudo -u "$k8s_user" /bin/bash -c \
+        "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)" \
+        </dev/null
+    export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
+    if ! brew_available; then
+        log_error "Homebrew installation failed. Install manually from https://brew.sh"
+        exit 1
+    fi
+    log_step "Homebrew installed"
+    log_ok
+}
+
+#------------------------------------------------------------------------------
+# Function: find_colima
+# Description: Locates the colima binary at known macOS install paths.
+#              colima is not on PATH when running via sudo, so we check
+#              known Homebrew locations explicitly.
+#------------------------------------------------------------------------------
+find_colima() {
+    for candidate in \
+        "/opt/homebrew/bin/colima" \
+        "/usr/local/bin/colima"; do
+        if [[ -x "$candidate" ]]; then
+            printf '%s' "$candidate"
+            return 0
+        fi
+    done
+    if command -v colima &>/dev/null; then
+        command -v colima; return 0
+    fi
+    return 1
+}
+
+#------------------------------------------------------------------------------
+# Function: start_colima
+# Description: Starts Colima with k3s and containerd for standard Gazelle use.
+#              k3s version matches the Ubuntu local environment.
+#              containerd is used (not Docker) for consistency.
+#------------------------------------------------------------------------------
+start_colima() {
+    local colima
+    if ! colima=$(find_colima); then
+        log_error "colima not found. Install with: brew install colima"
+        exit 1
+    fi
+    # Pass Homebrew PATH explicitly — sudo strips PATH so colima's internal
+    # kubectl dependency check fails without it.
+    sudo -u "$k8s_user" env PATH="/opt/homebrew/bin:/usr/local/bin:$PATH" \
+        "$colima" start \
+        --kubernetes \
+        --kubernetes-version "v1.30.0+k3s1" \
+        --runtime docker \
+        --memory 16 \
+        --cpu 4 \
+        --network-address
+}
+
+#------------------------------------------------------------------------------
+# Function: install_mac_k8s
+# Description: Ensures Colima (k3s) is running on macOS.
+#              Colima is the supported provider — it uses k3s via Lima,
+#              matching the Ubuntu environment and avoiding image pull issues.
+#              Errors if another Kubernetes provider is found running.
+#------------------------------------------------------------------------------
+install_mac_k8s() {
+    log_section "Checking macOS Kubernetes provider"
+    ensure_homebrew
+
+    # socket_vmnet sudoers: required for colima --network-address to get a routable VM IP.
+    # colima sudoers emits the necessary /etc/sudoers.d snippet; idempotent on every run.
+    local colima_bin
+    if colima_bin=$(find_colima); then
+        sudo -u "$k8s_user" "$colima_bin" sudoers 2>/dev/null \
+            | tee /etc/sudoers.d/colima >/dev/null 2>&1 || true
+    fi
+
+    # Ensure kubeconfig context is colima if available (may be stale from prior provider)
+    use_colima_context
+
+    # If cluster is accessible, verify it is Colima
+    if is_cluster_accessible; then
+        local current_context
+        current_context=$(su - "$k8s_user" -c "kubectl config current-context" 2>/dev/null)
+        if [[ "$current_context" != "colima" ]]; then
+            log_error "A Kubernetes cluster is already running but it is not Colima."
+            printf "   Current context: %s\n" "$current_context"
+            printf "   mifos-gazelle requires Colima on macOS.\n"
+            printf "   Please stop the other provider and re-run.\n"
+            exit 1
+        fi
+        log_step "Colima Kubernetes is ready"
+        log_ok
+        return 0
+    fi
+
+    # VM may already be running in a broken state (e.g. kubelet crashed due to a
+    # stale config artifact from a previous run).  Try auto-recovery before
+    # attempting a full start, so we don't waste time shutting down a live VM.
+    local colima
+    if colima=$(find_colima); then
+        local vm_state
+        vm_state=$(sudo -u "$k8s_user" "$colima" list --json 2>/dev/null \
+            | python3 -c "import sys,json; items=json.load(sys.stdin); print(items[0].get('status','') if items else '')" 2>/dev/null || true)
+        if [[ "$vm_state" == "Running" ]]; then
+            printf "    VM is running but cluster is unreachable — attempting auto-recovery...\n"
+            if recover_mac_k8s; then
+                log_step "Colima Kubernetes is ready"
+        log_ok
+                return 0
+            fi
+            # Recovery failed — fall through to a clean start below
+        fi
+    fi
+
+    # Colima installed but not running (or recovery failed) — start it
+    if colima=$(find_colima); then
+        printf "    Colima found, starting...\n"
+        start_colima
+        # Ensure kubeconfig points at colima (may be stale from a previous provider)
+        use_colima_context
+        if wait_for_k8s 240; then
+            log_step "Colima Kubernetes is ready"
+        log_ok
+            return 0
+        fi
+        log_error "Colima did not become ready."
+        printf "   Run: colima list    and check for errors.\n"
+        exit 1
+    fi
+
+    # Not installed — install Colima + Docker tooling via Homebrew then start
+    printf "    Colima not found. Installing via Homebrew (this may take a few minutes)...\n"
+    if ! sudo -u "$k8s_user" brew install colima docker docker-compose; then
+        log_error "Colima installation failed."
+        exit 1
+    fi
+    printf "    Starting Colima with Kubernetes (this may take a few minutes)...\n"
+    start_colima
+    if ! wait_for_k8s 300; then
+        log_error "Colima did not become ready."
+        exit 1
+    fi
+    log_step "Colima Kubernetes is ready"
+        log_ok
+}
+
+#------------------------------------------------------------------------------
+# Function: env_setup_mac_cluster
+# Description: Sets up Gazelle on a macOS host using Colima (k3s) as the
+#              Kubernetes provider.
+# Parameters:
+#   $1 - Mode of operation: "deploy", "cleanapps", or "cleanall"
+#------------------------------------------------------------------------------
+env_setup_mac_cluster() {
+    local mode="$1"
+    if [[ "$mode" == "deploy" ]]; then
+        check_resources_ok
+        install_mac_k8s
+        configure_mac_vm_limits
+        # NOTE: configure_mac_k3s_node_ip is intentionally NOT called here.
+        # The default Colima k3s setup works correctly without explicit node-ip binding.
+        # The function exists and is updated for potential future use if needed.
+        ensure_python_venv
+        add_hosts
+        check_and_load_helm_repos
+        install_nginx_local_cluster
+        log_section "macOS kubernetes cluster configured for $k8s_user"
+        print_end_message
+    elif [[ "$mode" == "cleanapps" || "$mode" == "cleanall" ]]; then
+        if is_cluster_accessible; then
+            # Cluster is up — delete namespaces and helm releases cleanly
+            if [[ "$mode" == "cleanapps" ]]; then
+                : # app deletion handled by delete_apps called from commandline.sh
+            else
+                log_step "Removing ingress-nginx"
+                run_as_user "helm uninstall ingress-nginx -n default" >/dev/null 2>&1 || true
+                log_ok
+            fi
+        else
+            if [[ "$mode" == "cleanapps" ]]; then
+                log_error "Kubernetes cluster is NOT accessible"
+                exit 1
+            else
+                log_warn "Kubernetes cluster is not accessible — skipping namespace cleanup"
+            fi
+        fi
+        remove_hosts
+        if [[ "$mode" == "cleanall" ]]; then
+            # Delete the Colima VM entirely — full wipe of k3s state and images.
+            # colima delete stops the VM first if running, then removes the disk.
+            local colima
+            if colima=$(find_colima); then
+                log_step "Deleting Colima VM (full cleanall)"
+                # --yes skips the interactive confirmation prompt.
+                # Stop first (ignoring errors if already stopped) so containerd
+                # shuts down cleanly before delete removes the disk; this avoids
+                # the ttrpc/JSON errors that occur when delete tries to stop a
+                # partially-running VM itself.
+                sudo -u "$k8s_user" "$colima" stop 2>/dev/null || true
+                sudo -u "$k8s_user" "$colima" delete --yes 2>/dev/null || true
+                # colima delete leaves behind ~/.colima (named disks, Lima config, SSH
+                # config) which can hold 20-30 GB of disk images. Remove the entire
+                # directory for a true cleanall — Colima recreates it on next start.
+                rm -rf "$k8s_user_home/.colima" 2>/dev/null || true
+                log_ok
+                # Remove stale kubeconfig and Docker contexts left by the deleted VM.
+                su - "$k8s_user" -c "kubectl config delete-context colima" >/dev/null 2>&1 || true
+                sudo -u "$k8s_user" docker context rm colima >/dev/null 2>&1 || true
+            fi
+        fi
+    else
+        show_usage
+        exit 1
+    fi
+}

--- a/src/utils/data-loading/requirements.txt
+++ b/src/utils/data-loading/requirements.txt
@@ -1,0 +1,1 @@
+requests

--- a/src/utils/helpers.sh
+++ b/src/utils/helpers.sh
@@ -8,6 +8,21 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
 fi
 
 #------------------------------------------------------------------------------
+# Function : sed_inplace
+# Description: Cross-platform in-place sed. macOS (BSD) sed requires an explicit
+#              backup extension after -i; GNU sed does not. Pass sed args exactly
+#              as you would for GNU sed — the -i '' is added automatically on macOS.
+# Usage: sed_inplace -e 's/foo/bar/' file
+#------------------------------------------------------------------------------
+function sed_inplace() {
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+        sed -i '' "$@"
+    else
+        sed -i "$@"
+    fi
+}
+
+#------------------------------------------------------------------------------
 # Function : check_sudo
 # Description: Checks if the script is run with sudo from a non-root user.
 #              Rejects direct root execution (e.g. 'sudo su -') because

--- a/src/utils/helpers.sh
+++ b/src/utils/helpers.sh
@@ -14,7 +14,7 @@ fi
 #              as you would for GNU sed — the -i '' is added automatically on macOS.
 # Usage: sed_inplace -e 's/foo/bar/' file
 #------------------------------------------------------------------------------
-function sed_inplace() {
+sed_inplace() {
     if [[ "$(uname -s)" == "Darwin" ]]; then
         sed -i '' "$@"
     else
@@ -30,7 +30,7 @@ function sed_inplace() {
 #              to determine the real invoking user and causing all artifacts
 #              to be owned by root.
 #------------------------------------------------------------------------------
-function check_sudo() {
+check_sudo() {
     if [[ $EUID -ne 0 ]]; then
         log_error "This script must be run with sudo: sudo ./run.sh"
         exit 1
@@ -49,10 +49,10 @@ function check_sudo() {
 # Parameters:
 #   $1 - Command to run
 #------------------------------------------------------------------------------
-function run_as_user() {
+run_as_user() {
     local command="$1"
     # Debug: Log the command being executed
-    #logWithVerboseCheck "$debug" debug "Running as $k8s_user: $command"
+    #log_with_verbose_check "$debug" debug "Running as $k8s_user: $command"
     
     # Execute the command as k8s_user and capture output and exit code
     local output
@@ -73,7 +73,7 @@ function run_as_user() {
 #   $1 - Exit code of the command
 #   $2 - Command that was executed (for logging purposes)
 #------------------------------------------------------------------------------
-function check_command_execution() {
+check_command_execution() {
     local exit_code=$1
     local cmd="$2"
     if [[ $exit_code -ne 0 ]]; then
@@ -86,7 +86,7 @@ function check_command_execution() {
 #------------------------------------------------------------------------------     
 # Debug function to check if a function exists
 #------------------------------------------------------------------------------
-function function_exists() {
+function_exists() {
     declare -f "$1" > /dev/null
     return $?
 }

--- a/src/utils/import-local-image-to-k3s.sh
+++ b/src/utils/import-local-image-to-k3s.sh
@@ -9,7 +9,7 @@ IMAGE_NAME=""
 IMAGE_TAG=""
 VERBOSE=false
 
-function showUsage() {
+showUsage() {
     cat << EOF
 Usage: $(basename $0) [OPTIONS]
 Publish a local Docker image to k3s Kubernetes cluster.
@@ -31,18 +31,18 @@ EOF
     exit 1
 }
 
-function log() {
+log() {
     if [[ "$VERBOSE" == true ]]; then
         echo "[$(date +'%Y-%m-%d %H:%M:%S')] $1"
     fi
 }
 
-function error() {
+error() {
     echo "ERROR: $1" >&2
     exit 1
 }
 
-function set_user() {
+set_user() {
     # set the k8s_user
     k8s_user=$(who am i | cut -d " " -f1)
     log "k8s_user = $k8s_user"

--- a/src/utils/logger.sh
+++ b/src/utils/logger.sh
@@ -9,21 +9,21 @@ CYAN='\033[0;36m'
 BOLD='\033[1m'
 RESET='\033[0m'
 
-# Log levels (used by logWithLevel / logWithVerboseCheck)
+# Log levels (used by log_with_level / log_with_verbose_check)
 DEBUG="debug"
 INFO="info"
 WARNING="warning"
 ERROR="error"
 
 #------------------------------------------------------------------------------
-# Low-level levelled logger — used internally and by logWithVerboseCheck
+# Low-level levelled logger — used internally and by log_with_verbose_check
 #------------------------------------------------------------------------------
-function logWithLevel() {
+log_with_level() {
   local logLevel=$1
   shift
 
   if [ -z "$logLevel" ] || [ -z "$1" ]; then
-    echo "Usage: logWithLevel <log_level> <log_message>"
+    echo "Usage: log_with_level <log_level> <log_message>"
     return 1
   fi
 
@@ -51,18 +51,18 @@ function logWithLevel() {
 #------------------------------------------------------------------------------
 # Verbose-gated logger — only prints when isVerbose=true
 #------------------------------------------------------------------------------
-function logWithVerboseCheck() {
+log_with_verbose_check() {
   local isVerbose=$1
   local logLevel=$2
   shift && shift
 
   if [ -z "$isVerbose" ] || [ -z "$logLevel" ] || [ -z "$1" ]; then
-    echo "Usage: logWithVerboseCheck <verbose_flag> <log_level> <log_message>"
+    echo "Usage: log_with_verbose_check <verbose_flag> <log_level> <log_message>"
     return 1
   fi
 
   if [ "$isVerbose" = true ]; then
-    logWithLevel "$logLevel" "$*"
+    log_with_level "$logLevel" "$*"
   fi
 }
 
@@ -71,22 +71,28 @@ function logWithVerboseCheck() {
 #------------------------------------------------------------------------------
 
 # Major section header: ==> Title
-function log_section() {
+log_section() {
   echo -e "\n${BLUE}${BOLD}==> $*${RESET}"
 }
 
 # Step in progress (no newline — caller must follow with log_ok or log_failed)
-function log_step() {
-  printf "    %s " "$*"
+# Pads to column 55 so status tags align regardless of message length.
+log_step() {
+  printf "%-55s" "    $*"
 }
 
 # Success status — appended on same line as log_step
-function log_ok() {
+log_ok() {
   echo -e "${GREEN}[  ok  ]${RESET}"
 }
 
+# Skipped status — appended on same line as log_step
+log_skipped() {
+  echo -e "${YELLOW}[skipping]${RESET}"
+}
+
 # Failure status — appended on same line as log_step, optional detail on next line
-function log_failed() {
+log_failed() {
   echo -e "${RED}[FAILED]${RESET}"
   if [ -n "$1" ]; then
     echo -e "         ${RED}$*${RESET}"
@@ -94,17 +100,17 @@ function log_failed() {
 }
 
 # Warning message (non-fatal)
-function log_warn() {
+log_warn() {
   echo -e "${YELLOW}WARN${RESET}   $*"
 }
 
 # Error message (fatal — caller should exit after)
-function log_error() {
+log_error() {
   echo -e "${RED}ERROR${RESET}  $*"
 }
 
 # Success banner — green box with fixed 34-char rule
-function log_banner() {
+log_banner() {
   echo -e "\n${GREEN}==================================${RESET}"
   echo -e "${GREEN} $*${RESET}"
   echo -e "${GREEN}==================================${RESET}"

--- a/src/utils/make-payment.sh
+++ b/src/utils/make-payment.sh
@@ -13,7 +13,7 @@ TRANSFER_URL=""
 MIFOS_CORE_API=""
 MIFOS_AUTH="mifos:password"
 
-function usage() {
+usage() {
 cat <<EOF
 Usage: $0 [-f <config_file>] [-p <payer_msisdn>] [-r <payee_msisdn>] [-t <tenant_id>] [-d <payee_dfsp_id>] [-v]
  -c Path to config.ini file (default: ../config/config.ini) [optional]
@@ -30,7 +30,7 @@ EOF
 }
 
 # Function to lookup client name by MSISDN
-function lookup_client_name() {
+lookup_client_name() {
     local msisdn="$1"
     local tenant_id="$2"
     local client_type="$3"  # "payer" or "payee" for debugging
@@ -103,7 +103,7 @@ function lookup_client_name() {
 }
 
 # Function to get first client MSISDN from tenant
-function get_first_client_msisdn() {
+get_first_client_msisdn() {
     local tenant="$1"
     local client_type="$2"  # "payer" or "payee" for logging
 

--- a/src/utils/postman_setup.sh
+++ b/src/utils/postman_setup.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
-RUN_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"  # the directory that this script is in 
+RUN_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"  # the directory that this script is in
 echo "RUN_DIR is $RUN_DIR"
 BASE_DIR="$( cd $(dirname "$RUN_DIR") ; pwd )"
+source "$BASE_DIR/utils/helpers.sh"
 echo "BASE_DIR is $BASE_DIR"
 
 function welcome {
@@ -84,7 +85,7 @@ add_or_update_hosts() {
 
     if [ -n "$existing_line" ]; then
         if $override; then
-            sed -i "/^$ip[[:space:]]/c\\$ip $hosts" /etc/hosts
+            sed_inplace "/^$ip[[:space:]]/c\\$ip $hosts" /etc/hosts
             echo "Updated existing entry for $ip with hardcoded hostnames."
         else
             echo "$ip $hosts" >> /etc/hosts

--- a/src/utils/postman_setup.sh
+++ b/src/utils/postman_setup.sh
@@ -6,7 +6,7 @@ BASE_DIR="$( cd $(dirname "$RUN_DIR") ; pwd )"
 source "$BASE_DIR/utils/helpers.sh"
 echo "BASE_DIR is $BASE_DIR"
 
-function welcome {
+welcome() {
     echo -e "\e[33mWARNING: In case you start getting service unavailable errors, please follow the Step 5 from the POSTMAN_SETPUP.md file.\e[0m"
     echo -e "\e[33mWARNING: This script will only work if you have run the deployment atleast once successfully.\e[0m"
     echo -e "\e[33mWARNING: This script uses the directory repos/phlabs/orchestration/feel/ to upload the BPMN diagrams to zeebe operations service.\e[0m"

--- a/src/utils/view-mifos-transactions.py
+++ b/src/utils/view-mifos-transactions.py
@@ -130,15 +130,11 @@ def print_transaction(txn, indent=6):
 # Main
 # ----------------------------------------------------------------------
 def main():
-    script_path = Path(__file__).absolute()
-    base_dir = script_path.parent.parent.parent.parent
-    default_config = base_dir / "config" / "config.ini"
-
     parser = argparse.ArgumentParser(
         description="View Mifos transaction history for all clients"
     )
-    parser.add_argument('--config', '-c', type=Path, default=default_config,
-                        help=f'Path to config.ini (default: {default_config})')
+    parser.add_argument('--config', '-c', type=Path, default=Path("config/config.ini"),
+                        help='Path to config.ini (default: config/config.ini)')
     parser.add_argument('--tenant', '-t', type=str,
                         help='Show only specific tenant (e.g., bluebank, greenbank)')
     parser.add_argument('--client-id', type=int,


### PR DESCRIPTION
**Overview** : Update Mifos Gazelle scripts from run.sh to incorporate and deploy on macOS
- config.ini environment now has values [local, remote , mac]
- added mac_setup.sh to environment setup
- chose to use colima kubernetes which is k3s engine in managed QEMU env (there are no native macOS k8s engines)
- tried to make mac functionality separate => Ubuntu is still the main tested platform

**Details and included changes**
    MacOS adds complexity to scripts so to counteract this ....
    refactor: apply Google Shell Style Guide across core pipeline and seperate MacOS and clean up  ..
    - Rename all functions to snake_case; remove `function` keyword
    - Extract macOS/Colima setup into src/environmentSetup/mac_setup.sh
    - Fix output alignment: standardise log_step/log_ok across all setup
      scripts (k8s.sh, mac_setup.sh, helpers.sh, environmentSetup.sh)
    - Remove dead code: TODO stubs, commented-out implementations, unused
      vnext_configure_ttk function
    - Fix bugs: perl -i.bak leaving backup files; duplicate
      install_os_prerequisites call; _ensure_homebrew→ensure_homebrew
    - Hoist single deploy_infrastructure call before app loop
    - implemented a (necessary) change to vNext liveness probes to reduce restarts on deploy

**Other**
- bug fix on  auditing script  view-mifos-transactions.py config to config/config.ini
- added Claude.md
- updated docs to include macOS but also removed or corrected context around word "supported"
-  fixed output so it aligns on screen nicely (there had been drift)

** tested on Ubuntu and macOS ** 
- make-payment.sh runs and correctly debits accounts on both platforms 
- 