### PR TITLE
Add perf metrics collection, TCO estimator, and JMeter load-test wrapper

### DIFF
--- a/docs/PERF-TCO.md
+++ b/docs/PERF-TCO.md
@@ -1,0 +1,246 @@
+# Performance Testing and TCO Estimation
+
+This guide covers the performance and cost tooling added to Mifos Gazelle.
+Three scripts work together to answer two questions:
+
+- **Performance:** how does the stack behave under load?
+- **TCO:** what does it cost to run this in production on a cloud provider?
+
+---
+
+## Tools
+
+| Script | What it does |
+|--------|-------------|
+| `src/utils/perf/collect-metrics.sh` | Collects CPU/memory usage from a live cluster and writes a JSON report |
+| `src/utils/perf/tco-estimate.py` | Reads that JSON and estimates monthly/annual cloud costs |
+| `src/utils/perf/run-load-test.sh` | Runs the JMeter load test headlessly and captures before/after resource snapshots |
+
+---
+
+## Prerequisites
+
+```bash
+# jq — JSON processor used by collect-metrics.sh
+sudo apt-get install -y jq
+
+# Python 3 — already used by Gazelle; no extra packages needed for tco-estimate.py
+
+# JMeter — only needed for run-load-test.sh
+wget https://downloads.apache.org/jmeter/binaries/apache-jmeter-5.6.3.tgz
+tar -xzf apache-jmeter-5.6.3.tgz -C $HOME
+mv $HOME/apache-jmeter-5.6.3 $HOME/apache-jmeter
+export PATH=$HOME/apache-jmeter/bin:$PATH
+```
+
+All three tools have a `--mock` flag that runs with built-in sample data so you can test them without a live cluster.
+
+---
+
+## Quick Start (no cluster needed)
+
+```bash
+# 1. Collect metrics (mock mode)
+bash src/utils/perf/collect-metrics.sh --mock --out /tmp/metrics.json
+
+# 2. Estimate TCO from those metrics
+python3 src/utils/perf/tco-estimate.py --metrics /tmp/metrics.json
+
+# 3. Compare across all cloud providers
+python3 src/utils/perf/tco-estimate.py --metrics /tmp/metrics.json --all-providers
+
+# 4. See what a load test would run (mock mode, no JMeter needed)
+bash src/utils/perf/run-load-test.sh --mock
+```
+
+---
+
+## Collecting Metrics from a Live Cluster
+
+Requires a running Gazelle deployment and `kubectl` configured.
+k3s includes metrics-server by default so `kubectl top` works out of the box.
+
+```bash
+# Collect from the default kubeconfig
+bash src/utils/perf/collect-metrics.sh
+
+# Custom kubeconfig (e.g. remote cluster)
+bash src/utils/perf/collect-metrics.sh --kubeconfig ~/.kube/my-cluster.yaml
+
+# Save to a specific file
+bash src/utils/perf/collect-metrics.sh --out /tmp/gazelle-metrics.json
+
+# Include PVC requested storage per namespace (recommended for TCO)
+bash src/utils/perf/collect-metrics.sh --storage --out /tmp/gazelle-metrics.json
+```
+
+The script queries `kubectl top pods` for each Gazelle namespace (`infra`, `mifosx`, `paymenthub`, `vnext`) and writes a JSON file with per-pod and per-namespace CPU/memory figures.
+
+---
+
+## TCO Estimation
+
+```bash
+# AWS us-east-1 (default)
+python3 src/utils/perf/tco-estimate.py --metrics /tmp/gazelle-metrics.json
+
+# GCP us-central1
+python3 src/utils/perf/tco-estimate.py --metrics /tmp/gazelle-metrics.json \
+  --provider gcp --region us-central1
+
+# Azure East US
+python3 src/utils/perf/tco-estimate.py --metrics /tmp/gazelle-metrics.json \
+  --provider azure --region eastus
+
+# Compare all providers and regions at once
+python3 src/utils/perf/tco-estimate.py --metrics /tmp/gazelle-metrics.json \
+  --all-providers
+
+# Adjust headroom buffer (default 30%)
+python3 src/utils/perf/tco-estimate.py --metrics /tmp/gazelle-metrics.json \
+  --headroom 0.50
+
+# Set monthly network egress explicitly (GiB/month)
+python3 src/utils/perf/tco-estimate.py --metrics /tmp/gazelle-metrics.json \
+  --egress-gib 50
+
+# Model HA baseline (3 nodes)
+python3 src/utils/perf/tco-estimate.py --metrics /tmp/gazelle-metrics.json \
+  --topology ha-3node
+
+# Use external pricing catalog (recommended for freshness)
+python3 src/utils/perf/tco-estimate.py --metrics /tmp/gazelle-metrics.json \
+  --pricing-file /tmp/pricing.json
+
+# Save full JSON output for further processing
+python3 src/utils/perf/tco-estimate.py --metrics /tmp/gazelle-metrics.json \
+  --json-out /tmp/tco-result.json
+```
+
+### How the estimate works
+
+1. Reads measured CPU and memory from the metrics file
+2. Adds a headroom buffer (default 30%) for OS overhead and traffic spikes
+3. Finds the cheapest cloud instance that satisfies both CPU and memory requirements
+4. Computes: `instance_hourly_price × 730 hours/month`
+5. Adds storage (prefer measured PVC requested capacity if present) and network egress costs
+6. Breaks down costs proportionally per DPG component
+
+### Interpreting the output
+
+- The estimate is for a **single-node demo/test deployment** by default
+- A production HA deployment (3+ nodes for redundancy) would cost roughly 3× more
+- Reserved instance pricing (1-year) typically cuts the compute cost by 30–40%
+- Prices are on-demand rates as of early 2026 — verify against provider pricing pages before budgeting
+- PVC storage values represent **requested capacity**, not actual used bytes
+- Network cost accuracy depends on realistic `--egress-gib` input from observed traffic
+
+---
+
+## Load Testing
+
+Requires JMeter installed and a running Gazelle deployment.
+
+```bash
+# Basic run — 10 users for 60 seconds
+bash src/utils/perf/run-load-test.sh
+
+# Higher load
+bash src/utils/perf/run-load-test.sh --threads 50 --duration 300 --rampup 30
+
+# Custom host (e.g. remote cluster)
+bash src/utils/perf/run-load-test.sh --host ops.my-cluster.example.com --port 443
+
+# Specify JMeter location explicitly
+bash src/utils/perf/run-load-test.sh --jmeter $HOME/apache-jmeter/bin
+
+# Save results to a specific directory
+bash src/utils/perf/run-load-test.sh --out /tmp/my-load-test
+```
+
+The script:
+1. Takes a resource snapshot before the test (`metrics-before.json`)
+2. Runs `performance-testing/paymentHubEE.jmx` headlessly via JMeter CLI
+3. Takes a resource snapshot after the test (`metrics-after.json`)
+4. Prints a summary of request counts, pass/fail rates, and response times
+5. Shows the CPU/memory delta between before and after
+
+### Output files
+
+```
+/tmp/gazelle-perf-<timestamp>/
+├── report/index.html      # JMeter HTML report (open in browser)
+├── results.jtl            # Raw results CSV
+├── metrics-before.json    # Resource snapshot before test
+├── metrics-after.json     # Resource snapshot after test
+├── summary.txt            # Human-readable summary
+└── jmeter.log             # JMeter execution log
+```
+
+### Full pipeline: load test → TCO under load
+
+```bash
+# Run load test
+bash src/utils/perf/run-load-test.sh --threads 20 --duration 120 --out /tmp/lt
+
+# Estimate TCO based on resource usage observed during the load test
+python3 src/utils/perf/tco-estimate.py --metrics /tmp/lt/metrics-after.json
+```
+
+This gives you a TCO estimate that reflects actual resource consumption under realistic load, not just idle usage.
+
+---
+
+## Data Provenance: What Comes From Where
+
+- **CPU/Memory (live):** `kubectl top pods` across `infra`, `mifosx`, `paymenthub`, `vnext`
+- **CPU/Memory (mock):** hardcoded representative pod metrics in `collect-metrics.sh`
+- **Storage (live):** `kubectl get pvc` requested sizes, converted to GiB (`--storage`)
+- **Storage (mock):** representative namespace-level values in `collect-metrics.sh`
+- **Pricing (default):** embedded `INSTANCE_CATALOG` in `tco-estimate.py`
+- **Pricing (override):** `--pricing-file` JSON catalog (supports optional metadata)
+- **Egress:** user input via `--egress-gib` (defaults to a conservative baseline)
+- **Topology:** `--topology single-node|ha-3node`
+
+### Pricing File Formats
+
+Raw catalog format:
+
+```json
+{
+  "aws": {
+    "us-east-1": [
+      {"name": "m6i.xlarge", "vcpu": 4, "ram_gib": 16, "price_usd_hr": 0.192}
+    ]
+  }
+}
+```
+
+Metadata-wrapped format:
+
+```json
+{
+  "pricing_as_of": "2026-05",
+  "source": "manual provider snapshot",
+  "catalog": {
+    "aws": {
+      "us-east-1": [
+        {"name": "m6i.xlarge", "vcpu": 4, "ram_gib": 16, "price_usd_hr": 0.192}
+      ]
+    }
+  }
+}
+```
+
+---
+
+## Supported Cloud Providers and Regions
+
+| Provider | Regions |
+|----------|---------|
+| AWS | `us-east-1`, `eu-west-1`, `ap-southeast-1` |
+| GCP | `us-central1`, `europe-west1` |
+| Azure | `eastus`, `westeurope` |
+
+Pricing data is embedded in `tco-estimate.py` and reflects approximate on-demand Linux instance prices as of early 2026.
+To add a region, extend the `INSTANCE_CATALOG` dictionary in that file.

--- a/docs/PERF-TCO.md
+++ b/docs/PERF-TCO.md
@@ -1,6 +1,7 @@
 # Performance Testing and TCO Estimation
 
