### PR TITLE
fix: integrate inotify parameter setup into environmentSetup deploy flow

### DIFF
--- a/src/environmentSetup/environmentSetup.sh
+++ b/src/environmentSetup/environmentSetup.sh
@@ -67,20 +67,10 @@ function add_hosts {
         
         MIFOSXHOSTS=( mifos.$DOMAIN )
         
-        ALLHOSTS=( "${MIFOSXHOSTS[@]}" "${PHEEHOSTS[@]}" "${VNEXTHOSTS[@]}" )
-
-        # Remove any previous Gazelle-managed block to keep updates idempotent.
-        if grep -q '^# GAZELLE_START$' /etc/hosts || grep -q '^# GAZELLE_END$' /etc/hosts; then
-            sed -i '/^# GAZELLE_START$/,/^# GAZELLE_END$/d' /etc/hosts
-        fi
-
-        {
-            printf '%s\n' '# GAZELLE_START'
-            for hostname in "${ALLHOSTS[@]}"; do
-                printf '127.0.0.1 %s\n' "$hostname"
-            done
-            printf '%s\n' '# GAZELLE_END'
-        } >> /etc/hosts
+        ALLHOSTS=( "127.0.0.1" "localhost" "${MIFOSXHOSTS[@]}" "${PHEEHOSTS[@]}" "${VNEXTHOSTS[@]}" )
+        export ENDPOINTS=`echo ${ALLHOSTS[*]}`
+        perl -pi -e 's/^(127\.0\.0\.1\s+)(.*)/$1localhost/' /etc/hosts
+        perl -p -i.bak -e 's/127\.0\.0\.1.*localhost.*$/$ENV{ENDPOINTS} /' /etc/hosts
     else
         printf "==> Skipping /etc/hosts modification for remote cluster \n"
     fi

--- a/src/environmentSetup/environmentSetup.sh
+++ b/src/environmentSetup/environmentSetup.sh
@@ -67,10 +67,20 @@ function add_hosts {
         
         MIFOSXHOSTS=( mifos.$DOMAIN )
         
-        ALLHOSTS=( "127.0.0.1" "localhost" "${MIFOSXHOSTS[@]}" "${PHEEHOSTS[@]}" "${VNEXTHOSTS[@]}" )
-        export ENDPOINTS=`echo ${ALLHOSTS[*]}`
-        perl -pi -e 's/^(127\.0\.0\.1\s+)(.*)/$1localhost/' /etc/hosts
-        perl -p -i.bak -e 's/127\.0\.0\.1.*localhost.*$/$ENV{ENDPOINTS} /' /etc/hosts
+        ALLHOSTS=( "${MIFOSXHOSTS[@]}" "${PHEEHOSTS[@]}" "${VNEXTHOSTS[@]}" )
+
+        # Remove any previous Gazelle-managed block to keep updates idempotent.
+        if grep -q '^# GAZELLE_START$' /etc/hosts || grep -q '^# GAZELLE_END$' /etc/hosts; then
+            sed -i '/^# GAZELLE_START$/,/^# GAZELLE_END$/d' /etc/hosts
+        fi
+
+        {
+            printf '%s\n' '# GAZELLE_START'
+            for hostname in "${ALLHOSTS[@]}"; do
+                printf '127.0.0.1 %s\n' "$hostname"
+            done
+            printf '%s\n' '# GAZELLE_END'
+        } >> /etc/hosts
     else
         printf "==> Skipping /etc/hosts modification for remote cluster \n"
     fi

--- a/src/environmentSetup/environmentSetup.sh
+++ b/src/environmentSetup/environmentSetup.sh
@@ -348,7 +348,8 @@ env_setup_local_cluster() {
         check_resources_ok
         ensure_python_venv
         add_hosts
-
+        increase_inotify_params
+        
         if ! is_local_cluster_installed; then
             install_k3s
             $UTILS_DIR/install-k9s.sh > /dev/null 2>&1

--- a/src/environmentSetup/k8s.sh
+++ b/src/environmentSetup/k8s.sh
@@ -294,6 +294,34 @@ install_k8s_tools() {
 
 
 #------------------------------------------------------------------------------
+# Function: increase_inotify_params
+# Description: Increases inotify limits required for Kubernetes/container
+#              workloads. Without this, vnext pods hit EMFILE errors on startup.
+#------------------------------------------------------------------------------
+increase_inotify_params() {
+    log_step "Increase inotify limits for Kubernetes workloads"
+    local SYSCTL_FILE="/etc/sysctl.d/99-inotify.conf"
+
+    sysctl -w fs.inotify.max_user_watches=1048576 >/dev/null 2>&1 || {
+        log_warn "Failed to set fs.inotify.max_user_watches"
+        return 1
+    }
+    sysctl -w fs.inotify.max_user_instances=1024 >/dev/null 2>&1 || {
+        log_warn "Failed to set fs.inotify.max_user_instances"
+        return 1
+    }
+
+    cat <<EOF > "${SYSCTL_FILE}"
+# Increased inotify limits for Kubernetes/container workloads
+fs.inotify.max_user_watches = 1048576
+fs.inotify.max_user_instances = 1024
+EOF
+
+    sysctl --system >/dev/null 2>&1
+    log_ok
+}
+
+#------------------------------------------------------------------------------
 # Function : report_cluster_info
 # Description: Reports basic information about the Kubernetes cluster.
 #------------------------------------------------------------------------------


### PR DESCRIPTION
## Problem
vnext pods hit EMFILE (CrashLoopBackOff) on fresh Ubuntu deploys because 
inotify limits are too low. A fix script existed at 
src/utils/test-scripts/increase-inotify-params-untested.sh but was never 
called from the main deploy flow.

## Fix
- Added increase_inotify_params() function to src/environmentSetup/k8s.sh
- Calls sysctl to set max_user_watches=1048576, max_user_instances=1024
- Persists settings to /etc/sysctl.d/99-inotify.conf
- Called from env_setup_local_cluster() deploy flow after add_hosts(), before k3s install

## Tested
Verified on AWS EC2 t3.xlarge Ubuntu 24.04 — sysctl values confirmed set, 
vnext pods Running without EMFILE errors.

Closes: referenced in #gazelle-dev Slack discussion 