### PR TITLE
fix: add timeout to wait_for_pods_ready() to prevent indefinite hang

### DIFF
--- a/src/deployer/core.sh
+++ b/src/deployer/core.sh
@@ -65,10 +65,19 @@ function is_app_running() {
 
 function wait_for_pods_ready() {
     local namespace="$1"
+    local timeout="${startup_timeout:-600}"
+    local start_time
+    start_time=$(date +%s)
     log_step "Waiting for $namespace pods to stabilise"
 
     STABLE_COUNT=0
     while [ $STABLE_COUNT -lt 3 ]; do
+      local elapsed=$(( $(date +%s) - start_time ))
+      if [[ $elapsed -ge $timeout ]]; then
+        log_failed "Pods in $namespace did not stabilise within ${timeout}s"
+        return 1
+      fi
+
       NOT_READY=$(run_as_user "kubectl get pods -n \"$namespace\" --no-headers" | awk '{split($2,a,"/"); if(a[1]!=a[2] || a[1]==0) print}')
 
       if [ -z "$NOT_READY" ]; then
@@ -76,7 +85,7 @@ function wait_for_pods_ready() {
         logWithVerboseCheck "$debug" "$DEBUG" "All pods ready — stable count: $STABLE_COUNT/3"
       else
         STABLE_COUNT=0
-        logWithVerboseCheck "$debug" "$DEBUG" "Some pods not ready — waiting 60s..."
+        logWithVerboseCheck "$debug" "$DEBUG" "Some pods not ready — waiting 60s... (${elapsed}s/${timeout}s)"
       fi
       sleep 60
     done


### PR DESCRIPTION
Fixes #132 

Here's the fix for the issue I raised.

## What I changed

wait_for_pods_ready() had no exit condition  if pods stayed unready 
for any reason, the loop would run forever with no error or feedback.

Wired up the existing startup_timeout variable (same way 
wait_for_fineract_api_ready and generateMifosXandVNextData already do it) 
with a safe fallback of 600s if not set.

Also updated the waiting log message to show elapsed/total time so 
operators can actually see progress instead of watching a blank screen.

## Files Changed
- `src/deployer/core.sh`

## Before
Loop runs forever if pods don't stabilise. No error, no exit.

## After
Exits cleanly with an error after startup_timeout seconds (default 600s).
Progress shown as elapsed/total in log output.