### PR TITLE
Added memory/CPU caps to Fineract & Web-app and tuned Fineract JVM heap

### DIFF
--- a/src/deployer/manifests/mifosx/fineract-server-deployment.yaml
+++ b/src/deployer/manifests/mifosx/fineract-server-deployment.yaml
@@ -25,7 +25,7 @@ spec:
               value: > 
                     -Xss256k
                     -Xms512m 
-                    -Xmx2048m 
+                    -Xmx1536m 
                     -XX:+UseSerialGC
                     -XX:+HeapDumpOnOutOfMemoryError
                     -Dnetworkaddress.cache.ttl=30
@@ -127,13 +127,13 @@ spec:
           ports:
             - containerPort: 8080
               protocol: TCP
-          # resources:
-          #   requests:
-          #     memory: "256Mi"
-          #     cpu: "200m"
-          #   limits:
-          #     memory: "1600Mi"
-          #     cpu: "500m"
+          resources:
+            requests:
+              memory: "512Mi"
+              cpu: "200m"
+            limits:
+              memory: "2560Mi"
+              cpu: "1000m"
           volumeMounts:
             - mountPath: /data
               name: fineract-server-claim0

--- a/src/deployer/manifests/mifosx/web-app-deployment.yaml
+++ b/src/deployer/manifests/mifosx/web-app-deployment.yaml
@@ -43,4 +43,11 @@ spec:
           ports:
             - containerPort: 80
               protocol: TCP
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "50m"
+            limits:
+              memory: "256Mi"
+              cpu: "200m"    
       restartPolicy: Always


### PR DESCRIPTION
## Problem

The MifosX pods (`fineract-server`, `web-app`) ran without Kubernetes resource
requests/limits. This is a hygiene gap: an uncapped pod has no ceiling, so a runaway can't be
contained to itself. Fineract also ran with `-Xmx2048m`, leaving little room under the container
 for JVM non-heap usage.

## Solution

Re-enable Kubernetes resource requests/limits on both deployments and tune the Fineract heap 
so memory stays bounded:

- **fineract-server**: requests `512Mi / 200m`, limits `2560Mi / 1000m`; lower `-Xmx` from `2048m`
 to `1536m`, leaving ~1Gi headroom for metaspace, thread stacks, and direct buffers.
- **web-app**: requests `64Mi / 50m`, limits `256Mi / 200m`.

With limits in place, a runaway container is OOM-killed and restarted on its own instead of dragging 
the whole node into swap.

## Scope

This adds layered protection to help the system fail smoothly, but it is not a cure for node-level OOM (Out-Of-Memory) issues.

## Testing

- Deployed MifosX with `./run.sh -m deploy -a mifosx` and confirmed both pods start and pass their liveness/readiness health checks with the new limits applied.