-This guide covers the performance and cost tooling added to Mifos Gazelle.
+This guide covers optional performance and total-cost-of-ownership (TCO) tooling for Mifos Gazelle. For full deployment prerequisites (RAM, disk, OS), see [MIFOS-GAZELLE-README.md](MIFOS-GAZELLE-README.md).
+
 Three scripts work together to answer two questions:
 
 - **Performance:** how does the stack behave under load?
@@ -26,7 +27,8 @@ sudo apt-get install -y jq
 
 # Python 3 — already used by Gazelle; no extra packages needed for tco-estimate.py
 
-# JMeter — only needed for run-load-test.sh
+# JMeter — only needed for run-load-test.sh (requires a JDK on PATH)
+sudo apt-get install -y default-jdk
 wget https://downloads.apache.org/jmeter/binaries/apache-jmeter-5.6.3.tgz
 tar -xzf apache-jmeter-5.6.3.tgz -C $HOME
 mv $HOME/apache-jmeter-5.6.3 $HOME/apache-jmeter
@@ -126,6 +128,22 @@ python3 src/utils/perf/tco-estimate.py --metrics /tmp/gazelle-metrics.json \
 5. Adds storage (prefer measured PVC requested capacity if present) and network egress costs
 6. Breaks down costs proportionally per DPG component
 
+### Measured inputs vs modeled costs
+
+The dollar amounts are **not** taken from your cloud bill. They are a **model** built from:
+
+| Input | Source |
+|-------|--------|
+| CPU and memory totals | **Measured** at collection time via `kubectl top pods` (point-in-time usage, not limits). |
+| Per-namespace PVC sizes (`--storage`) | **Measured** as Kubernetes **requested** capacity on each PVC, summed per namespace (not actual bytes written). |
+| Instance type and hourly rate | **Modeled** from the built-in catalog or `--pricing-file` (indicative on-demand Linux prices). |
+| Monthly compute | `hourly_rate × 730 hours × topology multiplier` (`single-node` = 1, `ha-3node` = 3). The HA multiplier is a planning shortcut, not proof of a three-node architecture. |
+| Monthly storage | `total_requested_gib × provider_storage_price_per_gib_month × topology multiplier`. |
+| Monthly network | `--egress-gib` (GiB/month) × provider egress price per GiB — **you supply** egress unless you have metering data. |
+| Per-component (DPG) cost share | **Heuristic:** allocated by each component’s share of **measured memory** across namespaces, not true chargeback. |
+
+So: **workload shape is grounded in real cluster snapshots**; **prices, egress, HA shape, and allocation method are assumptions** you should tune and disclose when sharing numbers.
+
 ### Interpreting the output
 
 - The estimate is for a **single-node demo/test deployment** by default
@@ -188,6 +206,38 @@ python3 src/utils/perf/tco-estimate.py --metrics /tmp/lt/metrics-after.json
 ```
 
 This gives you a TCO estimate that reflects actual resource consumption under realistic load, not just idle usage.
+
+The bundled `performance-testing/paymentHubEE.jmx` plan may return HTTP errors until it is aligned with your deployment (correct host, paths, and authentication). The wrapper script still produces snapshots, JTL output, and an HTML report for iteration.
+
+---
+
+## Exporting evidence from a test VM
+
+Artifacts are written under `/tmp` by default. To copy them to your laptop:
+
+**Option A — one archive on the VM, then download**
+
+Run on the VM (adjust paths if your load-test output directory differs):
+
+```bash
+cd /tmp
+tar -czf gazelle-perf-evidence.tgz live-metrics.json tco-result.json live-lt
+```
+
+If `live-lt` or `tco-result.json` does not exist yet, omit those names or create them first. Then download `/tmp/gazelle-perf-evidence.tgz` from the VM (for example Google Cloud browser SSH: use the **Download file** action and enter that path).
+
+From a machine with the Google Cloud SDK installed:
+gcloud compute scp INSTANCE_NAME:/tmp/gazelle-perf-evidence.tgz . --zone YOUR_ZONE
+```
+
+**Option B — individual files with `gcloud compute scp`**
+
+```bash
+gcloud compute scp INSTANCE_NAME:/tmp/live-metrics.json ./gazelle-evidence/ --zone YOUR_ZONE
+gcloud compute scp --recurse INSTANCE_NAME:/tmp/live-lt ./gazelle-evidence/live-lt --zone YOUR_ZONE
+```
+
+Keep evidence outside the git tree (for example a local `gazelle-evidence/` directory that is gitignored) unless maintainers ask for artifacts attached to an issue or PR.
 
 ---
 

