### PR TITLE
GAZ-286: Add test mode with health checks for infra, mifosx, phee, vnext

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -16,6 +16,7 @@ logging = false
 # The main bottleneck is Fineract's Liquibase migrations on first boot.
 # Default: 600 (10 min). Slow hardware / Raspberry Pi: 1800. Managed cold-start: 900.
 startup_timeout = 1200
+health_check_timeout = 30
 
 [kubernetes]
 # Environment type: 'local' for a local cluster (Linux k3s or macOS Colima — auto-detected),

--- a/docs/MIFOS-GAZELLE-README.md
+++ b/docs/MIFOS-GAZELLE-README.md
@@ -235,6 +235,36 @@ CR definitions live in `src/deployer/operators/paymenthub/config/cr/` — one fi
 
 ---
 
+## Health Checks
+
+After a deployment completes, you can verify all components are healthy:
+
+```bash
+# Check all deployed components
+sudo ./run.sh -u $USER -m test -a all
+
+# Check individual components
+sudo ./run.sh -u $USER -m test -a mifosx
+sudo ./run.sh -u $USER -m test -a phee
+sudo ./run.sh -u $USER -m test -a vnext
+sudo ./run.sh -u $USER -m test -a infra
+
+# Check a subset
+sudo ./run.sh -u $USER -m test -a "mifosx,phee"
+```
+
+Health checks verify:
+- All pods in the component's namespace are `Running` or `Completed`
+- Key web endpoints return HTTP 2xx/3xx responses
+
+If a check fails, the output identifies the failing namespace, pod, or endpoint.
+The `src/utils/k8s-error-summary.py` utility is automatically invoked on pod failures to provide additional diagnostics.
+
+Failed checks return a non-zero exit code, suitable for use in CI pipelines.
+
+
+---
+
 ## Cleanup
 
 ```bash

--- a/src/commandline/commandline.sh
+++ b/src/commandline/commandline.sh
@@ -218,24 +218,26 @@ welcome() {
 #------------------------------------------------------------------------------
 show_usage() {
     echo "
-    USAGE: $0 [-f <config_file_path>] -m [mode] -a [apps] -e [environment] -d [true/false] -r [true/false]
+USAGE: $0 [-f <config_file_path>] -m [mode] -a [apps] -e [environment] -d [true/false] -r [true/false]
 
     Deploys or removes Mifos Gazelle applications on an already-configured cluster.
     Run 'sudo ./setup-env.sh' first to set up the environment (k3s, /etc/hosts, tools).
 
     Example 1 : $0 -m deploy                                  # deploy all apps enabled in config.ini
     Example 2 : $0 -m deploy -a paymenthub                    # deploy PaymentHub only
-    Example 3 : $0 -m deploy -a \"mifosx,vnext\"                # deploy MifosX and vNext only
+    Example 3 : $0 -m deploy -a "mifosx,vnext"                # deploy MifosX and vNext only
     Example 4 : $0 -m deploy -e remote -d true                # deploy on remote cluster with debug
     Example 5 : $0 -m cleanapps                               # delete all deployed apps
     Example 6 : $0 -m cleanapps -a paymenthub                 # delete PaymentHub only
     Example 7 : $0 -f /opt/my_config.ini -m deploy            # use a custom config file
     Example 8 : $0 -m deploy -a setup-data                    # re-run data generation
+    Example 9 : $0 -m test -a all                             # health check all deployed components
+    Example 10: $0 -m test -a mifosx                          # health check MifosX only
 
     Options:
     -f config_file_path .. Specify an alternative config.ini file path (optional)
-    -m mode .............. deploy|cleanapps (required)
-    -u user .............. non-root user for k8s operations (optional, defaults to \$USER)
+    -m mode .............. deploy|cleanapps|test (required)
+    -u user .............. non-root user for k8s operations (optional, defaults to $USER)
     -a apps .............. Comma-separated list of apps or 'all' (optional)
                            Valid: vnext paymenthub mifosx infra mastercard-demo openg2p openspp setup-data all
     -e environment ....... local (default) | remote
@@ -298,14 +300,14 @@ validate_inputs() {
         exit 1
     fi
 
-    if [[ "$mode" != "deploy" && "$mode" != "cleanapps" ]]; then
-        log_error "Invalid mode '$mode'. run.sh accepts: deploy | cleanapps"
+if [[ "$mode" != "deploy" && "$mode" != "cleanapps" && "$mode" != "test" ]]; then
+        log_error "Invalid mode '$mode'. run.sh accepts: deploy | cleanapps | test"
         log_error "For environment setup and teardown use: sudo ./setup-env.sh [-m cleanall]"
         show_usage
         exit 1
     fi
 
-    if [[ "$mode" == "deploy" || "$mode" == "cleanapps" ]]; then
+    if [[ "$mode" == "deploy" || "$mode" == "cleanapps" || "$mode" == "test" ]]; then
         if [[ -z "$apps" ]]; then
             log_warn "No apps specified via -a or config file. Defaulting to 'all'."
             apps="all"
@@ -356,7 +358,7 @@ validate_inputs() {
                 # for mode = deploy ensure 'infra' is first app if present
                 apps="infra $(echo "$apps" | sed 's/infra//')"
                 apps=$(echo "$apps" | xargs)
-            else # mode = cleanapps
+            elif [[ "$mode" == "cleanapps" ]]; then
                 # for mode = cleanapps ensure 'infra' is last app if present
                 apps="$(echo "$apps" | sed 's/infra//') infra"
                 apps=$(echo "$apps" | xargs)
@@ -562,6 +564,9 @@ main() {
     elif [ "$mode" == "cleanapps" ]; then
         log_with_verbose_check "$debug" "$INFO" "Cleaning up Mifos Gazelle applications only"
         delete_apps "$apps"
+    elif [ "$mode" == "test" ]; then
+        test_apps "$apps"
+        exit $?
     else
         show_usage
         exit 1

--- a/src/deployer/deployer.sh
+++ b/src/deployer/deployer.sh
@@ -385,3 +385,155 @@ deploy_apps() {
   save_applied_domain
   print_deployment_end_message "$data_gen_failed"
 }
+
+#------------------------------------------------------------
+# Description : Checks all pods in a namespace are Running/Completed.
+#               Calls k8s-error-summary.py on failure.
+# Usage : check_pods_ready <namespace>
+# Returns : 0 = all ready, 1 = something not ready
+#------------------------------------------------------------
+check_pods_ready() {
+  local namespace="$1"
+  local not_ready
+
+  not_ready=$(run_as_user "kubectl get pods -n \"$namespace\" --no-headers 2>/dev/null" \
+    | grep -v -E "Running|Completed|Succeeded" | wc -l)
+
+  if [[ "$not_ready" -gt 0 ]]; then
+    log_error "Namespace '$namespace': $not_ready pod(s) not Running/Completed:"
+    run_as_user "kubectl get pods -n \"$namespace\""
+    if [[ -f "$UTILS_DIR/k8s-error-summary.py" ]]; then
+      python3 "$UTILS_DIR/k8s-error-summary.py" "$namespace" || true
+    fi
+    return 1
+  fi
+
+  log_ok
+  return 0
+}
+
+#------------------------------------------------------------
+# Description : Checks an HTTP endpoint is reachable (HTTP 2xx/3xx).
+# Usage : check_endpoint <label> <url>
+# Returns : 0 = reachable, 1 = not reachable
+#------------------------------------------------------------
+check_endpoint() {
+  local label="$1"
+  local url="$2"
+  local http_code
+
+  http_code=$(curl -sk --max-time 10 -o /dev/null -w "%{http_code}" "$url" 2>/dev/null || echo "000")
+
+  if [[ "$http_code" =~ ^[23] ]]; then
+    log_ok
+    return 0
+  else
+
+    log_error "Endpoint '$label' at $url — HTTP $http_code (unreachable or error)"
+    return 1
+  fi
+}
+
+#------------------------------------------------------------
+# Description : Health check for infrastructure namespace.
+#------------------------------------------------------------
+test_infra() {
+  local rc=0
+  log_section "Health check: infra"
+
+  log_step "Pods in namespace '$INFRA_NAMESPACE'"
+  check_pods_ready "$INFRA_NAMESPACE" || rc=1
+
+  log_step "Cluster default health endpoint"
+  check_endpoint "Cluster" "http://${GAZELLE_DOMAIN}/health" || rc=1
+
+  return $rc
+}
+
+#------------------------------------------------------------
+# Description : Health check for MifosX / Fineract.
+#------------------------------------------------------------
+test_mifosx() {
+  local rc=0
+  log_section "Health check: MifosX"
+
+  log_step "Pods in namespace '$MIFOSX_NAMESPACE'"
+  check_pods_ready "$MIFOSX_NAMESPACE" || rc=1
+
+  log_step "Fineract API health endpoint"
+  check_endpoint "Fineract" "https://mifos.${GAZELLE_DOMAIN}/fineract-provider/actuator/health" || rc=1
+
+  return $rc
+}
+
+#------------------------------------------------------------
+# Description : Health check for Payment Hub EE.
+#------------------------------------------------------------
+test_phee() {
+  local rc=0
+  log_section "Health check: Payment Hub EE"
+
+  log_step "Pods in namespace '$PH_NAMESPACE'"
+  check_pods_ready "$PH_NAMESPACE" || rc=1
+
+  log_step "Ops Web endpoint"
+  check_endpoint "Ops Web" "http://ops.${GAZELLE_DOMAIN}" || rc=1
+
+  log_step "Zeebe Operate endpoint"
+  check_endpoint "Zeebe Operate" "http://zeebe-operate.${GAZELLE_DOMAIN}" || rc=1
+
+  return $rc
+}
+
+#------------------------------------------------------------
+# Description : Health check for Mojaloop vNext.
+#------------------------------------------------------------
+test_vnext() {
+  local rc=0
+  log_section "Health check: Mojaloop vNext"
+
+  log_step "Pods in namespace '$VNEXT_NAMESPACE'"
+  check_pods_ready "$VNEXT_NAMESPACE" || rc=1
+
+  log_step "vNext Admin endpoint"
+  check_endpoint "vNext Admin" "http://vnextadmin.${GAZELLE_DOMAIN}" || rc=1
+
+  return $rc
+}
+
+#------------------------------------------------------------
+# Description : Orchestrates health checks for selected components.
+# Usage : test_apps <"app1 app2" | all>
+# Example: test_apps "mifosx phee"
+#------------------------------------------------------------
+test_apps() {
+  local appsToTest="$1"
+  local overall_rc=0
+
+  log_with_verbose_check "$debug" "$DEBUG" "Apps to test: $appsToTest"
+
+  for app in $appsToTest; do
+    case "$app" in
+      "infra")
+        test_infra   || overall_rc=1 ;;
+      "mifosx")
+        test_mifosx  || overall_rc=1 ;;
+      "phee")
+        test_phee    || overall_rc=1 ;;
+      "vnext")
+        test_vnext   || overall_rc=1 ;;
+      *)
+        log_error "Unknown app '$app' for testing. Valid: infra, mifosx, phee, vnext."
+        overall_rc=1
+        ;;
+    esac
+  done
+
+  if [[ "$overall_rc" -eq 0 ]]; then
+    log_banner "All health checks passed"
+  else
+    log_banner "One or more health checks FAILED"
+  fi
+
+  return $overall_rc
+}

--- a/src/deployer/deployer.sh
+++ b/src/deployer/deployer.sh
@@ -394,14 +394,26 @@ deploy_apps() {
 #------------------------------------------------------------
 check_pods_ready() {
   local namespace="$1"
-  local not_ready
+  local kubectl_output
+  local kubectl_exit_code
 
-  not_ready=$(run_as_user "kubectl get pods -n \"$namespace\" --no-headers 2>/dev/null" \
-    | grep -v -E "Running|Completed|Succeeded" | wc -l)
+  kubectl_output=$(run_as_user "kubectl get pods -n \"$namespace\" --no-headers 2>/dev/null")
+  kubectl_exit_code=$?
+
+  if [[ $kubectl_exit_code -ne 0 ]]; then
+    log_error "Namespace '$namespace': kubectl failed (cluster down or namespace missing)"
+    if [[ -f "$UTILS_DIR/k8s-error-summary.py" ]]; then
+      python3 "$UTILS_DIR/k8s-error-summary.py" "$namespace" || true
+    fi
+    return 1
+  fi
+
+  local not_ready
+  not_ready=$(echo "$kubectl_output" | grep -v -E "Running|Completed|Succeeded" | wc -l)
 
   if [[ "$not_ready" -gt 0 ]]; then
     log_error "Namespace '$namespace': $not_ready pod(s) not Running/Completed:"
-    run_as_user "kubectl get pods -n \"$namespace\""
+    echo "$kubectl_output"
     if [[ -f "$UTILS_DIR/k8s-error-summary.py" ]]; then
       python3 "$UTILS_DIR/k8s-error-summary.py" "$namespace" || true
     fi
@@ -422,7 +434,8 @@ check_endpoint() {
   local url="$2"
   local http_code
 
-  http_code=$(curl -sk --max-time 10 -o /dev/null -w "%{http_code}" "$url" 2>/dev/null || echo "000")
+  local timeout="${health_check_timeout:-30}"
+  http_code=$(curl -sk --max-time "$timeout" -o /dev/null -w "%{http_code}" "$url" 2>/dev/null || echo "000")
 
   if [[ "$http_code" =~ ^[23] ]]; then
     log_ok
@@ -525,6 +538,7 @@ test_apps() {
       *)
         log_error "Unknown app '$app' for testing. Valid: infra, mifosx, phee, vnext."
         overall_rc=1
+        # Loop continues — remaining valid apps in $appsToTest will still be tested
         ;;
     esac
   done


### PR DESCRIPTION
Closes #124

Adds `-m test` mode to `run.sh` for health checking deployed components.

Before: `-m test` was rejected as invalid mode.
After: `-m test` runs health checks across all components.

## Changes
- `src/commandline/commandline.sh` — added test mode to validation, usage, and dispatcher
- `src/deployer/deployer.sh` — implemented check_pods_ready, check_endpoint, test_infra, test_mifosx, test_phee, test_vnext, test_apps
- `docs/MIFOS-GAZELLE-README.md` — added health check usage examples

## Test Output
<img width="1539" height="377" alt="image" src="https://github.com/user-attachments/assets/7c546bf5-80b8-4635-ad26-8e44c9faa376" />

