### PR TITLE
GAZ-42: Fix invalid Kubernetes memory quantity in ph_values.yaml

### DIFF
--- a/config/ph_values.yaml
+++ b/config/ph_values.yaml
@@ -315,7 +315,7 @@ ph-ee-engine:
     resources:
       requests:
         cpu: 50m
-        memory: 192Miq
+        memory: 192Mi
       limits:
         cpu: 300m
         memory: 256Mi


### PR DESCRIPTION
## Problem
`config/ph_values.yaml` line 318 had an invalid Kubernetes memory 
quantity suffix `Miq`:
```yaml
memory: 192Miq
```
`Miq` is not a valid Kubernetes quantity. Valid suffixes are 
`Ki`, `Mi`, `Gi`, etc. This can cause Helm/Kubernetes deployment 
validation to silently fail or reject the resource spec when 
deploying Payment Hub EE.

## Fix
Changed `192Miq` to `192Mi`.

## Related
GAZ-42 — MifosX upgrade epic (memory optimisation is an explicit 
goal of this epic)
GitHub: https://github.com/openMF/mifos-gazelle/issues/102

## Validation
- YAML parses successfully
- Resource quantity scan reports no remaining invalid quantities
- git diff --check passed
- Confirmed not already fixed in any open PR

## Checklist
- [x] CLA signed
- [x] CONTRIBUTING.md read and followed
- [x] Branched from dev
- [x] Single focused fix, no unrelated changes