--- a/src/utils/perf/collect-metrics.sh
+++ b/src/utils/perf/collect-metrics.sh
@@ -1,0 +1,401 @@
+#!/usr/bin/env bash
+# collect-metrics.sh -- Collect CPU/memory resource usage from a live Gazelle deployment
+#
+# Queries kubectl top for all Gazelle namespaces and writes a structured JSON
+# report that the TCO calculator (tco-estimate.py) can consume.
+# Also collects actual PVC storage usage when --storage flag is passed.
+#
+# Usage:
+#   ./src/utils/perf/collect-metrics.sh [--kubeconfig <path>] [--out <file>] [--storage]
+#   ./src/utils/perf/collect-metrics.sh --mock
+#
+# Output: JSON file at /tmp/gazelle-metrics-<timestamp>.json (or --out path)
+#
+# Requirements:
+#   - kubectl installed and configured (skipped in --mock mode)
+#   - metrics-server running in the cluster (k3s includes this by default)
+#   - jq installed (for JSON formatting)
+
+set -euo pipefail
+
+# ── colour helpers (inline so this script is self-contained) ─────────────────
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'
+BLUE='\033[0;34m'; BOLD='\033[1m'; RESET='\033[0m'
+
+log_section() { echo -e "\n${BLUE}${BOLD}==> $*${RESET}"; }
+log_step()    { printf "%-55s" "    $*"; }
+log_ok()      { echo -e "${GREEN}[  ok  ]${RESET}"; }
+log_warn()    { echo -e "${YELLOW}WARN${RESET}   $*"; }
+log_error()   { echo -e "${RED}ERROR${RESET}  $*"; }
+
+# ── defaults ─────────────────────────────────────────────────────────────────
+KUBECONFIG_PATH="${KUBECONFIG:-$HOME/.kube/config}"
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+OUT_FILE="/tmp/gazelle-metrics-${TIMESTAMP}.json"
+MOCK_MODE=false
+COLLECT_STORAGE=false
+
+# Gazelle namespaces to measure
+GAZELLE_NAMESPACES=("infra" "mifosx" "paymenthub" "vnext")
+
+# ── argument parsing ──────────────────────────────────────────────────────────
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --kubeconfig) KUBECONFIG_PATH="$2"; shift 2 ;;
+    --out)        OUT_FILE="$2";        shift 2 ;;
+    --mock)       MOCK_MODE=true;       shift   ;;
+    --storage)    COLLECT_STORAGE=true; shift   ;;
+    -h|--help)
+      echo "Usage: $0 [--kubeconfig <path>] [--out <file>] [--mock] [--storage]"
+      echo "  --storage  Also collect PVC sizes from the cluster (live mode only)"
+      exit 0 ;;
+    *) log_error "Unknown option: $1"; exit 1 ;;
+  esac
+done
+
+export KUBECONFIG="$KUBECONFIG_PATH"
+
+# ── dependency checks ─────────────────────────────────────────────────────────
+check_deps() {
+  local missing=()
+  command -v jq &>/dev/null || missing+=("jq")
+  if [[ "$MOCK_MODE" == "false" ]]; then
+    command -v kubectl &>/dev/null || missing+=("kubectl")
+  fi
+  if [[ ${#missing[@]} -gt 0 ]]; then
+    log_error "Missing required tools: ${missing[*]}"
+    echo "  Install jq:      sudo apt-get install -y jq"
+    echo "  Install kubectl: https://kubernetes.io/docs/tasks/tools/"
+    exit 1
+  fi
+}
+
+# ── kubectl top parser ────────────────────────────────────────────────────────
+# kubectl top pods -n <ns> --no-headers outputs lines like:
+#   fineract-server-xxx-yyy   245m   512Mi
+# Parses into one JSON object per pod.
+parse_top_output() {
+  local ns="$1"
+  local raw="$2"
+
+  echo "$raw" | awk -v namespace="$ns" '
+    NF >= 3 {
+      pod=$1; cpu=$2; mem=$3
+
+      cpu_val = cpu
+      if (sub(/m$/, "", cpu_val)) { cpu_m = cpu_val + 0 }
+      else                        { cpu_m = cpu_val * 1000 }
+
+      mem_val = mem
+      if      (sub(/Gi$/, "", mem_val)) { mem_mib = mem_val * 1024 }
+      else if (sub(/Mi$/, "", mem_val)) { mem_mib = mem_val + 0 }
+      else if (sub(/Ki$/, "", mem_val)) { mem_mib = mem_val / 1024 }
+      else                              { mem_mib = mem_val / 1048576 }
+
+      printf "{\"namespace\":\"%s\",\"pod\":\"%s\",\"cpu_millicores\":%d,\"memory_mib\":%.1f}\n",
+             namespace, pod, cpu_m, mem_mib
+    }
+  '
+}
+
+# ── collect PVC storage from cluster ─────────────────────────────────────────
+# Returns a JSON object: {namespace: requested_gib, ...}
+collect_pvc_storage() {
+  local pvc_json="{}"
+
+  for ns in "${GAZELLE_NAMESPACES[@]}"; do
+    if ! kubectl get namespace "$ns" &>/dev/null; then
+      continue
+    fi
+
+    # Sum requested storage for all PVCs in this namespace
+    local total_gib
+    total_gib=$(kubectl get pvc -n "$ns" -o json 2>/dev/null | jq '
+      [.items[].spec.resources.requests.storage // "0"] |
+      map(
+        if   test("Gi$") then gsub("Gi";"") | tonumber
+        elif test("Mi$") then gsub("Mi";"") | tonumber / 1024
+        elif test("Ti$") then gsub("Ti";"") | tonumber * 1024
+        else 0
+        end
+      ) | add // 0
+    ')
+
+    pvc_json=$(echo "$pvc_json" | jq --arg ns "$ns" --argjson gib "$total_gib" \
+      '. + {($ns): $gib}')
+  done
+
+  echo "$pvc_json"
+}
+
+# ── collect from live cluster ─────────────────────────────────────────────────
+# Sets globals: PODS_JSON, NS_SUMMARIES_JSON
+collect_live() {
+  log_section "Collecting resource metrics from cluster"
+
+  log_step "Cluster connectivity"
+  if ! kubectl cluster-info &>/dev/null; then
+    echo ""
+    log_error "Cannot reach cluster. Check your kubeconfig: $KUBECONFIG_PATH"
+    exit 1
+  fi
+  log_ok
+
+  log_step "Metrics-server availability"
+  if ! kubectl top nodes &>/dev/null 2>&1; then
+    echo ""
+    log_warn "metrics-server not responding. On k3s run:"
+    log_warn "  kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml"
+    log_warn "Then wait ~60s and retry."
+    exit 1
+  fi
+  log_ok
+
+  PODS_JSON="[]"
+  NS_SUMMARIES_JSON="[]"
+
+  for ns in "${GAZELLE_NAMESPACES[@]}"; do
+    log_step "Namespace: $ns"
+
+    if ! kubectl get namespace "$ns" &>/dev/null; then
+      echo -e "${YELLOW}[not deployed]${RESET}"
+      continue
+    fi
+
+    local raw
+    raw=$(kubectl top pods -n "$ns" --no-headers 2>/dev/null || true)
+
+    if [[ -z "$raw" ]]; then
+      echo -e "${YELLOW}[no pods running]${RESET}"
+      continue
+    fi
+
+    local pods_json
+    pods_json=$(parse_top_output "$ns" "$raw")
+
+    while IFS= read -r pod_obj; do
+      [[ -z "$pod_obj" ]] && continue
+      PODS_JSON=$(echo "$PODS_JSON" | jq --argjson p "$pod_obj" '. + [$p]')
+    done <<< "$pods_json"
+
+    local total_cpu total_mem pod_count
+    total_cpu=$(echo "$pods_json" | jq -s '[.[].cpu_millicores] | add // 0')
+    total_mem=$(echo "$pods_json" | jq -s '[.[].memory_mib]     | add // 0')
+    pod_count=$(echo "$pods_json" | jq -s 'length')
+
+    local ns_summary
+    ns_summary=$(jq -n \
+      --arg  ns    "$ns" \
+      --argjson cpu   "$total_cpu" \
+      --argjson mem   "$total_mem" \
+      --argjson count "$pod_count" \
+      '{namespace: $ns, pod_count: $count, total_cpu_millicores: $cpu, total_memory_mib: $mem}')
+
+    NS_SUMMARIES_JSON=$(echo "$NS_SUMMARIES_JSON" | jq --argjson s "$ns_summary" '. + [$s]')
+    log_ok
+  done
+}
+
+# ── mock data (for testing without a cluster) ─────────────────────────────────
+# Representative values from a typical single-node Gazelle deployment.
+collect_mock() {
+  log_warn "Running in MOCK mode — using representative sample data, not a live cluster."
+  echo ""
+
+  PODS_JSON='[
+    {"namespace":"infra","pod":"mysql-0","cpu_millicores":45,"memory_mib":512.0},
+    {"namespace":"infra","pod":"kafka-0","cpu_millicores":120,"memory_mib":768.0},
+    {"namespace":"infra","pod":"redis-master-0","cpu_millicores":8,"memory_mib":32.0},
+    {"namespace":"infra","pod":"mongodb-0","cpu_millicores":35,"memory_mib":256.0},
+    {"namespace":"infra","pod":"elasticsearch-master-0","cpu_millicores":180,"memory_mib":1024.0},
+    {"namespace":"infra","pod":"nginx-ingress-controller","cpu_millicores":12,"memory_mib":64.0},
+    {"namespace":"mifosx","pod":"fineract-server-xxx","cpu_millicores":320,"memory_mib":1536.0},
+    {"namespace":"mifosx","pod":"mifos-web-app-xxx","cpu_millicores":5,"memory_mib":48.0},
+    {"namespace":"paymenthub","pod":"ph-ee-connector-channel-xxx","cpu_millicores":85,"memory_mib":384.0},
+    {"namespace":"paymenthub","pod":"ph-ee-operations-app-xxx","cpu_millicores":60,"memory_mib":256.0},
+    {"namespace":"paymenthub","pod":"ph-ee-bulk-processor-xxx","cpu_millicores":70,"memory_mib":320.0},
+    {"namespace":"paymenthub","pod":"zeebe-gateway-xxx","cpu_millicores":95,"memory_mib":512.0},
+    {"namespace":"paymenthub","pod":"zeebe-broker-0","cpu_millicores":140,"memory_mib":768.0},
+    {"namespace":"vnext","pod":"account-lookup-svc-xxx","cpu_millicores":40,"memory_mib":192.0},
+    {"namespace":"vnext","pod":"transfers-bc-xxx","cpu_millicores":55,"memory_mib":256.0},
+    {"namespace":"vnext","pod":"quoting-bc-xxx","cpu_millicores":35,"memory_mib":192.0},
+    {"namespace":"vnext","pod":"participants-bc-xxx","cpu_millicores":30,"memory_mib":160.0},
+    {"namespace":"vnext","pod":"admin-ui-xxx","cpu_millicores":5,"memory_mib":64.0}
+  ]'
+
+  NS_SUMMARIES_JSON='[
+    {"namespace":"infra","pod_count":6,"total_cpu_millicores":400,"total_memory_mib":2656.0},
+    {"namespace":"mifosx","pod_count":2,"total_cpu_millicores":325,"total_memory_mib":1584.0},
+    {"namespace":"paymenthub","pod_count":5,"total_cpu_millicores":450,"total_memory_mib":2240.0},
+    {"namespace":"vnext","pod_count":5,"total_cpu_millicores":165,"total_memory_mib":864.0}
+  ]'
+}
+
+# ── node metrics ──────────────────────────────────────────────────────────────
+collect_node_metrics() {
+  if [[ "$MOCK_MODE" == "true" ]]; then
+    echo '{"node_count":1,"total_cpu_millicores":4000,"total_memory_mib":16384}'
+    return
+  fi
+
+  local node_raw
+  node_raw=$(kubectl top nodes --no-headers 2>/dev/null || true)
+
+  if [[ -z "$node_raw" ]]; then
+    echo '{"node_count":0,"total_cpu_millicores":0,"total_memory_mib":0}'
+    return
+  fi
+
+  echo "$node_raw" | awk '
+    NF >= 3 {
+      cpu=$2; mem=$4
+      cpu_val=cpu
+      if (sub(/m$/, "", cpu_val)) cpu_m = cpu_val + 0
+      else                        cpu_m = cpu_val * 1000
+      mem_val=mem
+      if      (sub(/Gi$/, "", mem_val)) mem_mib = mem_val * 1024
+      else if (sub(/Mi$/, "", mem_val)) mem_mib = mem_val + 0
+      else                              mem_mib = mem_val / 1048576
+      total_cpu += cpu_m; total_mem += mem_mib; count++
+    }
+    END {
+      printf "{\"node_count\":%d,\"total_cpu_millicores\":%d,\"total_memory_mib\":%.0f}\n",
+             count, total_cpu, total_mem
+    }
+  '
+}
+
+# ── assemble final JSON report ────────────────────────────────────────────────
+build_report() {
+  local pods_json="$1"
+  local ns_summaries_json="$2"
+  local node_metrics="$3"
+  local storage_json="$4"
+
+  local grand_cpu grand_mem total_pods
+  grand_cpu=$(echo "$pods_json"  | jq '[.[].cpu_millicores] | add // 0')
+  grand_mem=$(echo "$pods_json"  | jq '[.[].memory_mib]     | add // 0')
+  total_pods=$(echo "$pods_json" | jq 'length')
+
+  jq -n \
+    --arg  ts          "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    --arg  mode        "$([[ "$MOCK_MODE" == "true" ]] && echo "mock" || echo "live")" \
+    --argjson pods         "$pods_json" \
+    --argjson ns_summaries "$ns_summaries_json" \
+    --argjson nodes        "$node_metrics" \
+    --argjson storage      "$storage_json" \
+    --argjson grand_cpu    "$grand_cpu" \
+    --argjson grand_mem    "$grand_mem" \
+    --argjson total_pods   "$total_pods" \
+    '{
+      collected_at: $ts,
+      mode: $mode,
+      cluster: $nodes,
+      summary: {
+        total_pods: $total_pods,
+        total_cpu_millicores: $grand_cpu,
+        total_memory_mib: $grand_mem,
+        total_cpu_cores: ($grand_cpu / 1000),
+        total_memory_gib: ($grand_mem / 1024)
+      },
+      storage_gib: $storage,
+      namespaces: $ns_summaries,
+      pods: $pods
+    }'
+}
+
+# ── print human-readable summary ─────────────────────────────────────────────
+print_summary() {
+  local report="$1"
+
+  echo ""
+  echo -e "${BLUE}${BOLD}  Resource Usage Summary${RESET}"
+  echo    "  ─────────────────────────────────────────────────"
+  printf  "  %-20s %10s %12s\n" "Namespace" "CPU (cores)" "Memory (GiB)"
+  echo    "  ─────────────────────────────────────────────────"
+
+  # Use a temp file to avoid subshell variable scoping issues with while+IFS
+  local tmpfile
+  tmpfile=$(mktemp)
+  echo "$report" | jq -r '.namespaces[] | [.namespace, (.total_cpu_millicores/1000), (.total_memory_mib/1024)] | @tsv' > "$tmpfile"
+  while IFS=$'\t' read -r ns cpu mem; do
+    printf "  %-20s %10.2f %12.2f\n" "$ns" "$cpu" "$mem"
+  done < "$tmpfile"
+  rm -f "$tmpfile"
+
+  echo    "  ─────────────────────────────────────────────────"
+  local total_cpu total_mem
+  total_cpu=$(echo "$report" | jq '.summary.total_cpu_cores')
+  total_mem=$(echo "$report"  | jq '.summary.total_memory_gib')
+  printf  "  %-20s %10.2f %12.2f\n" "TOTAL" "$total_cpu" "$total_mem"
+
+  # Show measured storage if present
+  local has_storage
+  has_storage=$(echo "$report" | jq '.storage_gib | length > 0')
+  if [[ "$has_storage" == "true" ]]; then
+    echo ""
+    echo -e "${BLUE}${BOLD}  Measured PVC Storage${RESET}"
+    echo    "  ─────────────────────────────────────────────────"
+    local stmpfile
+    stmpfile=$(mktemp)
+    echo "$report" | jq -r '.storage_gib | to_entries[] | [.key, .value] | @tsv' > "$stmpfile"
+    while IFS=$'\t' read -r ns gib; do
+      printf "  %-20s %10.1f GiB\n" "$ns" "$gib"
+    done < "$stmpfile"
+    rm -f "$stmpfile"
+  fi
+
+  echo ""
+}
+
+# ── globals set by collect_live / collect_mock ────────────────────────────────
+PODS_JSON="[]"
+NS_SUMMARIES_JSON="[]"
+
+# ── main ──────────────────────────────────────────────────────────────────────
+main() {
+  check_deps
+
+  echo -e "${BLUE}${BOLD}"
+  echo "  Mifos Gazelle — Resource Metrics Collector"
+  echo -e "${RESET}"
+
+  if [[ "$MOCK_MODE" == "true" ]]; then
+    collect_mock
+  else
+    collect_live
+  fi
+
+  log_step "Collecting node metrics"
+  local node_metrics
+  node_metrics=$(collect_node_metrics)
+  log_ok
+
+  # Storage: collect from cluster if --storage flag set, else empty object
+  local storage_json="{}"
+  if [[ "$COLLECT_STORAGE" == "true" && "$MOCK_MODE" == "false" ]]; then
+    log_step "Collecting PVC storage"
+    storage_json=$(collect_pvc_storage)
+    log_ok
+  elif [[ "$MOCK_MODE" == "true" ]]; then
+    # Provide representative mock storage so tco-estimate.py can use real values
+    storage_json='{"infra":45,"mifosx":8,"paymenthub":9,"vnext":7}'
+  fi
+
+  log_step "Building report"
+  local report
+  report=$(build_report "$PODS_JSON" "$NS_SUMMARIES_JSON" "$node_metrics" "$storage_json")
+  log_ok
+
+  log_step "Writing report to $OUT_FILE"
+  echo "$report" | jq '.' > "$OUT_FILE"
+  log_ok
+
+  print_summary "$report"
+
+  echo -e "${GREEN}  Report saved: $OUT_FILE${RESET}"
+  echo -e "  Run TCO estimate: python3 src/utils/perf/tco-estimate.py --metrics $OUT_FILE"
+  echo ""
+}
+
+main "$@"

--- a/src/utils/perf/collect-metrics.sh
+++ b/src/utils/perf/collect-metrics.sh
@@ -78,7 +78,7 @@ parse_top_output() {
   local ns="$1"
   local raw="$2"
 
-  echo "$raw" | awk -v namespace="$ns" '
+  echo "$raw" | awk -v ns_name="$ns" '
     NF >= 3 {
       pod=$1; cpu=$2; mem=$3
 
@@ -93,7 +93,7 @@ parse_top_output() {
       else                              { mem_mib = mem_val / 1048576 }
 
       printf "{\"namespace\":\"%s\",\"pod\":\"%s\",\"cpu_millicores\":%d,\"memory_mib\":%.1f}\n",
-             namespace, pod, cpu_m, mem_mib
+             ns_name, pod, cpu_m, mem_mib
     }
   '
 }

--- a/src/utils/perf/run-load-test.sh
+++ b/src/utils/perf/run-load-test.sh
@@ -1,0 +1,362 @@
+#!/usr/bin/env bash
+# run-load-test.sh -- Headless JMeter load test runner for Mifos Gazelle
+#
+# Wraps the existing performance-testing/paymentHubEE.jmx plan so it can be
+# run from the command line without opening the JMeter GUI. Captures a
+# resource snapshot before and after the test so you can see how load
+# affects CPU/memory consumption.
+#
+# Usage:
+#   ./src/utils/perf/run-load-test.sh [options]
+#
+# Options:
+#   --threads   <n>      Number of concurrent virtual users (default: 10)
+#   --duration  <s>      Test duration in seconds (default: 60)
+#   --rampup    <s>      Ramp-up period in seconds (default: 10)
+#   --host      <host>   PaymentHub EE host (default: ops.mifos.gazelle.test)
+#   --port      <port>   PaymentHub EE port (default: 443)
+#   --jmeter    <path>   Path to JMeter bin dir (default: auto-detect)
+#   --out       <dir>    Output directory for reports (default: /tmp/gazelle-perf-<ts>)
+#   --no-snapshot        Skip before/after resource snapshots
+#   --mock               Dry-run: print what would be executed, don't run JMeter
+#
+# Output:
+#   <out>/report/          JMeter HTML report
+#   <out>/results.jtl      Raw JMeter results (CSV)
+#   <out>/metrics-before.json  Resource snapshot before test
+#   <out>/metrics-after.json   Resource snapshot after test
+#   <out>/summary.txt      Human-readable summary
+
+set -euo pipefail
+
+# ── colour helpers ────────────────────────────────────────────────────────────
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'
+BLUE='\033[0;34m'; BOLD='\033[1m'; RESET='\033[0m'
+
+log_section() { echo -e "\n${BLUE}${BOLD}==> $*${RESET}"; }
+log_step()    { printf "%-55s" "    $*"; }
+log_ok()      { echo -e "${GREEN}[  ok  ]${RESET}"; }
+log_warn()    { echo -e "${YELLOW}WARN${RESET}   $*"; }
+log_error()   { echo -e "${RED}ERROR${RESET}  $*"; }
+log_info()    { echo -e "${BLUE}INFO${RESET}   $*"; }
+
+# ── defaults ──────────────────────────────────────────────────────────────────
+THREADS=10
+DURATION=60
+RAMPUP=10
+PH_HOST="ops.mifos.gazelle.test"
+PH_PORT=443
+JMETER_BIN=""
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+OUT_DIR="/tmp/gazelle-perf-${TIMESTAMP}"
+TAKE_SNAPSHOTS=true
+MOCK_MODE=false
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+JMX_FILE="$REPO_ROOT/performance-testing/paymentHubEE.jmx"
+METRICS_SCRIPT="$SCRIPT_DIR/collect-metrics.sh"
+
+# ── argument parsing ──────────────────────────────────────────────────────────
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --threads)      THREADS="$2";      shift 2 ;;
+    --duration)     DURATION="$2";     shift 2 ;;
+    --rampup)       RAMPUP="$2";       shift 2 ;;
+    --host)         PH_HOST="$2";      shift 2 ;;
+    --port)         PH_PORT="$2";      shift 2 ;;
+    --jmeter)       JMETER_BIN="$2";   shift 2 ;;
+    --out)          OUT_DIR="$2";      shift 2 ;;
+    --no-snapshot)  TAKE_SNAPSHOTS=false; shift ;;
+    --mock)         MOCK_MODE=true;    shift ;;
+    -h|--help)
+      sed -n '2,30p' "$0" | grep '^#' | sed 's/^# \?//'
+      exit 0 ;;
+    *) log_error "Unknown option: $1"; exit 1 ;;
+  esac
+done
+
+# ── locate JMeter ─────────────────────────────────────────────────────────────
+find_jmeter() {
+  # 1. Explicit --jmeter flag
+  if [[ -n "$JMETER_BIN" ]]; then
+    if [[ -x "$JMETER_BIN/jmeter" ]]; then
+      echo "$JMETER_BIN/jmeter"
+      return 0
+    fi
+    log_error "JMeter not found at: $JMETER_BIN/jmeter"
+    return 1
+  fi
+
+  # 2. On PATH
+  if command -v jmeter &>/dev/null; then
+    command -v jmeter
+    return 0
+  fi
+
+  # 3. Common install locations
+  for candidate in \
+    "$HOME/apache-jmeter/bin/jmeter" \
+    "/opt/apache-jmeter/bin/jmeter" \
+    "/usr/local/bin/jmeter" \
+    "/usr/share/jmeter/bin/jmeter"
+  do
+    if [[ -x "$candidate" ]]; then
+      echo "$candidate"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+# ── dependency checks ─────────────────────────────────────────────────────────
+check_deps() {
+  local missing=()
+
+  if [[ "$MOCK_MODE" == "false" ]]; then
+    if ! JMETER_CMD=$(find_jmeter); then
+      missing+=("jmeter")
+    fi
+  fi
+
+  if [[ ${#missing[@]} -gt 0 ]]; then
+    log_error "Missing required tools: ${missing[*]}"
+    echo ""
+    echo "  Install JMeter:"
+    echo "    wget https://downloads.apache.org/jmeter/binaries/apache-jmeter-5.6.3.tgz"
+    echo "    tar -xzf apache-jmeter-5.6.3.tgz -C \$HOME"
+    echo "    mv \$HOME/apache-jmeter-5.6.3 \$HOME/apache-jmeter"
+    echo "    export PATH=\$HOME/apache-jmeter/bin:\$PATH"
+    echo ""
+    exit 1
+  fi
+
+  if [[ ! -f "$JMX_FILE" ]]; then
+    log_error "JMeter test plan not found: $JMX_FILE"
+    log_error "Expected at: performance-testing/paymentHubEE.jmx"
+    exit 1
+  fi
+}
+
+# ── take resource snapshot ────────────────────────────────────────────────────
+take_snapshot() {
+  local label="$1"   # "before" or "after"
+  local out_file="$OUT_DIR/metrics-${label}.json"
+
+  if [[ "$TAKE_SNAPSHOTS" == "false" ]]; then
+    return 0
+  fi
+
+  if [[ ! -f "$METRICS_SCRIPT" ]]; then
+    log_warn "collect-metrics.sh not found — skipping $label snapshot"
+    return 0
+  fi
+
+  log_step "Resource snapshot ($label)"
+  if bash "$METRICS_SCRIPT" --storage --out "$out_file" > /dev/null 2>&1; then
+    log_ok
+  else
+    # Non-fatal: snapshot failure shouldn't abort the load test
+    echo -e "${YELLOW}[skipped]${RESET}"
+    log_warn "Could not collect $label snapshot (cluster may not be reachable)"
+  fi
+}
+
+# ── run JMeter ────────────────────────────────────────────────────────────────
+run_jmeter() {
+  local results_file="$OUT_DIR/results.jtl"
+  local report_dir="$OUT_DIR/report"
+  local log_file="$OUT_DIR/jmeter.log"
+
+  mkdir -p "$report_dir"
+
+  # JMeter CLI flags:
+  #   -n           non-GUI (headless) mode
+  #   -t           test plan file
+  #   -l           results log file (JTL/CSV)
+  #   -e           generate HTML report after test
+  #   -o           HTML report output directory
+  #   -j           JMeter log file
+  #   -J<prop>     override a JMeter property (maps to ${__P(prop)} in the JMX)
+  local jmeter_cmd=(
+    "$JMETER_CMD"
+    -n
+    -t "$JMX_FILE"
+    -l "$results_file"
+    -e -o "$report_dir"
+    -j "$log_file"
+    -Jthreads="$THREADS"
+    -Jduration="$DURATION"
+    -Jrampup="$RAMPUP"
+    -Jhost="$PH_HOST"
+    -Jport="$PH_PORT"
+  )
+
+  log_info "Running: ${jmeter_cmd[*]}"
+  echo ""
+
+  if "${jmeter_cmd[@]}"; then
+    return 0
+  else
+    log_error "JMeter exited with errors. Check: $log_file"
+    return 1
+  fi
+}
+
+# ── parse JTL results ─────────────────────────────────────────────────────────
+# JTL is a CSV with header: timeStamp,elapsed,label,responseCode,success,...
+parse_jtl() {
+  local jtl="$1"
+
+  if [[ ! -f "$jtl" ]]; then
+    echo "  No results file found."
+    return
+  fi
+
+  awk -F',' '
+    NR == 1 { next }   # skip header
+    {
+      elapsed=$2; success=$8
+      total++
+      if (success == "true") passed++
+      else failed++
+      sum_elapsed += elapsed
+      if (elapsed > max_elapsed) max_elapsed = elapsed
+      if (min_elapsed == 0 || elapsed < min_elapsed) min_elapsed = elapsed
+    }
+    END {
+      if (total == 0) { print "  No samples recorded."; exit }
+      avg = sum_elapsed / total
+      error_pct = (failed / total) * 100
+      printf "  Total requests:  %d\n",  total
+      printf "  Passed:          %d\n",  passed
+      printf "  Failed:          %d  (%.1f%%)\n", failed, error_pct
+      printf "  Avg response:    %.0f ms\n", avg
+      printf "  Min response:    %.0f ms\n", min_elapsed
+      printf "  Max response:    %.0f ms\n", max_elapsed
+    }
+  ' "$jtl"
+}
+
+# ── compare before/after snapshots ───────────────────────────────────────────
+compare_snapshots() {
+  local before="$OUT_DIR/metrics-before.json"
+  local after="$OUT_DIR/metrics-after.json"
+
+  if [[ ! -f "$before" || ! -f "$after" ]]; then
+    return
+  fi
+
+  if ! command -v jq &>/dev/null; then
+    return
+  fi
+
+  local cpu_before cpu_after mem_before mem_after
+  cpu_before=$(jq '.summary.total_cpu_cores'  "$before")
+  cpu_after=$(jq  '.summary.total_cpu_cores'  "$after")
+  mem_before=$(jq '.summary.total_memory_gib' "$before")
+  mem_after=$(jq  '.summary.total_memory_gib' "$after")
+
+  echo "  Resource delta (before → after load test):"
+  printf "  CPU (cores):  %.2f  →  %.2f\n" "$cpu_before" "$cpu_after"
+  printf "  Memory (GiB): %.2f  →  %.2f\n" "$mem_before" "$mem_after"
+}
+
+# ── write summary file ────────────────────────────────────────────────────────
+write_summary() {
+  local summary_file="$OUT_DIR/summary.txt"
+  {
+    echo "Mifos Gazelle Load Test Summary"
+    echo "================================"
+    echo "Date:       $(date)"
+    echo "Host:       $PH_HOST:$PH_PORT"
+    echo "Threads:    $THREADS"
+    echo "Duration:   ${DURATION}s"
+    echo "Ramp-up:    ${RAMPUP}s"
+    echo ""
+    echo "Results:"
+    parse_jtl "$OUT_DIR/results.jtl"
+    echo ""
+    compare_snapshots
+  } | tee "$summary_file"
+}
+
+# ── mock dry-run ──────────────────────────────────────────────────────────────
+run_mock() {
+  log_warn "MOCK mode — showing what would be executed (JMeter not invoked)"
+  echo ""
+  echo "  JMeter plan:  $JMX_FILE"
+  echo "  Target host:  $PH_HOST:$PH_PORT"
+  echo "  Threads:      $THREADS"
+  echo "  Duration:     ${DURATION}s"
+  echo "  Ramp-up:      ${RAMPUP}s"
+  echo "  Output dir:   $OUT_DIR"
+  echo ""
+  echo "  JMeter command that would run:"
+  echo "    jmeter -n -t $JMX_FILE \\"
+  echo "      -l $OUT_DIR/results.jtl \\"
+  echo "      -e -o $OUT_DIR/report \\"
+  echo "      -Jthreads=$THREADS -Jduration=$DURATION -Jrampup=$RAMPUP \\"
+  echo "      -Jhost=$PH_HOST -Jport=$PH_PORT"
+  echo ""
+  echo "  To run for real: remove --mock flag"
+  echo "  To install JMeter: see --help"
+}
+
+# ── main ──────────────────────────────────────────────────────────────────────
+main() {
+  echo -e "${BLUE}${BOLD}"
+  echo "  Mifos Gazelle — Load Test Runner"
+  echo -e "${RESET}"
+
+  if [[ "$MOCK_MODE" == "true" ]]; then
+    run_mock
+    exit 0
+  fi
+
+  check_deps
+
+  mkdir -p "$OUT_DIR"
+
+  log_section "Test configuration"
+  log_info "Host:       $PH_HOST:$PH_PORT"
+  log_info "Threads:    $THREADS concurrent users"
+  log_info "Duration:   ${DURATION}s"
+  log_info "Ramp-up:    ${RAMPUP}s"
+  log_info "Output:     $OUT_DIR"
+  echo ""
+
+  # Snapshot before
+  log_section "Pre-test resource snapshot"
+  take_snapshot "before"
+
+  # Run the test
+  log_section "Running load test"
+  if ! run_jmeter; then
+    log_error "Load test failed. Check $OUT_DIR/jmeter.log"
+    exit 1
+  fi
+
+  # Snapshot after
+  log_section "Post-test resource snapshot"
+  take_snapshot "after"
+
+  # Summary
+  log_section "Results"
+  write_summary
+
+  echo ""
+  echo -e "${GREEN}  Load test complete.${RESET}"
+  echo "  HTML report:  $OUT_DIR/report/index.html"
+  echo "  Raw results:  $OUT_DIR/results.jtl"
+  echo "  Summary:      $OUT_DIR/summary.txt"
+  if [[ "$TAKE_SNAPSHOTS" == "true" ]]; then
+    echo ""
+    echo "  Run TCO estimate on post-test metrics:"
+    echo "    python3 src/utils/perf/tco-estimate.py --metrics $OUT_DIR/metrics-after.json"
+  fi
+  echo ""
+}
+
+main "$@"

--- a/src/utils/perf/tco-estimate.py
+++ b/src/utils/perf/tco-estimate.py
@@ -1,0 +1,507 @@
+#!/usr/bin/env python3
+"""
+tco-estimate.py -- Total Cost of Ownership calculator for Mifos Gazelle
+
+Reads a metrics JSON file produced by collect-metrics.sh and estimates
+the monthly/annual cloud infrastructure cost to run the Gazelle stack.
+
+Usage:
+    python3 src/utils/perf/tco-estimate.py --metrics /tmp/gazelle-metrics-*.json
+    python3 src/utils/perf/tco-estimate.py --mock
+    python3 src/utils/perf/tco-estimate.py --metrics <file> --provider aws --region us-east-1
+
+How the estimate works:
+    1. Read actual CPU + memory consumption from the metrics file
+    2. Add a headroom buffer (default 30%) for OS overhead and traffic spikes
+    3. Find the cheapest cloud instance that satisfies both CPU and memory
+    4. Multiply instance hourly price × 730 hours/month
+    5. Add estimated storage and network costs
+    6. Output a breakdown per DPG and a grand total
+
+Pricing data is embedded (no API calls needed) and reflects approximate
+on-demand prices as of early 2026. Prices are indicative — always verify
+against the provider's current pricing page before making budget decisions.
+"""
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+
+# ── embedded cloud pricing ────────────────────────────────────────────────────
+# Format: {provider: {region: [{name, vcpu, ram_gib, price_per_hour_usd}]}}
+# Sources (approximate on-demand Linux prices, early 2026):
+#   AWS:   https://aws.amazon.com/ec2/pricing/on-demand/
+#   GCP:   https://cloud.google.com/compute/vm-instance-pricing
+#   Azure: https://azure.microsoft.com/en-us/pricing/details/virtual-machines/linux/
+#
+# To use updated pricing: pass --pricing-file <path> pointing to a JSON file
+# with the same structure as INSTANCE_CATALOG below.
+PRICING_LAST_UPDATED = "2026-01"  # update this when you refresh prices
+
+INSTANCE_CATALOG = {
+    "aws": {
+        "us-east-1": [
+            {"name": "t3.medium",   "vcpu": 2,  "ram_gib": 4,   "price_usd_hr": 0.0416},
+            {"name": "t3.large",    "vcpu": 2,  "ram_gib": 8,   "price_usd_hr": 0.0832},
+            {"name": "t3.xlarge",   "vcpu": 4,  "ram_gib": 16,  "price_usd_hr": 0.1664},
+            {"name": "t3.2xlarge",  "vcpu": 8,  "ram_gib": 32,  "price_usd_hr": 0.3328},
+            {"name": "m6i.large",   "vcpu": 2,  "ram_gib": 8,   "price_usd_hr": 0.096},
+            {"name": "m6i.xlarge",  "vcpu": 4,  "ram_gib": 16,  "price_usd_hr": 0.192},
+            {"name": "m6i.2xlarge", "vcpu": 8,  "ram_gib": 32,  "price_usd_hr": 0.384},
+            {"name": "r6i.large",   "vcpu": 2,  "ram_gib": 16,  "price_usd_hr": 0.126},
+            {"name": "r6i.xlarge",  "vcpu": 4,  "ram_gib": 32,  "price_usd_hr": 0.252},
+        ],
+        "eu-west-1": [
+            {"name": "t3.medium",   "vcpu": 2,  "ram_gib": 4,   "price_usd_hr": 0.0464},
+            {"name": "t3.large",    "vcpu": 2,  "ram_gib": 8,   "price_usd_hr": 0.0928},
+            {"name": "t3.xlarge",   "vcpu": 4,  "ram_gib": 16,  "price_usd_hr": 0.1856},
+            {"name": "t3.2xlarge",  "vcpu": 8,  "ram_gib": 32,  "price_usd_hr": 0.3712},
+            {"name": "m6i.xlarge",  "vcpu": 4,  "ram_gib": 16,  "price_usd_hr": 0.214},
+            {"name": "m6i.2xlarge", "vcpu": 8,  "ram_gib": 32,  "price_usd_hr": 0.428},
+        ],
+        "ap-southeast-1": [
+            {"name": "t3.medium",   "vcpu": 2,  "ram_gib": 4,   "price_usd_hr": 0.0464},
+            {"name": "t3.xlarge",   "vcpu": 4,  "ram_gib": 16,  "price_usd_hr": 0.1856},
+            {"name": "m6i.xlarge",  "vcpu": 4,  "ram_gib": 16,  "price_usd_hr": 0.222},
+            {"name": "m6i.2xlarge", "vcpu": 8,  "ram_gib": 32,  "price_usd_hr": 0.444},
+        ],
+    },
+    "gcp": {
+        "us-central1": [
+            {"name": "e2-standard-2",  "vcpu": 2,  "ram_gib": 8,   "price_usd_hr": 0.0670},
+            {"name": "e2-standard-4",  "vcpu": 4,  "ram_gib": 16,  "price_usd_hr": 0.1340},
+            {"name": "e2-standard-8",  "vcpu": 8,  "ram_gib": 32,  "price_usd_hr": 0.2680},
+            {"name": "n2-standard-4",  "vcpu": 4,  "ram_gib": 16,  "price_usd_hr": 0.1900},
+            {"name": "n2-standard-8",  "vcpu": 8,  "ram_gib": 32,  "price_usd_hr": 0.3800},
+            {"name": "n2-highmem-4",   "vcpu": 4,  "ram_gib": 32,  "price_usd_hr": 0.2960},
+        ],
+        "europe-west1": [
+            {"name": "e2-standard-4",  "vcpu": 4,  "ram_gib": 16,  "price_usd_hr": 0.1474},
+            {"name": "e2-standard-8",  "vcpu": 8,  "ram_gib": 32,  "price_usd_hr": 0.2948},
+            {"name": "n2-standard-4",  "vcpu": 4,  "ram_gib": 16,  "price_usd_hr": 0.2090},
+            {"name": "n2-highmem-4",   "vcpu": 4,  "ram_gib": 32,  "price_usd_hr": 0.3256},
+        ],
+    },
+    "azure": {
+        "eastus": [
+            {"name": "Standard_D2s_v3",  "vcpu": 2,  "ram_gib": 8,   "price_usd_hr": 0.096},
+            {"name": "Standard_D4s_v3",  "vcpu": 4,  "ram_gib": 16,  "price_usd_hr": 0.192},
+            {"name": "Standard_D8s_v3",  "vcpu": 8,  "ram_gib": 32,  "price_usd_hr": 0.384},
+            {"name": "Standard_E4s_v3",  "vcpu": 4,  "ram_gib": 32,  "price_usd_hr": 0.252},
+            {"name": "Standard_E8s_v3",  "vcpu": 8,  "ram_gib": 64,  "price_usd_hr": 0.504},
+        ],
+        "westeurope": [
+            {"name": "Standard_D4s_v3",  "vcpu": 4,  "ram_gib": 16,  "price_usd_hr": 0.211},
+            {"name": "Standard_D8s_v3",  "vcpu": 8,  "ram_gib": 32,  "price_usd_hr": 0.422},
+            {"name": "Standard_E4s_v3",  "vcpu": 4,  "ram_gib": 32,  "price_usd_hr": 0.277},
+        ],
+    },
+}
+
+# Storage cost per GiB/month (SSD/block storage)
+STORAGE_PRICE_PER_GIB_MONTH = {
+    "aws":   0.10,   # gp3 EBS
+    "gcp":   0.17,   # SSD persistent disk
+    "azure": 0.115,  # Premium SSD LRS
+}
+
+# Estimated storage per namespace in GiB (persistent volumes)
+NAMESPACE_STORAGE_GIB = {
+    "infra":       50,   # MySQL, Elasticsearch, Kafka, MongoDB data
+    "mifosx":      10,   # Fineract DB (shared with infra MySQL but separate PV)
+    "paymenthub":  10,   # Zeebe data, MinIO
+    "vnext":       10,   # MongoDB collections for vNext BCs
+}
+
+# Network egress cost per GiB (outbound only; inbound is free on all providers)
+NETWORK_EGRESS_PRICE_PER_GIB = {
+    "aws":   0.09,
+    "gcp":   0.08,
+    "azure": 0.087,
+}
+
+# Assumed monthly outbound traffic in GiB for a demo/test deployment
+ESTIMATED_EGRESS_GIB_MONTH = 10
+
+HOURS_PER_MONTH = 730
+
+# ── topology multipliers ──────────────────────────────────────────────────────
+# single-node: dev/demo baseline (1 node, no redundancy)
+# ha-3node:    production minimum (3 nodes, stateful services replicated)
+TOPOLOGY_MULTIPLIERS = {
+    "single-node": 1.0,
+    "ha-3node":    3.0,
+}
+
+
+# ── DPG namespace mapping ─────────────────────────────────────────────────────
+DPG_NAMESPACES = {
+    "MifosX (Core Banking)":          ["mifosx"],
+    "Payment Hub EE":                  ["paymenthub"],
+    "Mojaloop vNext (Payment Switch)": ["vnext"],
+    "Shared Infrastructure":           ["infra"],
+}
+
+
+def find_cheapest_instance(required_vcpu: float, required_ram_gib: float,
+                            provider: str, region: str, catalog: dict) -> dict | None:
+    """Return the cheapest instance that satisfies both CPU and RAM requirements."""
+    instances = catalog.get(provider, {}).get(region)
+    if not instances:
+        return None
+    candidates = [
+        i for i in instances
+        if i["vcpu"] >= required_vcpu and i["ram_gib"] >= required_ram_gib
+    ]
+    if not candidates:
+        return None
+    return min(candidates, key=lambda i: i["price_usd_hr"])
+
+
+def calculate_tco(metrics: dict, provider: str, region: str,
+                  headroom_pct: float, egress_gib: float,
+                  topology: str, catalog: dict,
+                  pricing_as_of: str, pricing_source: str) -> dict:
+    """
+    Core TCO calculation.
+
+    Args:
+        metrics:      parsed JSON from collect-metrics.sh
+        provider:     'aws', 'gcp', or 'azure'
+        region:       cloud region string
+        headroom_pct: fractional overhead buffer, e.g. 0.30 for 30%
+        egress_gib:   estimated monthly outbound traffic in GiB
+        topology:     'single-node' or 'ha-3node'
+        catalog:      instance pricing catalog (INSTANCE_CATALOG or loaded from file)
+
+    Returns:
+        dict with full cost breakdown
+    """
+    summary = metrics.get("summary", {})
+    ns_data = {ns["namespace"]: ns for ns in metrics.get("namespaces", [])}
+
+    # Total measured resource consumption
+    measured_cpu_cores = summary.get("total_cpu_cores", 0)
+    measured_mem_gib   = summary.get("total_memory_gib", 0)
+
+    # Apply headroom buffer
+    required_cpu = measured_cpu_cores * (1 + headroom_pct)
+    required_mem = measured_mem_gib   * (1 + headroom_pct)
+
+    # Find the right instance
+    instance = find_cheapest_instance(required_cpu, required_mem, provider, region, catalog)
+
+    if not instance:
+        all_instances = catalog.get(provider, {}).get(region, [])
+        candidates = [i for i in all_instances if i["ram_gib"] >= required_mem]
+        instance = min(candidates, key=lambda i: i["price_usd_hr"]) if candidates else None
+
+    # Topology multiplier (single-node vs HA)
+    topo_mult = TOPOLOGY_MULTIPLIERS.get(topology, 1.0)
+
+    # Use measured PVC storage from metrics if available, else fall back to defaults
+    storage_measured = metrics.get("storage_gib", {})
+    storage_per_ns = {
+        ns: storage_measured.get(ns, NAMESPACE_STORAGE_GIB.get(ns, 0))
+        for ns in NAMESPACE_STORAGE_GIB
+    }
+    total_storage_gib = sum(storage_per_ns.values())
+
+    # Compute costs
+    compute_monthly = (instance["price_usd_hr"] * HOURS_PER_MONTH * topo_mult) if instance else 0
+    storage_monthly = total_storage_gib * STORAGE_PRICE_PER_GIB_MONTH.get(provider, 0.10) * topo_mult
+    network_monthly = egress_gib * NETWORK_EGRESS_PRICE_PER_GIB.get(provider, 0.09)
+
+    total_monthly  = compute_monthly + storage_monthly + network_monthly
+    total_annually = total_monthly * 12
+
+    # Per-DPG breakdown (proportional to memory share)
+    dpg_breakdown = []
+    for dpg_name, namespaces in DPG_NAMESPACES.items():
+        dpg_cpu_m = sum(
+            ns_data[ns]["total_cpu_millicores"]
+            for ns in namespaces if ns in ns_data
+        )
+        dpg_mem_mib = sum(
+            ns_data[ns]["total_memory_mib"]
+            for ns in namespaces if ns in ns_data
+        )
+        mem_share = (dpg_mem_mib / 1024) / measured_mem_gib if measured_mem_gib > 0 else 0
+        dpg_monthly = total_monthly * mem_share
+
+        dpg_breakdown.append({
+            "component":          dpg_name,
+            "namespaces":         namespaces,
+            "cpu_cores":          round(dpg_cpu_m / 1000, 2),
+            "memory_gib":         round(dpg_mem_mib / 1024, 2),
+            "memory_share_pct":   round(mem_share * 100, 1),
+            "estimated_monthly_usd": round(dpg_monthly, 2),
+        })
+
+    return {
+        "generated_at":    datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "provider":        provider,
+        "region":          region,
+        "topology":        topology,
+        "headroom_pct":    headroom_pct * 100,
+        "egress_gib_month": egress_gib,
+        "pricing_as_of":   pricing_as_of,
+        "pricing_source":  pricing_source,
+        "measured": {
+            "cpu_cores":   round(measured_cpu_cores, 2),
+            "memory_gib":  round(measured_mem_gib, 2),
+        },
+        "required_with_headroom": {
+            "cpu_cores":   round(required_cpu, 2),
+            "memory_gib":  round(required_mem, 2),
+        },
+        "recommended_instance": instance,
+        "costs": {
+            "compute_monthly_usd": round(compute_monthly, 2),
+            "storage_monthly_usd": round(storage_monthly, 2),
+            "network_monthly_usd": round(network_monthly, 2),
+            "total_monthly_usd":   round(total_monthly, 2),
+            "total_annual_usd":    round(total_annually, 2),
+            "topology_multiplier": topo_mult,
+            "storage_breakdown_gib": storage_per_ns,
+            "storage_source": "measured" if storage_measured else "estimated",
+        },
+        "dpg_breakdown": dpg_breakdown,
+    }
+
+
+def print_report(result: dict) -> None:
+    """Print a human-readable TCO report to stdout."""
+    sep = "─" * 60
+
+    print()
+    print("  Mifos Gazelle — TCO Estimate")
+    print(f"  Generated: {result['generated_at']}")
+    print(f"  Provider:  {result['provider'].upper()}  |  Region: {result['region']}")
+    print(f"  Topology:  {result['topology']}  |  Headroom: {result['headroom_pct']:.0f}%")
+    print(f"  Egress:    {result['egress_gib_month']:.0f} GiB/month  |  Pricing as of: {result['pricing_as_of']}")
+    print(f"  Pricing:   {result['pricing_source']}")
+    print()
+    print(f"  {sep}")
+    print("  Measured Resource Consumption")
+    print(f"  {sep}")
+    m = result["measured"]
+    r = result["required_with_headroom"]
+    print(f"  CPU (cores):   {m['cpu_cores']:.2f} measured  →  {r['cpu_cores']:.2f} with headroom")
+    print(f"  Memory (GiB):  {m['memory_gib']:.2f} measured  →  {r['memory_gib']:.2f} with headroom")
+    print()
+
+    inst = result.get("recommended_instance")
+    if inst:
+        print(f"  {sep}")
+        print("  Recommended Instance")
+        print(f"  {sep}")
+        print(f"  Type:          {inst['name']}")
+        print(f"  vCPU:          {inst['vcpu']}")
+        print(f"  RAM:           {inst['ram_gib']} GiB")
+        print(f"  On-demand:     ${inst['price_usd_hr']:.4f}/hr")
+        print()
+
+    print(f"  {sep}")
+    print("  Cost Breakdown (per month)")
+    print(f"  {sep}")
+    costs = result["costs"]
+    storage_label = f"({sum(costs['storage_breakdown_gib'].values()):.0f} GiB SSD, {costs['storage_source']})"
+    print(f"  Compute:       ${costs['compute_monthly_usd']:>8.2f}  (×{costs['topology_multiplier']:.0f} nodes)")
+    print(f"  Storage:       ${costs['storage_monthly_usd']:>8.2f}  {storage_label}")
+    print(f"  Network:       ${costs['network_monthly_usd']:>8.2f}  ({result['egress_gib_month']:.0f} GiB egress)")
+    print(f"  {'─'*40}")
+    print(f"  Monthly total: ${costs['total_monthly_usd']:>8.2f}")
+    print(f"  Annual total:  ${costs['total_annual_usd']:>8.2f}")
+    print()
+
+    print(f"  {sep}")
+    print("  Cost by Component")
+    print(f"  {sep}")
+    print(f"  {'Component':<35} {'CPU':>6} {'Mem(GiB)':>10} {'Monthly':>10}")
+    print(f"  {'─'*35} {'─'*6} {'─'*10} {'─'*10}")
+    for dpg in result["dpg_breakdown"]:
+        print(
+            f"  {dpg['component']:<35} "
+            f"{dpg['cpu_cores']:>6.2f} "
+            f"{dpg['memory_gib']:>10.2f} "
+            f"${dpg['estimated_monthly_usd']:>9.2f}"
+        )
+    print()
+
+    print(f"  {sep}")
+    print("  Notes")
+    print(f"  {sep}")
+    print("  - Prices are on-demand (no reserved instance discount).")
+    print("  - Reserved 1-year instances typically save 30-40%.")
+    print("  - Reserved 3-year instances typically save 50-60%.")
+    print("  - This estimate covers a single-node deployment (dev/test/demo).")
+    print("  - Production would require HA setup (3+ nodes): use --topology ha-3node.")
+    print(f"  - Pricing data as of {result['pricing_as_of']}. Verify before budgeting.")
+    print("  - Use --pricing-file to supply updated pricing data.")
+    print("  - PVC storage reflects requested capacity (not actual bytes used).")
+    print("  - For network cost realism, pass observed monthly egress via --egress-gib.")
+    print()
+
+
+def load_mock_metrics() -> dict:
+    """Return representative metrics matching collect-metrics.sh --mock output."""
+    return {
+        "collected_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "mode": "mock",
+        "cluster": {
+            "node_count": 1,
+            "total_cpu_millicores": 4000,
+            "total_memory_mib": 16384,
+        },
+        "summary": {
+            "total_pods": 18,
+            "total_cpu_millicores": 1340,
+            "total_memory_mib": 7344,
+            "total_cpu_cores": 1.34,
+            "total_memory_gib": 7.17,
+        },
+        "namespaces": [
+            {"namespace": "infra",       "pod_count": 6, "total_cpu_millicores": 400, "total_memory_mib": 2656.0},
+            {"namespace": "mifosx",      "pod_count": 2, "total_cpu_millicores": 325, "total_memory_mib": 1584.0},
+            {"namespace": "paymenthub",  "pod_count": 5, "total_cpu_millicores": 450, "total_memory_mib": 2240.0},
+            {"namespace": "vnext",       "pod_count": 5, "total_cpu_millicores": 165, "total_memory_mib":  864.0},
+        ],
+        "storage_gib": {
+            "infra": 45,
+            "mifosx": 8,
+            "paymenthub": 9,
+            "vnext": 7,
+        },
+        "pods": [],
+    }
+
+
+def load_pricing_catalog(pricing_file: str | None) -> tuple[dict, str, str]:
+    """
+    Load pricing catalog and metadata.
+
+    Supported file formats:
+      1) Raw catalog (same shape as INSTANCE_CATALOG)
+      2) Wrapped metadata:
+         {
+           "pricing_as_of": "2026-05",
+           "source": "custom snapshot",
+           "catalog": { ...same as INSTANCE_CATALOG... }
+         }
+    """
+    if not pricing_file:
+        return INSTANCE_CATALOG, PRICING_LAST_UPDATED, "built-in catalog"
+
+    try:
+        with open(pricing_file) as f:
+            payload = json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError) as e:
+        print(f"ERROR: could not load pricing file: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    if isinstance(payload, dict) and "catalog" in payload:
+        catalog = payload.get("catalog", {})
+        pricing_as_of = payload.get("pricing_as_of", PRICING_LAST_UPDATED)
+        source = payload.get("source", f"external file: {pricing_file}")
+    else:
+        catalog = payload
+        pricing_as_of = PRICING_LAST_UPDATED
+        source = f"external file: {pricing_file}"
+
+    if not isinstance(catalog, dict) or not catalog:
+        print("ERROR: pricing catalog is empty or invalid", file=sys.stderr)
+        sys.exit(1)
+
+    return catalog, pricing_as_of, source
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Mifos Gazelle TCO Estimator",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument("--metrics",  help="Path to metrics JSON from collect-metrics.sh")
+    parser.add_argument("--mock",     action="store_true", help="Use built-in sample data (no cluster needed)")
+    parser.add_argument("--provider", default="aws",       help="Cloud provider: aws, gcp, azure (default: aws)")
+    parser.add_argument("--region",   default="us-east-1", help="Cloud region (default: us-east-1)")
+    parser.add_argument("--headroom", type=float, default=0.30,
+                        help="Headroom buffer fraction, e.g. 0.30 = 30%% (default: 0.30)")
+    parser.add_argument("--egress-gib", type=float, default=float(ESTIMATED_EGRESS_GIB_MONTH),
+                        help=f"Estimated monthly outbound traffic in GiB (default: {ESTIMATED_EGRESS_GIB_MONTH})")
+    parser.add_argument("--topology", default="single-node",
+                        choices=["single-node", "ha-3node"],
+                        help="Deployment topology: single-node (dev/demo) or ha-3node (production, default: single-node)")
+    parser.add_argument("--pricing-file",
+                        help="Path to a JSON pricing catalog file (same structure as built-in INSTANCE_CATALOG)")
+    parser.add_argument("--all-providers", action="store_true",
+                        help="Show estimates for all providers and regions")
+    parser.add_argument("--json-out", help="Also write full result JSON to this file")
+    args = parser.parse_args()
+
+    # Load metrics
+    if args.mock:
+        metrics = load_mock_metrics()
+        print("  [mock mode] Using representative sample data — not a live cluster.")
+    elif args.metrics:
+        try:
+            with open(args.metrics) as f:
+                metrics = json.load(f)
+        except FileNotFoundError:
+            print(f"ERROR: metrics file not found: {args.metrics}", file=sys.stderr)
+            sys.exit(1)
+        except json.JSONDecodeError as e:
+            print(f"ERROR: invalid JSON in metrics file: {e}", file=sys.stderr)
+            sys.exit(1)
+    else:
+        print("ERROR: provide --metrics <file> or --mock", file=sys.stderr)
+        parser.print_help()
+        sys.exit(1)
+
+    # Load pricing catalog (external file overrides built-in)
+    catalog, pricing_as_of, pricing_source = load_pricing_catalog(args.pricing_file)
+    if args.pricing_file:
+        print(f"  [pricing] Loaded from: {args.pricing_file} (as of {pricing_as_of})")
+    else:
+        print(f"  [pricing] Using built-in data (as of {pricing_as_of}). "
+              "Pass --pricing-file for updated prices.")
+
+    egress = args.egress_gib
+
+    if args.all_providers:
+        print(f"\n  Mifos Gazelle — TCO Comparison Across Providers  [{args.topology}]\n")
+        print(f"  {'Provider':<8} {'Region':<20} {'Instance':<18} {'Monthly':>10} {'Annual':>10}")
+        print(f"  {'─'*8} {'─'*20} {'─'*18} {'─'*10} {'─'*10}")
+        for prov, regions in catalog.items():
+            for reg in regions:
+                r = calculate_tco(
+                    metrics, prov, reg, args.headroom, egress, args.topology,
+                    catalog, pricing_as_of, pricing_source
+                )
+                inst = r.get("recommended_instance")
+                inst_name = inst["name"] if inst else "N/A"
+                print(
+                    f"  {prov:<8} {reg:<20} {inst_name:<18} "
+                    f"${r['costs']['total_monthly_usd']:>9.2f} "
+                    f"${r['costs']['total_annual_usd']:>9.2f}"
+                )
+        print()
+        return
+
+    # Single provider/region estimate
+    result = calculate_tco(
+        metrics, args.provider, args.region, args.headroom, egress, args.topology,
+        catalog, pricing_as_of, pricing_source
+    )
+    print_report(result)
+
+    if args.json_out:
+        with open(args.json_out, "w") as f:
+            json.dump(result, f, indent=2)
+        print(f"  Full JSON written to: {args.json_out}\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Summary
Adds a self-contained **performance/resource metrics** and **total cost of ownership (TCO) estimation** toolkit for Mifos Gazelle, aligned with the current codebase and deployment model.

Addresses the spirit of [GAZ-5](https://mifosforge.jira.com/browse/GAZ-5): give operators and contributors a repeatable way to snapshot what the stack consumes on a real cluster and produce directional cloud cost estimates from those snapshots.

**Evidence Artifacts from the cloud VM that was run on GCP, and the metrics generated!**
[metrics-after.json](https://github.com/user-attachments/files/27701038/metrics-after.json)
[metrics-before.json](https://github.com/user-attachments/files/27701041/metrics-before.json)
[tco-result.json](https://github.com/user-attachments/files/27701042/tco-result.json)
[summary.txt](https://github.com/user-attachments/files/27701083/summary.txt)
[live-metrics.json](https://github.com/user-attachments/files/27701084/live-metrics.json)

<img width="1104" height="572" alt="Screenshot from 2026-05-12 22-41-16" src="https://github.com/user-attachments/assets/5653034d-1d9a-406b-a666-c27939c23204" />
<img width="1104" height="572" alt="Screenshot from 2026-05-12 22-40-45" src="https://github.com/user-attachments/assets/01fb68bf-bca7-416d-9f1a-1a9f536881b7" />
<img width="1920" height="1018" alt="Screenshot from 2026-05-12 22-29-03" src="https://github.com/user-attachments/assets/375b59bf-f0d5-4be0-9c56-3041df5aac18" />
<img width="1920" height="1018" alt="Screenshot from 2026-05-12 22-28-59" src="https://github.com/user-attachments/assets/c393ddeb-5af2-474d-92df-38960e3c3627" />
---

### What was added

| Path | Purpose |
|------|---------|
| `src/utils/perf/collect-metrics.sh` | Collects per-pod CPU/memory via `kubectl top pods` for Gazelle namespaces (`infra`, `mifosx`, `paymenthub`, `vnext`). Optional `--storage` flag sums requested PVC capacity per namespace. Writes a single JSON report. Supports `--mock` for local testing without a cluster. |
| `src/utils/perf/tco-estimate.py` | Reads the metrics JSON and estimates monthly/annual cost using an embedded instance catalog (with optional `--pricing-file`), configurable `--egress-gib`, `--topology` (`single-node` \| `ha-3node`), and `--headroom`. Supports `--json-out` and `--all-providers` comparison. |
| `src/utils/perf/run-load-test.sh` | Headless wrapper around `performance-testing/paymentHubEE.jmx`. Runs JMeter with parameterized threads/duration/host, and invokes `collect-metrics.sh --storage` before/after when snapshots are enabled. Supports `--mock` dry-run. |
| `docs/PERF-TCO.md` | Usage guide, prerequisites (including JDK for JMeter), data provenance, instructions for exporting evidence from a test VM, and interpretation notes. |

#### Implementation notes

- **gawk / Ubuntu compatibility:** `collect-metrics.sh` avoids using `namespace` as an `awk` variable name (reserved in gawk), ensuring `kubectl top` output parses correctly on Ubuntu 22.04+.
- **Load-test snapshots** call `collect-metrics.sh --storage` so TCO inputs can use measured PVC requests when the cluster is reachable.

---

### Quick start

See `docs/PERF-TCO.md` for full details. Typical flow on a machine with `kubectl` pointed at a Gazelle cluster:

```bash
# Collect metrics
bash src/utils/perf/collect-metrics.sh --storage --out /tmp/gazelle-metrics.json

# Estimate TCO
python3 src/utils/perf/tco-estimate.py \
  --metrics /tmp/gazelle-metrics.json \
  --topology ha-3node \
  --egress-gib 25

# Run load test with before/after snapshots
bash src/utils/perf/run-load-test.sh --threads 10 --duration 120 --out /tmp/lt

# Estimate TCO from post-load snapshot
python3 src/utils/perf/tco-estimate.py \
  --metrics /tmp/lt/metrics-after.json \
  --topology ha-3node \
  --egress-gib 25
```

---

### Measured inputs vs. modeled costs

> **Note:** Dollar amounts are **not** read from a cloud bill. They are a model built from cluster snapshots plus assumptions — suitable for planning and comparison, not procurement or finance sign-off without refreshed pricing.

**Grounded in real cluster data** (when run live):
- CPU and memory totals and per-namespace rollups from `kubectl top` (point-in-time usage, not guaranteed limits)
- With `--storage`: per-namespace `storage_gib` from summed PVC requested sizes (not bytes used on disk)

**Modeled or user-supplied:**
- Instance type and hourly rate from the built-in catalog or `--pricing-file` (indicative on-demand Linux prices; `pricing_as_of` / `source` are surfaced in output)
- Compute: `hourly_rate × 730 h/month × topology multiplier` (`ha-3node` uses a 3× planning multiplier)
- Storage: `requested GiB × per-GiB/month rate × topology multiplier`
- Network: `--egress-gib × per-GiB egress rate` (defaults are conservative placeholders)
- Per-DPG cost lines: heuristic allocation by each component's share of measured memory across namespaces

---

### Caveats and known limitations

- `kubectl top` reflects current usage; short spikes may not be captured, and limits/requests differ from usage
- PVC "storage" is requested capacity from the API, not actual disk consumption
- TCO omits real-world line items: support, backups, cross-AZ traffic, load balancers, logging sinks, discounts, committed use, etc.
- `paymentHubEE.jmx` is **unchanged** in this PR. On a real Gazelle deployment, requests may fail at the HTTP layer (auth, paths, tenant config) until the plan is aligned with current PHEE ingress and APIs. The wrapper, snapshots, and JTL/HTML reporting still validate the pipeline end-to-end.

---

### Testing

- `collect-metrics.sh --mock`
- Live run on a GCP Ubuntu VM (`e2-standard-4`) with full Gazelle deploy; JSON output includes `mode: "live"`, namespaces, and `storage_gib` when `--storage` is used
- `tco-estimate.py` on real metrics JSON; `--all-providers` and `--json-out` exercised
- `run-load-test.sh` end-to-end with JMeter + JDK; JMeter samples executed; HTTP failures documented as JMX/config gap, not script failure
- `run-load-test.sh --mock` dry-run without JMeter

---

### Follow-up (separate PR)

**JMeter plan maintenance:** Update or supplement `performance-testing/paymentHubEE.jmx` (and/or document required JMeter properties) so a default run against a standard Gazelle install achieves a meaningful success rate without manual credential configuration. Requires input from PHEE maintainers on supported public test endpoints and safe demo credentials.

---

### Related

- Jira: [GAZ-5](https://mifosforge.jira.com/browse/GAZ-5) — Perf and TCO facilities for Mifos Gazelle

> **Reviewers:** Please treat cost figures as illustrative unless `--pricing-file` and egress inputs are refreshed for your target environment.

[GAZ-5]: https://mifosforge.jira.com/browse/GAZ-5?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GAZ-5]: https://mifosforge.jira.com/browse/GAZ-5?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