### PR TITLE
[GAZ-295] : Integrate deployement via run.sh and openg2p.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ sudo ./setup-env.sh -e local -u $USER   # one-time: k3s, tools, /etc/hosts
 
 See [Deployment Guide](docs/MIFOS-GAZELLE-README.md) for prerequisites and full instructions.
 
+To also deploy OpenG2P (Government-to-Person payments), enable it in `config/config.ini` and run `./run.sh -m deploy -a openg2p`. See [OpenG2P](docs/GAZELLE_OPENG2P.md) for details.
+
 For Latest Development Release (May not be stable):
 ```bash
 git clone --branch dev https://github.com/openMF/mifos-gazelle.git
@@ -31,6 +33,7 @@ sudo ./setup-env.sh -e local -u $USER
 | [Deployment Guide](docs/MIFOS-GAZELLE-README.md) | Install, configure, test end-to-end payments, FAQ |
 | [Bulk Payment Tools](docs/BULK.md) | Submit/verify G2P batch payments, GovStack mode |
 | [GovStack Architecture](docs/GOVSTACK.md) | G2P bulk disbursement design and troubleshooting |
+| [OpenG2P](docs/GAZELLE_OPENG2P.md) | Deploy OpenG2P G2P payments (commons, PBMS, social-registry, SPAR, g2p-bridge) |
 | [Local Development](docs/LOCALDEV.md) | hostPath mounts for iterating on Payment Hub EE code |
 | [vNext Standalone](docs/VNEXT-README.md) | Deploy Mojaloop vNext on its own |
 | [Raspberry Pi](docs/RASPBERRY-PI-README.md) | Ubuntu setup on Raspberry Pi 5 |

--- a/config/config.ini
+++ b/config/config.ini
@@ -142,11 +142,11 @@ MASTERCARD_DECRYPTION_KEY_PATH =
 
 [openg2p]
 # Enable or disable OpenG2P deployment.
-enabled = true
+enabled = false
 # Namespace for OpenG2P components.
 OPENG2P_NAMESPACE = openg2p
 # Per-module toggles (each can be independently disabled).
-OPENG2P_SOCIAL_REGISTRY_ENABLED = true
-OPENG2P_PBMS_ENABLED = true
+OPENG2P_SOCIAL_REGISTRY_ENABLED = false
+OPENG2P_PBMS_ENABLED = false
 OPENG2P_SPAR_ENABLED = false
 OPENG2P_G2P_BRIDGE_ENABLED = false

--- a/config/config.ini
+++ b/config/config.ini
@@ -17,7 +17,6 @@ logging = false
 # Default: 600 (10 min). Slow hardware / Raspberry Pi: 1800. Managed cold-start: 900.
 startup_timeout = 1200
 
-
 [kubernetes]
 # Environment type: 'local' for a local cluster (Linux k3s or macOS Colima — auto-detected),
 # or 'remote' for an existing remote cluster.
@@ -140,3 +139,14 @@ MASTERCARD_DECRYPTION_KEY_PASSWORD =
 MASTERCARD_SIGNING_KEY_PATH =
 MASTERCARD_ENCRYPTION_CERT_PATH =
 MASTERCARD_DECRYPTION_KEY_PATH =
+
+[openg2p]
+# Enable or disable OpenG2P deployment.
+enabled = true
+# Namespace for OpenG2P components.
+OPENG2P_NAMESPACE = openg2p
+# Per-module toggles (each can be independently disabled).
+OPENG2P_SOCIAL_REGISTRY_ENABLED = true
+OPENG2P_PBMS_ENABLED = true
+OPENG2P_SPAR_ENABLED = false
+OPENG2P_G2P_BRIDGE_ENABLED = false

--- a/docs/GAZELLE_OPENG2P.md
+++ b/docs/GAZELLE_OPENG2P.md
@@ -1,0 +1,138 @@
+# OpenG2P
+
+## What It Is
+
+[OpenG2P](https://openg2p.org/) is a Digital Public Good for Government-to-Person (G2P) payment programmes — beneficiary registration, payment batch management, and program-to-payment-rail bridging. Mifos Gazelle deploys it as its own app (`-a openg2p`), independent of MifosX, Payment Hub EE, and vNext.
+
+Each OpenG2P module is installed as its own Helm release in the `openg2p` namespace so subchart-generated object names never collide across modules.
+
+---
+
+## How It Fits into Mifos Gazelle
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  Mifos Gazelle — openg2p namespace                           │
+│                                                                │
+│                     ┌─────────────────┐                       │
+│                     │  openg2p-commons │  (always deployed)   │
+│                     │  Postgres        │                       │
+│                     │  Keycloak (SSO)  │                       │
+│                     │  MinIO           │                       │
+│                     └────────┬─────────┘                       │
+│               ┌──────────────┼──────────────┬───────────────┐ │
+│               ▼              ▼              ▼               ▼ │
+│      social-registry       pbms           spar        g2p-bridge│
+│     (beneficiaries)   (payment batches) (SR mapper)  (depends  │
+│                              │                        on spar) │
+└──────────────────────────────┼────────────────────────────────┘
+                               ▼
+                     Payment Hub EE (PHEE)
+              via g2p_payment_phee Odoo connector
+```
+
+Modules:
+
+| Module | Helm chart | Enabled by default | Purpose |
+|---|---|---|---|
+| commons | `openg2p-commons` | always | Postgres, Keycloak (SSO/OIDC), MinIO — shared foundation every other module connects to |
+| social-registry | `openg2p-social-registry` | false | Beneficiary/registrant data management |
+| pbms | `openg2p-pbms` | true | Payment Batch Management System (Odoo) — creates and issues G2P payment batches |
+| spar | `openg2p-spar` | false | Social Registry mapper/API |
+| g2p-bridge | `openg2p-g2p-bridge` | false | Bridges G2P programs to payment rails; depends on the SPAR mapper |
+
+Deploy order (`deploy_openg2p()` in `src/deployer/openg2p.sh`): namespace + TLS → prerequisite CRDs (Istio networking, optional operator CRDs — installed so upstream chart objects apply harmlessly; Gazelle routes traffic via NGINX instead) → **commons** (must be healthy — an unhealthy commons aborts the OpenG2P deploy) → enabled modules in fixed order `social-registry` → `pbms` → `spar` → `g2p-bridge`. A module that fails to become ready is recorded and skipped; it does not block the rest, and failures are summarized at the end of the run.
+
+Once PBMS is up, Gazelle enables the `g2p_payment_phee` Odoo addon (`src/utils/openg2p/setup-pbms-phee.sh`) so PBMS can issue payment batches to **Payment Hub EE**.
+
+---
+
+## Prerequisites
+
+- Same base setup as any Gazelle deployment (`sudo ./setup-env.sh ...`)
+- No sudo required to deploy OpenG2P itself
+
+---
+
+## Getting Started
+
+### 1. Enable in `config/config.ini`
+
+```ini
+[openg2p]
+enabled = true
+OPENG2P_NAMESPACE = openg2p
+OPENG2P_SOCIAL_REGISTRY_ENABLED = false
+OPENG2P_PBMS_ENABLED = true
+OPENG2P_SPAR_ENABLED = false
+OPENG2P_G2P_BRIDGE_ENABLED = false
+```
+
+Each module has its own `OPENG2P_*_ENABLED` flag. Disabling a module that was previously deployed tears down its Helm release on the next deploy.
+
+### 2. Deploy
+
+```bash
+./run.sh -m deploy -a openg2p          # OpenG2P only
+./run.sh -m deploy -a all              # all DPGs, including OpenG2P
+./run.sh -m deploy -a openg2p -d true  # with debug output
+```
+
+Teardown:
+
+```bash
+./run.sh -m cleanapps -a openg2p
+```
+
+### 3. Log in
+
+Printed at the end of a successful deploy. With the default config (PBMS enabled, others disabled):
+
+| Console | URL |
+|---|---|
+| PBMS (Odoo) | https://pbms.mifos.gazelle.test |
+| Keycloak | https://keycloak.mifos.gazelle.test |
+| MinIO | https://minio.mifos.gazelle.test |
+
+If enabled, `social-registry`, `spar`, and `g2p-bridge` are reachable the same way at `https://<module>.mifos.gazelle.test`.
+
+PBMS and social-registry Odoo login is `admin@openg2p.org` / `adminopeng2p`.
+
+
+---
+
+## PBMS ↔ Payment Hub EE Connector
+
+After PBMS becomes ready, `src/utils/openg2p/setup-pbms-phee.sh` idempotently enables the `g2p_payment_phee` Odoo addon so PBMS can issue payment batches to Payment Hub EE:
+
+- Fetches the `openg2p-registry` and `openg2p-program` addon repos into the PBMS pod
+- Patches `payment_manager.py` so `amount_issued` is cast to `int` (PHEE's parser otherwise throws on a float and silently zeroes the batch total)
+- Stubs an Enterprise-only module reference that `g2p_programs` needs but Community edition lacks
+- Sets `batch_type_header=csv` on the PHEE payment manager
+
+This step is non-fatal — a failure logs a warning and the script can be re-run manually:
+
+```bash
+./src/utils/openg2p/setup-pbms-phee.sh
+```
+
+
+## Troubleshooting
+
+**A module never becomes ready / deploy warns "unready module(s)":**
+```bash
+kubectl get pods -n openg2p | grep -E '<module-name>'
+kubectl describe pod <pod-name> -n openg2p
+kubectl logs <pod-name> -n openg2p
+```
+
+**PBMS Odoo login fails after deploy** — re-run the admin fixup manually (idempotent):
+```bash
+kubectl exec -n openg2p <pbms-odoo-pod> -- bash -lc "odoo shell -c /etc/odoo/odoo.conf -d pbmsdb --no-http"
+```
+
+**A previously-failed Helm release blocks redeploy** — force it:
+```bash
+helm uninstall <release-name> -n openg2p --wait
+./run.sh -m deploy -a openg2p
+```

--- a/docs/GAZELLE_OPENG2P.md
+++ b/docs/GAZELLE_OPENG2P.md
@@ -8,6 +8,28 @@ Each OpenG2P module is installed as its own Helm release in the `openg2p` namesp
 
 ---
 
+## Deployment Method
+
+OpenG2P is deployed via Helm, consistent with the rest of Gazelle's infra (`src/deployer/helm/`). Five thin wrapper charts are vendored under `src/deployer/helm/openg2p/` — one per module: `openg2p-commons`, `openg2p-pbms`, `openg2p-social-registry`, `openg2p-spar`, `openg2p-g2p-bridge`.
+
+Each wrapper chart's `Chart.yaml` declares exactly one dependency: the corresponding upstream OpenG2P chart pinned to a specific version, pulled from OpenG2P's own chart repo (`https://openg2p.github.io/openg2p-helm`):
+
+```yaml
+dependencies:
+- name: openg2p-pbms
+  alias: pbms
+  version: "3.0.0"
+  repository: https://openg2p.github.io/openg2p-helm
+```
+
+Pinned versions: `openg2p-commons-base` 2.0.1, `openg2p-pbms` 3.0.0, `openg2p-social-registry` 2.0.8, `openg2p-spar` 0.0.0-develop, `openg2p-g2p-bridge` 3.0.0. The resolved upstream chart `.tgz` is vendored into each wrapper's `charts/` directory (`helm dependency update`, wrapped by `ensure_helm_dependencies()` in `src/deployer/core.sh`, which skips re-fetching if the `.tgz` count already matches `Chart.lock`) — so a deploy doesn't need live network access to the OpenG2P chart repo on every run.
+
+Gazelle-specific overrides (ingress hostnames, image repoints, fixed demo credentials, cross-module DB wiring) live in each wrapper's own `values.yaml`, layered on top of the vendored upstream chart's defaults. The upstream chart itself is never modified.
+
+At deploy time (`_deploy_openg2p_release()`), each chart is copied to a scratch working directory, its `values.yaml` has FQDN placeholders substituted for the real domain (`apply_domain_to_file`), and installed with `helm upgrade --install` (idempotent — a rerun against an already-healthy release is a no-op). No `--wait` is used, since Helm's readiness poll can misreport large charts as failed; Gazelle polls real pod status itself after the Helm apply returns.
+
+---
+
 ## How It Fits into Mifos Gazelle
 
 ```
@@ -41,9 +63,28 @@ Modules:
 | spar | `openg2p-spar` | false | Social Registry mapper/API |
 | g2p-bridge | `openg2p-g2p-bridge` | false | Bridges G2P programs to payment rails; depends on the SPAR mapper |
 
-Deploy order (`deploy_openg2p()` in `src/deployer/openg2p.sh`): namespace + TLS → prerequisite CRDs (Istio networking, optional operator CRDs — installed so upstream chart objects apply harmlessly; Gazelle routes traffic via NGINX instead) → **commons** (must be healthy — an unhealthy commons aborts the OpenG2P deploy) → enabled modules in fixed order `social-registry` → `pbms` → `spar` → `g2p-bridge`. A module that fails to become ready is recorded and skipped; it does not block the rest, and failures are summarized at the end of the run.
+Deploy order (`deploy_openg2p()` in `src/deployer/openg2p.sh`): namespace + TLS → prerequisite CRDs → **commons** (must be healthy — an unhealthy commons aborts the OpenG2P deploy) → enabled modules in fixed order `social-registry` → `pbms` → `spar` → `g2p-bridge`. A module that fails to become ready is recorded and skipped; it does not block the rest, and failures are summarized at the end of the run.
 
 Once PBMS is up, Gazelle enables the `g2p_payment_phee` Odoo addon (`src/utils/openg2p/setup-pbms-phee.sh`) so PBMS can issue payment batches to **Payment Hub EE**.
+
+### NGINX ingress instead of Istio
+
+OpenG2P's Keycloak subchart unconditionally emits Istio `Gateway` and `VirtualService` objects for routing. Gazelle standardizes on NGINX ingress across all DPGs, so no Istio control plane is installed. Rather than patching the upstream chart to strip these objects, they're allowed to apply harmlessly (see CRDs below) and real traffic is routed through Gazelle's existing NGINX ingress + per-module TLS secrets instead.
+
+### Why CRDs are needed
+
+Since the Istio/logging/monitoring controllers aren't installed, the CRDs (Custom Resource Definitions) for the object kinds those upstream charts emit don't exist either — without them, `helm install` fails validation on an unknown kind. Two minimal, open-schema CRD manifests are vendored to satisfy this, with no controller behind them (the objects land inertly, unused):
+
+- `src/deployer/manifests/openg2p/istio-networking-crds.yaml` — `gateways.networking.istio.io`, `virtualservices.networking.istio.io`
+- `src/deployer/manifests/openg2p/optional-operator-crds.yaml` — `flows.logging.banzaicloud.io`, `outputs.logging.banzaicloud.io`, `servicemonitors.monitoring.coreos.com`
+
+These are applied once per deploy, before any module Helm release, via `kubectl apply` in `deploy_openg2p()`.
+
+### Independent per-module releases
+
+OpenG2P already ships each app (commons, social-registry, pbms, spar, g2p-bridge) as its own separate upstream chart. What Gazelle adds is installing each as an independent Helm release in the `openg2p` namespace, so any single module can be individually enabled, disabled, or torn down via its own `OPENG2P_*_ENABLED` flag without touching the others.
+
+Upstream still expects all charts installed together against a shared reference — some modules' charts reference secrets that a sibling module's chart creates (e.g. `pbms` mounts a `social-registry-postgresql` secret regardless of whether social-registry is enabled). Since Gazelle allows any subset of modules to be enabled, `_openg2p_preflight_secrets()` pre-creates placeholder versions of these cross-module secrets when the module that would normally create them is disabled — otherwise the dependent module's pods crash-loop on `CreateContainerConfigError`. Real cross-module DB access via these secrets is a known follow-up (see [Known Limitations](#known-limitations)).
 
 ---
 
@@ -98,17 +139,15 @@ If enabled, `social-registry`, `spar`, and `g2p-bridge` are reachable the same w
 
 PBMS and social-registry Odoo login is `admin@openg2p.org` / `adminopeng2p`.
 
-
 ---
 
 ## PBMS ↔ Payment Hub EE Connector
 
-After PBMS becomes ready, `src/utils/openg2p/setup-pbms-phee.sh` idempotently enables the `g2p_payment_phee` Odoo addon so PBMS can issue payment batches to Payment Hub EE:
+The default PBMS Odoo image ships with none of the OpenG2P addon modules at all — no `g2p_payment_phee`, no `g2p_programs`, no registry addons are baked in or present out of the box. Once PBMS is ready, `src/utils/openg2p/setup-pbms-phee.sh` idempotently:
 
-- Fetches the `openg2p-registry` and `openg2p-program` addon repos into the PBMS pod
-- Patches `payment_manager.py` so `amount_issued` is cast to `int` (PHEE's parser otherwise throws on a float and silently zeroes the batch total)
-- Stubs an Enterprise-only module reference that `g2p_programs` needs but Community edition lacks
-- Sets `batch_type_header=csv` on the PHEE payment manager
+- Downloads the `openg2p-registry` (branch `17.0-1.5`) and `openg2p-program` (branch `17.0-1.3`) addon source repos from GitHub directly onto the pod's filesystem (PVC) and points Odoo at them via `ODOO_ADDONS_DIR`
+- Runs Odoo's `update_list()` so the addons even appear in Odoo's app list
+- Installs the specific modules PBMS needs — `g2p_social_registry_importer` and `g2p_payment_phee` — so PBMS can issue payment batches to Payment Hub EE (`pbms_theme_extension` is deliberately excluded: it depends on the `website` module and 500s the Community edition login page)
 
 This step is non-fatal — a failure logs a warning and the script can be re-run manually:
 
@@ -116,6 +155,21 @@ This step is non-fatal — a failure logs a warning and the script can be re-run
 ./src/utils/openg2p/setup-pbms-phee.sh
 ```
 
+### Patches applied to `g2p_payment_phee`
+
+The upstream `g2p_payment_phee` addon does not work out of the box against Gazelle's Payment Hub EE and Community-edition Odoo, so the setup script applies fixes after fetching the addon source and around the install:
+
+- **Enterprise-only module stub.** Installing `g2p_payment_phee` transitively reloads Odoo core's `payment` module data, which references the Enterprise-only `base.module_payment_sepa_direct_debit` xmlid — this does not exist in Community edition and crashes the install. This is a long-standing Odoo core Community/Enterprise packaging inconsistency (unrelated to OpenG2P's own code — `g2p_payment_phee` and `g2p_programs` do not declare this dependency themselves), documented in Odoo core issues since v13/v14. There is no official Community-edition fix upstream, so the script creates a stub `ir.module.module` record named `payment_sepa_direct_debit` (state `uninstalled`, no functionality activated) plus its `ir.model.data` entry, satisfying the reference so the install proceeds. This is a recognized community workaround pattern for this class of problem, not something specific or fragile to Gazelle — though it compensates for Odoo core behavior rather than an OpenG2P-published fix, so it should be re-verified on future Odoo/OpenG2P version bumps.
+- **`amount_issued` float→int cast.** `g2p_payment_phee`'s `payment_manager.py` (`prepare_csv_for_batch`) emits the payment batch's CSV row with `payment_id.amount_issued` as a float. PHEE's own CSV parser calls `parseInt` on that field, which throws on a float and silently zeroes the batch total. The script `sed`-patches the emission line to wrap it in `int(...)`. Applied before the module install (not after) so the single post-install Odoo restart reloads the patched source in the same step.
+- **`batch_type_header` / `payee_id_type` config.** After install, the script sets `batch_type_header=csv` on any existing `g2p.program.payment.manager.phee` record — upstream's default value of `"type"` causes PHEE to respond 500 — and aligns `payee_id_type` to `phone`.
+
+All patches are idempotent — safe to re-run against an already-patched deployment.
+
+## Known Limitations
+
+- **Keycloak is a hard dependency of `openg2p-commons`** and always deploys when OpenG2P is enabled — it is not a per-module toggle. PBMS's own login uses local Odoo auth and doesn't require it; Keycloak backs MinIO console SSO and is required if `social-registry`/`spar`/`g2p-bridge` are enabled.
+- Resource footprint (Postgres + Keycloak + MinIO + per-module services) has not yet been tuned for low-resource targets (e.g. Raspberry Pi) the way the other three DPGs have been.
+- The `g2p_payment_phee` Enterprise-module stub compensates for an Odoo-core artifact rather than an OpenG2P-published fix — re-verify it if the pinned Odoo/OpenG2P addon versions change.
 
 ## Troubleshooting
 

--- a/src/commandline/commandline.sh
+++ b/src/commandline/commandline.sh
@@ -155,7 +155,7 @@ load_config_from_file() {
 
     # Read app enablement flags and construct the 'apps' variable
     local enabled_apps_list=""
-    local valid_apps=("infra" "vnext" "paymenthub" "mifosx" "mastercard-demo")
+    local valid_apps=("infra" "vnext" "paymenthub" "mifosx" "mastercard-demo" "openg2p")
 
     for app_name in "${valid_apps[@]}"; do
         local app_enabled=$(crudini --get "$config_path" "$app_name" enabled 2>/dev/null)
@@ -237,7 +237,7 @@ show_usage() {
     -m mode .............. deploy|cleanapps (required)
     -u user .............. non-root user for k8s operations (optional, defaults to \$USER)
     -a apps .............. Comma-separated list of apps or 'all' (optional)
-                           Valid: vnext paymenthub mifosx infra mastercard-demo setup-data all
+                           Valid: vnext paymenthub mifosx infra mastercard-demo openg2p setup-data all
     -e environment ....... local (default) | remote
     -d debug ............. true|false (optional, default=false)
     -r redeploy .......... true|false (optional, default=true)
@@ -310,8 +310,8 @@ validate_inputs() {
             log_warn "No apps specified via -a or config file. Defaulting to 'all'."
             apps="all"
         fi
-        local ALL_VALID_APPS="infra vnext paymenthub mifosx mastercard-demo setup-data all"
-        local CORE_APPS="infra vnext paymenthub mifosx"
+        local ALL_VALID_APPS="infra vnext paymenthub mifosx mastercard-demo openg2p setup-data all"
+        local CORE_APPS="infra vnext paymenthub mifosx openg2p"
 
         local current_apps_array
         IFS=' ' read -r -a current_apps_array <<< "$apps"

--- a/src/deployer/deployer.sh
+++ b/src/deployer/deployer.sh
@@ -6,6 +6,7 @@ source "$RUN_DIR/src/deployer/vnext.sh" || { echo "FATAL: Could not source vnext
 source "$RUN_DIR/src/deployer/mifosx.sh" || { echo "FATAL: Could not source mifosx.sh. Check RUN_DIR: $RUN_DIR"; exit 1; }
 source "$RUN_DIR/src/deployer/paymenthub.sh" || { echo "FATAL: Could not source paymenthub.sh. Check RUN_DIR: $RUN_DIR"; exit 1; }
 source "$RUN_DIR/src/deployer/mastercard.sh" || { echo "FATAL: Could not source mastercard.sh. Check RUN_DIR: $RUN_DIR"; exit 1; }
+source "$RUN_DIR/src/deployer/openg2p.sh" || { echo "FATAL: Could not source openg2p.sh. Check RUN_DIR: $RUN_DIR"; exit 1; }
 source "$RUN_DIR/src/utils/helpers.sh" || { echo "FATAL: Could not source helpers.sh. Check RUN_DIR: $RUN_DIR"; exit 1; }
 
 #------------------------------------------------------------
@@ -290,6 +291,9 @@ delete_apps() {
         cleanup
         log_ok
         ;;
+      "openg2p")
+        clean_openg2p
+        ;;
       *)
         log_error "Invalid app '$app' for deletion. This should have been caught by validate_inputs."
         show_usage
@@ -352,6 +356,9 @@ deploy_apps() {
         fi
         log_with_verbose_check "$debug" "$DEBUG" "MASTERCARD_CBS_HOME=$MASTERCARD_CBS_HOME"
         deploy_mastercard
+        ;;
+      "openg2p")
+        deploy_openg2p
         ;;
       *)
         log_error "Unknown application '$app'. This should have been caught by validation."

--- a/src/deployer/helm/openg2p/openg2p-commons/Chart.yaml
+++ b/src/deployer/helm/openg2p/openg2p-commons/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+description: OpenG2P commons layer for Mifos Gazelle — Postgres, Keycloak, MinIO, Kafka-init
+name: gazelle-openg2p-commons
+version: 0.1.0
+home: https://github.com/openMF/mifos-gazelle
+sources:
+- https://github.com/openMF/mifos-gazelle
+
+dependencies:
+- name: openg2p-commons-base
+  alias: commons
+  version: "2.0.1"
+  repository: https://openg2p.github.io/openg2p-helm

--- a/src/deployer/helm/openg2p/openg2p-commons/values.yaml
+++ b/src/deployer/helm/openg2p/openg2p-commons/values.yaml
@@ -1,0 +1,107 @@
+############################################################
+# OpenG2P commons — shared infra for all OpenG2P modules.
+# Deploys into the openg2p namespace: Postgres, Keycloak (+keycloak-init),
+# MinIO, Kafka + Kafka-UI, OpenSearch (search/index only), Redis + Redis-auth,
+# SoftHSM, and the postgres-init DB jobs.
+# Domain baseline: mifos.gazelle.test — patched to live GAZELLE_DOMAIN at deploy time.
+#
+# Istio note: every service that emits an Istio Gateway/VirtualService has an
+# <service>.istio.enabled toggle, set false here EXCEPT keycloak, whose
+# Gateway/VirtualService render unconditionally on keycloak.enabled. openg2p.sh
+# installs the minimal Istio networking CRDs so those two objects apply
+# harmlessly; real traffic is routed via the NGINX ingress below.
+############################################################
+
+commons:
+  global:
+    baseDomain: mifos.gazelle.test
+    keycloakBaseUrl: "https://keycloak.mifos.gazelle.test"
+    keycloakInternalUrl: "http://openg2p-commons-keycloak:80"
+    sysAdminEmail: admin@mifos.gazelle.test
+    kafkaUiHostname: "kafka.mifos.gazelle.test"
+    opensearchHostname: "opensearch.mifos.gazelle.test"
+    minioHostname: "minio.mifos.gazelle.test"
+
+  ############################################################
+  # Keycloak — shared SSO for all OpenG2P modules.
+  ############################################################
+  keycloak:
+    ingress:
+      enabled: true
+      ingressClassName: nginx
+      annotations:
+        nginx.ingress.kubernetes.io/ssl-redirect: "true"
+        nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+      hostname: "keycloak.mifos.gazelle.test"
+      tls: true
+      extraTls:
+        - hosts:
+            - "keycloak.mifos.gazelle.test"
+          secretName: openg2p-tls
+    extraEnvVars:
+      - name: KC_HOSTNAME
+        value: "keycloak.mifos.gazelle.test"
+      - name: KC_HOSTNAME_STRICT
+        value: "false"
+    # Upstream ships no memory limit (request-only), so Keycloak is first in line
+    # for eviction under node memory pressure. Live usage ~1.6Gi; cap with headroom.
+    # Do NOT set JAVA_OPTS_APPEND — it clobbers the chart's JGroups DNS discovery.
+    resources:
+      limits:
+        memory: 2560Mi
+
+  postgresql:
+    istio:
+      enabled: false
+
+  ############################################################
+  # MinIO — shared object store.
+  ############################################################
+  minio:
+    hostname: "minio.mifos.gazelle.test"
+    # Upstream requests 16Gi; halved for the demo VM's local-path volume.
+    persistence:
+      size: 8Gi
+    istio:
+      enabled: false
+    ingress:
+      enabled: true
+      ingressClassName: nginx
+      annotations:
+        nginx.ingress.kubernetes.io/ssl-redirect: "true"
+      hostname: "minio.mifos.gazelle.test"
+      tls: true
+      extraTls:
+        - hosts:
+            - "minio.mifos.gazelle.test"
+          secretName: openg2p-tls
+
+  ############################################################
+  # OpenSearch — search/index only. Dashboards UI + its reporting jobs are
+  # disabled: the dashboards OIDC callback doesn't resolve in-cluster (mirrors
+  # the same fix in openg2p-social-registry/values.yaml).
+  ############################################################
+  opensearch:
+    istio:
+      enabled: false
+    # banzaicloud Logging Operator Flow/Output CRDs are not installed in Gazelle
+    loggingOutput:
+      enabled: false
+    dashboards:
+      enabled: false
+    # These jobs import saved searches/ISM policy/index templates INTO
+    # opensearch-dashboards; with dashboards disabled they hang until timeout.
+    savedSearch:
+      enabled: false
+    ismPolicy:
+      enabled: false
+    indexTemplate:
+      enabled: false
+    # Upstream requests 8Gi; halved for the demo VM's local-path volume.
+    master:
+      persistence:
+        size: 4Gi
+
+  kafkaUi:
+    istio:
+      enabled: false

--- a/src/deployer/helm/openg2p/openg2p-g2p-bridge/Chart.yaml
+++ b/src/deployer/helm/openg2p/openg2p-g2p-bridge/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+description: OpenG2P G2P Bridge for Mifos Gazelle
+name: gazelle-openg2p-g2p-bridge
+version: 0.1.0
+home: https://github.com/openMF/mifos-gazelle
+sources:
+- https://github.com/openMF/mifos-gazelle
+
+dependencies:
+- name: openg2p-g2p-bridge
+  alias: g2pbridge
+  version: "3.0.0"
+  repository: https://openg2p.github.io/openg2p-helm

--- a/src/deployer/helm/openg2p/openg2p-g2p-bridge/values.yaml
+++ b/src/deployer/helm/openg2p/openg2p-g2p-bridge/values.yaml
@@ -1,0 +1,88 @@
+############################################################
+# OpenG2P G2P Bridge (own helm release: g2p-bridge)
+# Requires openg2p-commons (Postgres @ openg2p-commons-postgresql, Keycloak)
+# and openg2p-spar (mapper @ spar-mapper-api).
+# Domain baseline: mifos.gazelle.test — patched to live GAZELLE_DOMAIN at deploy time.
+############################################################
+
+g2pbridge:
+  global:
+    postgresqlHost: "openg2p-commons-postgresql"
+    keycloakBaseUrl: "https://keycloak.mifos.gazelle.test"
+    keycloakIssuerUrl: "https://keycloak.mifos.gazelle.test/realms/master"
+    g2pBridgeHostname: "g2p-bridge.mifos.gazelle.test"
+    g2pBridgeMapperBaseUrl: "http://spar-mapper-api/sync"
+    keymanagerInstallationName: "openg2p-commons-keymanager"
+
+  # postgres-init reads the commons superuser password from existingSecret; upstream
+  # defaults to 'commons-postgresql' but Gazelle names it 'openg2p-commons-postgresql'.
+  # Without this override postgres-init dies: "secret commons-postgresql not found",
+  # never creates the g2p-bridge DB/user, and the api/celery init containers fail too.
+  postgres-init:
+    postgresql:
+      existingSecret: "openg2p-commons-postgresql"
+
+  # NOTE: secrets 'pbms' (key: pbms-db-user) and 'registry' (key: registry-db-user) must
+  # exist in the openg2p namespace before this chart deploys — the init container mounts
+  # them unconditionally. Until Gazelle provisions proper cross-module DB users, create
+  # them as stubs (placeholder passwords). The cross-module DB queries will fail at runtime
+  # but pods will start. See: deploy_openg2p / _deploy_openg2p_release for where to add
+  # a pre-flight secret creation step once the DB users are provisioned.
+
+  ############################################################
+  # g2pBridgeApi — main API + ingress.
+  # The bridge celery-worker reads cross-module DB passwords from secrets named 'pbms'
+  # (key: pbms-db-user) and 'registry' (key: registry-db-user). In the upstream monolithic
+  # install these are created by a shared postgres-init. In Gazelle, pbms and social-registry
+  # are SEPARATE releases each with their own postgres, so the DB hostnames below point at
+  # the actual per-module postgres services instead of the shared commons-postgresql upstream assumes.
+  ############################################################
+  g2pBridgeApi:
+    hostname: "g2p-bridge.mifos.gazelle.test"
+    envVars:
+      G2P_BRIDGE_DB_HOSTNAME: "openg2p-commons-postgresql"
+    ingress:
+      enabled: true
+      ingressClassName: nginx
+      annotations:
+        nginx.ingress.kubernetes.io/ssl-redirect: "true"
+        nginx.ingress.kubernetes.io/rewrite-target: /$2
+      hosts:
+        - host: "g2p-bridge.mifos.gazelle.test"
+          paths:
+            - path: /g2pCashTransferBridge/v1(/|$)(.*)
+              pathType: ImplementationSpecific
+      tls:
+        - hosts:
+            - "g2p-bridge.mifos.gazelle.test"
+          secretName: openg2p-tls
+    istio:
+      enabled: false
+
+  celeryWorker:
+    envVars:
+      G2P_BRIDGE_CELERY_WORKERS_DB_HOSTNAME_PBMS: "pbms-postgresql"
+      G2P_BRIDGE_CELERY_WORKERS_DB_HOSTNAME_REGISTRY: "social-registry-postgresql"
+      G2P_BRIDGE_GEO_RESOLVER_DB_HOSTNAME_REGISTRY: "social-registry-postgresql"
+      G2P_BRIDGE_MAPPER_CONNECTORS_DB_HOSTNAME_REGISTRY: "social-registry-postgresql"
+      G2P_BRIDGE_AGENCY_ALLOCATOR_DB_HOSTNAME_PBMS: "pbms-postgresql"
+      G2P_BRIDGE_WAREHOUSE_ALLOCATOR_DB_HOSTNAME_PBMS: "pbms-postgresql"
+
+  openg2pG2pBridgeBenePortalApi:
+    hostname: "g2p-bridge.mifos.gazelle.test"
+    ingress:
+      enabled: true
+      ingressClassName: nginx
+      annotations:
+        nginx.ingress.kubernetes.io/ssl-redirect: "true"
+      hosts:
+        - host: "g2p-bridge.mifos.gazelle.test"
+          paths:
+            - path: /bene-portal
+              pathType: Prefix
+      tls:
+        - hosts:
+            - "g2p-bridge.mifos.gazelle.test"
+          secretName: openg2p-tls
+    istio:
+      enabled: false

--- a/src/deployer/helm/openg2p/openg2p-pbms/Chart.yaml
+++ b/src/deployer/helm/openg2p/openg2p-pbms/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+description: OpenG2P PBMS for Mifos Gazelle
+name: gazelle-openg2p-pbms
+version: 0.1.0
+home: https://github.com/openMF/mifos-gazelle
+sources:
+- https://github.com/openMF/mifos-gazelle
+
+dependencies:
+- name: openg2p-pbms
+  alias: pbms
+  version: "3.0.0"
+  repository: https://openg2p.github.io/openg2p-helm

--- a/src/deployer/helm/openg2p/openg2p-pbms/values.yaml
+++ b/src/deployer/helm/openg2p/openg2p-pbms/values.yaml
@@ -1,0 +1,171 @@
+############################################################
+# OpenG2P PBMS (own helm release: pbms) — Payment & Beneficiary Management.
+# Requires openg2p-commons (Postgres @ openg2p-commons-postgresql, Keycloak).
+# Domain baseline: mifos.gazelle.test — patched to live GAZELLE_DOMAIN at deploy time.
+############################################################
+
+pbms:
+  global:
+    keycloakBaseUrl: "https://keycloak.mifos.gazelle.test"
+    keycloakIssuerUrl: "https://keycloak.mifos.gazelle.test/realms/master"
+    sysAdminEmail: admin@mifos.gazelle.test
+    # bg-task subcharts reach the social-registry DB via
+    # "{{ global.registryInstallationName }}-postgresql" (hostname + secret name).
+    # Upstream defaults this to 'registry', which only exists when pbms and
+    # social-registry share one install. In Gazelle they are separate releases,
+    # so the SR Postgres secret is "social-registry-postgresql" — without this
+    # override the bg-task init container dies: secret "registry-postgresql" not found.
+    registryInstallationName: 'social-registry'
+
+  hostname: "pbms.mifos.gazelle.test"
+
+  # PBMS uses a top-level istio toggle for its main gateway/virtualservice
+  istio:
+    enabled: false
+
+  ############################################################
+  # Odoo — the PBMS web UI.
+  ############################################################
+  odoo:
+    hostname: "pbms.mifos.gazelle.test"
+    # DEMO-ONLY fixed admin login (do not use on a shared/exposed cluster). Makes
+    # the odoo subchart write this into the 'pbms-odoo' secret instead of
+    # generating a random one. _openg2p_pbms_fix_admin_login (src/deployer/openg2p.sh)
+    # aligns Odoo's stored admin password to it post-deploy — the pbms-core image
+    # does not apply ODOO_PASSWORD to the existing admin row on its own. Only takes
+    # effect on a FRESH install (bitnami won't overwrite an existing secret on upgrade).
+    odooEmail: "admin@openg2p.org"
+    odooPassword: "adminopeng2p"
+
+    # --- g2p_payment_phee enablement (see src/utils/openg2p/setup-pbms-phee.sh) ---
+    # The payment addons (openg2p-registry, openg2p-program -> g2p_payment_phee) are
+    # downloaded as tarballs into the persistent PVC by that script; these keys point
+    # Odoo at them. We do NOT use EXTRA_ADDONS_URLS_TO_PULL: its startup path
+    # git-clones, and the pbms-core image ships no `git`, so a non-empty value
+    # crash-loops the pod. Kept set (harmless when the dirs are empty) so they
+    # survive helm upgrades once setup-pbms-phee.sh has fetched the repos.
+    extraEnvVars:
+      - name: EXTRA_ADDONS_URLS_TO_PULL
+        value: ""
+      - name: ODOO_ADDONS_DIR
+        value: "/bitnami/odoo/extraaddons/openg2p-registry,/bitnami/odoo/extraaddons/openg2p-program"
+
+    # The addon repos' Python deps install into /usr/local/lib (ephemeral), so they
+    # must be reinstalled on every pod start. mkdir runs first: ODOO_ADDONS_DIR puts
+    # these paths on Odoo's addons_path, and a missing path 500s every /web asset
+    # (blank, unstyled login page). No-op (`|| true`) when the repos aren't present yet.
+    lifecycleHooks:
+      postStart:
+        exec:
+          command:
+            - /bin/sh
+            - "-c"
+            - >-
+              mkdir -p /bitnami/odoo/extraaddons/openg2p-registry
+              /bitnami/odoo/extraaddons/openg2p-program;
+              (unset SSL_CERT_FILE REQUESTS_CA_BUNDLE;
+              pip install --trusted-host pypi.org --trusted-host files.pythonhosted.org
+              -r /bitnami/odoo/extraaddons/openg2p-registry/requirements.txt
+              -r /bitnami/odoo/extraaddons/openg2p-program/requirements.txt
+              rstr) > /tmp/postStart-pip.log 2>&1 || true
+
+    # Odoo is the heaviest PBMS pod (Python asset build spikes memory on boot).
+    # Upstream reserves 2Gi/1cpu; request eased so it schedules alongside the
+    # other DPGs on a shared node, limit kept at 3Gi for the asset-build spike.
+    resources:
+      requests:
+        cpu: 250m
+        memory: 768Mi
+      limits:
+        cpu: "1.5"
+        memory: 3Gi
+
+    # odoo subchart's S3_URL env resolves .Values.minio.hostname in odoo scope
+    minio:
+      hostname: "minio-pbms.mifos.gazelle.test"
+
+    # The odoo subchart uses the bitnami-style ingress schema: a single 'hostname' +
+    # 'path'/'pathType' + 'tls'/'extraTls' — NOT a hosts[] array. With hosts[] the
+    # chart ignored our host and fell back to 'odoo.local' (404 from NGINX).
+    ingress:
+      enabled: true
+      ingressClassName: nginx
+      hostname: "pbms.mifos.gazelle.test"
+      path: /
+      pathType: Prefix
+      annotations:
+        nginx.ingress.kubernetes.io/ssl-redirect: "true"
+        nginx.ingress.kubernetes.io/proxy-body-size: "50m"
+        nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
+      tls: true
+      extraTls:
+        - hosts:
+            - "pbms.mifos.gazelle.test"
+          secretName: openg2p-tls
+
+    postgresql:
+      istio:
+        enabled: false
+      # Upstream's bitnami/postgresql:16.3.0-debian-12-r16 tag was deleted from
+      # Docker Hub (ImagePullBackOff: NotFound). Repoint to OpenG2P's mirror of
+      # the same image (same fix as the social-registry release).
+      image:
+        registry: docker.io
+        repository: openg2p/postgresql
+        tag: 16.3.0-debian-12-r16
+      # Upstream reserves 2Gi/1cpu, limit 3Gi — a demo DB needs far less; mirror
+      # the commons Postgres sizing.
+      primary:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 512Mi
+          limits:
+            memory: 1Gi
+
+  ############################################################
+  # MinIO — PBMS/odoo S3 object store.
+  ############################################################
+  minio:
+    hostname: "minio-pbms.mifos.gazelle.test"
+    istio:
+      enabled: false
+    # Upstream ships no resource limits at all.
+    resources:
+      requests:
+        cpu: 50m
+        memory: 128Mi
+      limits:
+        memory: 512Mi
+    # Upstream requests 16Gi; halved for the demo VM's local-path volume.
+    persistence:
+      size: 8Gi
+
+  ############################################################
+  # Background task workers (api, celery-beat-producer, celery-worker) — ship
+  # with no resource limits upstream. celery-worker gets the most headroom
+  # (processes batches); api and the beat producer are light coordinators.
+  ############################################################
+  openg2p-pbms-bg-task-api:
+    resources:
+      requests:
+        cpu: 50m
+        memory: 128Mi
+      limits:
+        memory: 512Mi
+
+  openg2p-pbms-bg-task-celery-beat-producers:
+    resources:
+      requests:
+        cpu: 50m
+        memory: 128Mi
+      limits:
+        memory: 512Mi
+
+  openg2p-pbms-bg-task-celery-workers:
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        memory: 768Mi

--- a/src/deployer/helm/openg2p/openg2p-social-registry/Chart.yaml
+++ b/src/deployer/helm/openg2p/openg2p-social-registry/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+description: OpenG2P Social Registry for Mifos Gazelle
+name: gazelle-openg2p-social-registry
+version: 0.1.0
+home: https://github.com/openMF/mifos-gazelle
+sources:
+- https://github.com/openMF/mifos-gazelle
+
+dependencies:
+- name: openg2p-social-registry
+  alias: socialregistry
+  version: "2.0.8"
+  repository: https://openg2p.github.io/openg2p-helm

--- a/src/deployer/helm/openg2p/openg2p-social-registry/values.yaml
+++ b/src/deployer/helm/openg2p/openg2p-social-registry/values.yaml
@@ -1,0 +1,245 @@
+############################################################
+# OpenG2P Social Registry (own helm release: social-registry)
+# Requires openg2p-commons (Postgres @ openg2p-commons-postgresql, Keycloak).
+# Domain baseline: mifos.gazelle.test — patched to live GAZELLE_DOMAIN at deploy time.
+############################################################
+
+socialregistry:
+  global:
+    keycloakBaseUrl: "https://keycloak.mifos.gazelle.test"
+    keycloakIssuerUrl: "https://keycloak.mifos.gazelle.test/realms/master"
+    sysAdminEmail: admin@mifos.gazelle.test
+    srAdminHostname: "social-registry.mifos.gazelle.test"
+    srOdkCentralHostname: "odk-sr.mifos.gazelle.test"
+    srMinioHostname: "minio-sr.mifos.gazelle.test"
+    srOpensearchHostname: "opensearch-sr.mifos.gazelle.test"
+    srKafkaUiHostname: "kafka-sr.mifos.gazelle.test"
+    srLandingPageHostname: "social-registry.mifos.gazelle.test"
+
+  ############################################################
+  # Odoo — the SR web UI (core registry).
+  ############################################################
+  odoo:
+    hostname: "social-registry.mifos.gazelle.test"
+    # DEMO-ONLY fixed admin login (do not use on a shared/exposed cluster), same
+    # value as PBMS. Makes the odoo subchart write this into the
+    # 'social-registry-odoo' secret instead of generating a random one. Only
+    # takes effect on a FRESH install (the subchart won't overwrite an existing
+    # secret on upgrade).
+    odooEmail: "admin@openg2p.org"
+    odooPassword: "adminopeng2p"
+    minio:
+      hostname: "minio-sr.mifos.gazelle.test"
+    # bitnami-style ingress schema: single 'hostname' + 'tls'/'extraTls' (NOT a hosts[] array)
+    ingress:
+      enabled: true
+      ingressClassName: nginx
+      hostname: "social-registry.mifos.gazelle.test"
+      path: /
+      pathType: Prefix
+      annotations:
+        nginx.ingress.kubernetes.io/ssl-redirect: "true"
+        nginx.ingress.kubernetes.io/proxy-body-size: "50m"
+        nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
+      tls: true
+      extraTls:
+        - hosts:
+            - "social-registry.mifos.gazelle.test"
+          secretName: openg2p-tls
+    istio:
+      enabled: false
+    postgresql:
+      istio:
+        enabled: false
+      # Additional DB users for the kernel/keymanager/esignet/odk services.
+      # Upstream leaves these blank, which makes postgres-init create users
+      # whose password doesn't match what the apps send ("password auth failed").
+      additionalDbs:
+        enabled: true
+        userPasswords:
+          kerneluser: kernel123
+          keymgruser: keymgr123
+          esignetuser: esignet123
+          odkuser: odk123
+          mockidsystemuser: mockid123
+          superset: superset
+
+  ############################################################
+  # Disabled subcharts — not needed for the pre-loaded-data Gazelle demo, or
+  # broken upstream. None of these are hard dependencies of the core registry.
+  ############################################################
+
+  # SMTP relay pins ixdotai/smtp:v0.5.2, deleted from Docker Hub (ImagePullBackOff).
+  mail:
+    enabled: false
+
+  # Crashes on an upstream JVM/Tomcat bug (NoClassDefFoundError: MBeanFactory) in
+  # the MOSIP image. Only powers crypto/identity-signing features.
+  keymanager:
+    enabled: false
+
+  # MOSIP kernel fails to auth as "kerneluser" — reads DB creds from the upstream
+  # mosip-config server, not the chart secret, so the password never matches.
+  idgenerator:
+    enabled: false
+
+  # Admin UI requires OIDC against the EXTERNAL keycloak hostname, which doesn't
+  # resolve from inside the cluster (UnknownHostException).
+  kafkaUi:
+    enabled: false
+
+  # No consumer in Gazelle — esignet, keymanager and idgenerator (softhsm's only
+  # clients) are all disabled above.
+  softhsm:
+    enabled: false
+
+  # ODK Central is the form-based data-collection front door (backend, frontend,
+  # enketo, pyxform + 2 redis). This demo pre-loads registry data instead, so
+  # it's dead weight — and enketo OOMKilled / failed its startup probe
+  # repeatedly regardless of limit. Nothing in the core registry depends on it
+  # (only dead SR_ODK_URL deep-links in the Odoo UI).
+  odk-central:
+    enabled: false
+  odk-central-enketo-redis-main:
+    enabled: false
+  odk-central-enketo-redis-cache:
+    enabled: false
+
+  ############################################################
+  # MinIO — SR object store.
+  ############################################################
+  minio:
+    hostname: "minio-sr.mifos.gazelle.test"
+    istio:
+      enabled: false
+    # Upstream ships no resource limits at all.
+    resources:
+      requests:
+        cpu: 50m
+        memory: 128Mi
+      limits:
+        memory: 512Mi
+    # Upstream requests 16Gi; halved for the demo VM's local-path volume.
+    persistence:
+      size: 8Gi
+
+  ############################################################
+  # OpenSearch — search/index only. Dashboards UI + its reporting-init job are
+  # disabled: the dashboards OIDC callback doesn't resolve in-cluster. The
+  # 'reporting' CDC pipeline (debezium + opensearch-kafka-connector) below is
+  # independent and stays on.
+  ############################################################
+  opensearch:
+    istio:
+      enabled: false
+    loggingOutput:
+      enabled: false
+    dashboards:
+      enabled: false
+
+  # Imports index patterns/dashboards INTO opensearch-dashboards; with the
+  # dashboards UI disabled, that Service doesn't exist and the job hangs until
+  # timeout.
+  reporting-init:
+    enabled: false
+
+  ############################################################
+  # Resource caps — upstream ships most of these workloads with NO memory limit
+  # (bitnami `resourcesPreset: none` / custom charts' `resources: {}`), so they
+  # rank first for eviction under node memory pressure on a shared cluster.
+  # Sizes below are calibrated against live `kubectl top` usage on this cluster,
+  # not upstream guesses.
+  ############################################################
+
+  superset:
+    istio:
+      enabled: false
+    # Global default — applies to the web pod (live usage ~210Mi, 1Gi is ample).
+    resources:
+      requests:
+        cpu: 100m
+        memory: 384Mi
+      limits:
+        memory: 1Gi
+    # The celery worker runs heavier than the web pod (live usage ~803Mi) and has
+    # its own key that overrides the global resources above.
+    supersetWorker:
+      resources:
+        requests:
+          cpu: 100m
+          memory: 512Mi
+        limits:
+          memory: 1536Mi
+
+  landing:
+    istio:
+      enabled: false
+    resources:
+      requests:
+        cpu: 25m
+        memory: 64Mi
+      limits:
+        memory: 128Mi
+
+  kafka:
+    controller:
+      resources:
+        requests:
+          cpu: 100m
+          memory: 512Mi
+        limits:
+          memory: 1Gi
+
+  reporting:
+    debezium:
+      resources:
+        requests:
+          cpu: 50m
+          memory: 256Mi
+        limits:
+          memory: 768Mi
+    opensearch-kafka-connector:
+      resources:
+        requests:
+          cpu: 50m
+          memory: 256Mi
+        limits:
+          memory: 768Mi
+
+  # producer + worker Deployments (unbounded upstream). The bg-tasks redis is a
+  # SEPARATE top-level chart aliased `bgTasksRedis` below, not nested here.
+  openg2p-registry-bg-tasks:
+    producer:
+      resources:
+        requests:
+          cpu: 50m
+          memory: 256Mi
+        # Live usage ~450Mi.
+        limits:
+          memory: 768Mi
+    worker:
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          memory: 768Mi
+
+  # Redis instances are top-level aliases in the SR Chart.yaml (bgTasksRedis,
+  # supersetRedis), NOT sub-keys of their consuming charts.
+  bgTasksRedis:
+    master:
+      resources:
+        requests:
+          cpu: 50m
+          memory: 64Mi
+        limits:
+          memory: 192Mi
+  supersetRedis:
+    master:
+      resources:
+        requests:
+          cpu: 50m
+          memory: 64Mi
+        limits:
+          memory: 192Mi

--- a/src/deployer/helm/openg2p/openg2p-spar/Chart.yaml
+++ b/src/deployer/helm/openg2p/openg2p-spar/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+description: OpenG2P SPAR for Mifos Gazelle
+name: gazelle-openg2p-spar
+version: 0.1.0
+home: https://github.com/openMF/mifos-gazelle
+sources:
+- https://github.com/openMF/mifos-gazelle
+
+dependencies:
+- name: openg2p-spar
+  alias: spar
+  version: "0.0.0-develop"
+  repository: https://openg2p.github.io/openg2p-helm

--- a/src/deployer/helm/openg2p/openg2p-spar/values.yaml
+++ b/src/deployer/helm/openg2p/openg2p-spar/values.yaml
@@ -1,0 +1,66 @@
+############################################################
+# OpenG2P SPAR (own helm release: spar)
+# Requires openg2p-commons (Postgres @ openg2p-commons-postgresql, Keycloak).
+# Domain baseline: mifos.gazelle.test — patched to live GAZELLE_DOMAIN at deploy time.
+############################################################
+
+spar:
+  global:
+    keycloakBaseUrl: "https://keycloak.mifos.gazelle.test"
+    keycloakIssuerUrl: "https://keycloak.mifos.gazelle.test/realms/master"
+    postgresqlHost: "openg2p-commons-postgresql"
+
+  # postgres-init reads the commons superuser password from existingSecret; upstream
+  # defaults to 'commons-postgresql' but Gazelle's commons release names it
+  # 'openg2p-commons-postgresql'. Without this override the postgres-init Job dies
+  # with "secret commons-postgresql not found", never creates the spar DB/user, and
+  # mapper-api/bene-portal-api fail with "password authentication failed for spar_user".
+  postgres-init:
+    postgresql:
+      existingSecret: "openg2p-commons-postgresql"
+
+  # keycloak-init reads the Keycloak admin password from existingSecret; same naming
+  # mismatch — upstream default 'commons-keycloak' vs actual 'openg2p-commons-keycloak'.
+  keycloak-init:
+    keycloak:
+      existingSecret: "openg2p-commons-keycloak"
+
+  sparMapperAPI:
+    hostname: "spar.mifos.gazelle.test"
+    ingress:
+      enabled: true
+      className: nginx
+      annotations:
+        nginx.ingress.kubernetes.io/ssl-redirect: "true"
+        nginx.ingress.kubernetes.io/rewrite-target: /$2
+      hosts:
+        - host: "spar.mifos.gazelle.test"
+          paths:
+            - path: /api/mapper(/|$)(.*)
+              pathType: ImplementationSpecific
+      tls:
+        - hosts:
+            - "spar.mifos.gazelle.test"
+          secretName: openg2p-tls
+    istio:
+      enabled: false
+
+  benePortalAPI:
+    benePortalHostname: "spar.mifos.gazelle.test"
+    ingress:
+      enabled: true
+      className: nginx
+      annotations:
+        nginx.ingress.kubernetes.io/ssl-redirect: "true"
+        nginx.ingress.kubernetes.io/rewrite-target: /$2
+      hosts:
+        - host: "spar.mifos.gazelle.test"
+          paths:
+            - path: /api/bene(/|$)(.*)
+              pathType: ImplementationSpecific
+      tls:
+        - hosts:
+            - "spar.mifos.gazelle.test"
+          secretName: openg2p-tls
+    istio:
+      enabled: false

--- a/src/deployer/manifests/openg2p/istio-networking-crds.yaml
+++ b/src/deployer/manifests/openg2p/istio-networking-crds.yaml
@@ -1,0 +1,63 @@
+# Minimal Istio networking CRDs for OpenG2P.
+# OpenG2P's Keycloak subchart emits Gateway and VirtualService objects unconditionally.
+# Gazelle uses NGINX ingress (not Istio), so these CRDs let those objects land
+# harmlessly with no Istio control plane. No field validation needed — open schema.
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: gateways.networking.istio.io
+spec:
+  group: networking.istio.io
+  names:
+    kind: Gateway
+    listKind: GatewayList
+    plural: gateways
+    singular: gateway
+    shortNames:
+    - gw
+  scope: Namespaced
+  versions:
+  - name: v1alpha3
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+  - name: v1beta1
+    served: true
+    storage: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: virtualservices.networking.istio.io
+spec:
+  group: networking.istio.io
+  names:
+    kind: VirtualService
+    listKind: VirtualServiceList
+    plural: virtualservices
+    singular: virtualservice
+    shortNames:
+    - vs
+  scope: Namespaced
+  versions:
+  - name: v1alpha3
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+  - name: v1beta1
+    served: true
+    storage: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true

--- a/src/deployer/manifests/openg2p/optional-operator-crds.yaml
+++ b/src/deployer/manifests/openg2p/optional-operator-crds.yaml
@@ -1,0 +1,80 @@
+# Minimal operator CRDs for OpenG2P sub-services.
+# OpenG2P module subcharts emit banzaicloud logging Flow/Output and Prometheus
+# ServiceMonitor objects. Gazelle runs neither operator, so these CRDs let those
+# objects land harmlessly (no controller acts on them). Open schema — no validation.
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: flows.logging.banzaicloud.io
+spec:
+  group: logging.banzaicloud.io
+  names:
+    kind: Flow
+    listKind: FlowList
+    plural: flows
+    singular: flow
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+  - name: v1alpha1
+    served: true
+    storage: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: outputs.logging.banzaicloud.io
+spec:
+  group: logging.banzaicloud.io
+  names:
+    kind: Output
+    listKind: OutputList
+    plural: outputs
+    singular: output
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+  - name: v1alpha1
+    served: true
+    storage: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: servicemonitors.monitoring.coreos.com
+spec:
+  group: monitoring.coreos.com
+  names:
+    kind: ServiceMonitor
+    listKind: ServiceMonitorList
+    plural: servicemonitors
+    singular: servicemonitor
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true

--- a/src/deployer/openg2p.sh
+++ b/src/deployer/openg2p.sh
@@ -1,0 +1,552 @@
+#!/usr/bin/env bash
+# openg2p.sh -- Mifos Gazelle deployer script for OpenG2P
+#
+# Each OpenG2P module is its own helm release so subchart-generated object names
+# never collide across modules. Deploy order: CRDs, then commons (Postgres/Keycloak/
+# MinIO foundation), then each enabled module gated on its own pods being ready.
+
+OPENG2P_HELM_DIR="${BASE_DIR}/src/deployer/helm/openg2p"
+OPENG2P_CRDS_DIR="${BASE_DIR}/src/deployer/manifests/openg2p"
+
+# Module deploy order. g2p-bridge last because it depends on the spar mapper.
+OPENG2P_MODULES=(social-registry pbms spar g2p-bridge)
+
+#------------------------------------------------------------------------------
+# Function : deploy_openg2p
+# Description: Top-level entry point — deploys commons, then each enabled module
+#              as its own helm release into the openg2p namespace on GAZELLE_DOMAIN.
+#------------------------------------------------------------------------------
+deploy_openg2p() {
+  log_section "Deploying OpenG2P"
+
+  if is_app_running "$OPENG2P_NAMESPACE"; then
+    if [[ "$redeploy" == "false" ]]; then
+      echo "    OpenG2P already deployed — skipping."
+      return 0
+    fi
+  fi
+
+  log_step "Creating namespace $OPENG2P_NAMESPACE"
+  create_namespace "$OPENG2P_NAMESPACE"
+  log_ok
+
+  log_step "Creating OpenG2P TLS secret"
+  create_ingress_secret "$OPENG2P_NAMESPACE" \
+    "openg2p.$GAZELLE_DOMAIN" \
+    "openg2p-tls" \
+    "social-registry.$GAZELLE_DOMAIN,pbms.$GAZELLE_DOMAIN,spar.$GAZELLE_DOMAIN,g2p-bridge.$GAZELLE_DOMAIN,keycloak.$GAZELLE_DOMAIN,minio.$GAZELLE_DOMAIN,*.$GAZELLE_DOMAIN"
+  log_ok
+
+  # OpenG2P charts emit Istio/logging/monitoring objects Gazelle has no controllers for.
+  # Install just their CRDs so the objects apply harmlessly; traffic routes via NGINX.
+  log_step "Installing OpenG2P prerequisite CRDs (Istio, logging, monitoring)"
+  kubectl apply -f "$OPENG2P_CRDS_DIR/istio-networking-crds.yaml" > /dev/null 2>&1
+  kubectl apply -f "$OPENG2P_CRDS_DIR/optional-operator-crds.yaml" > /dev/null 2>&1
+  log_ok
+
+  # Tear down disabled module releases first: leftover crashing pods from a disabled
+  # module would otherwise block the namespace-wide readiness waits below.
+  local module enabled
+  for module in "${OPENG2P_MODULES[@]}"; do
+    enabled=$(_openg2p_module_enabled "$module")
+    if [[ "$enabled" != "true" ]] && helm status "$module" -n "$OPENG2P_NAMESPACE" > /dev/null 2>&1; then
+      log_step "Removing disabled OpenG2P module '$module'"
+      _clean_openg2p_release "$module"
+      log_ok
+    fi
+  done
+
+  # Commons is the hard dependency — modules connect to its Postgres/Keycloak, so an
+  # unhealthy commons is fatal (modules can only fail against a broken foundation).
+  if ! _deploy_openg2p_release "openg2p-commons" "openg2p-commons"; then
+    log_error "OpenG2P commons did not become ready — aborting OpenG2P deploy"
+    return 1
+  fi
+
+  # Deploy each enabled module as its own release, gated per-release on its own pods.
+  # A failed module is recorded and the loop CONTINUES — reported at the end, never sticks.
+  local failed_modules=()
+  for module in "${OPENG2P_MODULES[@]}"; do
+    enabled=$(_openg2p_module_enabled "$module")
+    if [[ "$enabled" != "true" ]]; then
+      log_skipped "OpenG2P module '$module' is disabled — skipping"
+      continue
+    fi
+    # Create secrets the chart expects a monolithic install to have made (see function).
+    _openg2p_preflight_secrets "$module"
+
+    # release name == module name (short, unique prefix → no cross-module collisions)
+    if ! _deploy_openg2p_release "openg2p-$module" "$module"; then
+      failed_modules+=("$module")
+      log_warn "OpenG2P module '$module' is not fully ready — continuing with remaining modules"
+    else
+      # Module is up — run any post-deploy fixups it needs (idempotent).
+      _openg2p_postdeploy "$module"
+    fi
+  done
+
+  if [[ "${#failed_modules[@]}" -gt 0 ]]; then
+    local grep_alt
+    grep_alt=$(IFS='|'; echo "${failed_modules[*]}")   # join with '|' for grep -E
+    log_warn "OpenG2P deployed with unready module(s): ${failed_modules[*]}"
+    log_warn "Inspect with: kubectl get pods -n $OPENG2P_NAMESPACE | grep -E '${grep_alt}'"
+  fi
+  log_banner "OpenG2P Deployed"
+  _openg2p_print_urls
+}
+
+#------------------------------------------------------------------------------
+# Function : _openg2p_print_urls
+# Description: Prints access URLs for the enabled OpenG2P modules on GAZELLE_DOMAIN.
+#------------------------------------------------------------------------------
+_openg2p_print_urls() {
+  local d="$GAZELLE_DOMAIN"
+  local fmt="    %-18s%s\n"
+  printf "\n  OpenG2P modules:\n"
+  [[ "$(_openg2p_module_enabled social-registry)" == "true" ]] && \
+    printf "$fmt" "Social Registry:"  "https://social-registry.$d"
+  [[ "$(_openg2p_module_enabled pbms)" == "true" ]] && \
+    printf "$fmt" "PBMS:"             "https://pbms.$d"
+  [[ "$(_openg2p_module_enabled spar)" == "true" ]] && \
+    printf "$fmt" "SPAR (API):"       "https://spar.$d/api/mapper"
+  [[ "$(_openg2p_module_enabled g2p-bridge)" == "true" ]] && \
+    printf "$fmt" "G2P Bridge (API):" "https://g2p-bridge.$d"
+  # Shared commons services (always present once commons is deployed)
+  printf "$fmt" "Keycloak:"           "https://keycloak.$d"
+  printf "$fmt" "MinIO:"              "https://minio.$d"
+}
+
+#------------------------------------------------------------------------------
+# Function : _deploy_openg2p_release
+# Description: Idempotently deploys one helm release and gates on its pods becoming
+#              ready. Healthy releases are skipped; failed ones are torn down and
+#              reinstalled.
+#   $1 = chart dir name under helm/openg2p/ (e.g. openg2p-commons)
+#   $2 = helm release name                  (e.g. openg2p-commons, pbms)
+# Returns: 0 if deployed and pods ready (or already healthy); 1 if helm failed or
+#          pods did not become ready (caller decides whether that's fatal).
+#------------------------------------------------------------------------------
+_deploy_openg2p_release() {
+  local chart_name="$1"
+  local release_name="$2"
+  local chart_src="$OPENG2P_HELM_DIR/$chart_name"
+  local chart_work="$DEPLOY_WORK_DIR/$chart_name"
+
+  local status
+  status=$(helm status "$release_name" -n "$OPENG2P_NAMESPACE" -o json 2>/dev/null \
+    | grep -o '"status":"[a-z-]*"' | head -1 | cut -d'"' -f4)
+
+  # A pending-*/failed release blocks the next upgrade. If its pods are actually healthy,
+  # promote the record to "deployed" rather than wiping it (which would re-init Postgres).
+  if [[ "$status" == pending-* || "$status" == "failed" ]]; then
+    if _openg2p_release_pods_healthy "$release_name"; then
+      log_step "Release '$release_name' is '$status' but pods are healthy — promoting to deployed"
+      _promote_pending_release "$release_name" && status="deployed"
+      log_ok
+    fi
+  fi
+
+  if [[ -n "$status" && "$status" != "deployed" ]]; then
+    log_step "Previous '$release_name' release is '$status' — clearing it"
+    _clean_openg2p_release "$release_name"
+    log_ok
+  fi
+
+  # Idempotent skip: re-running helm re-applies every object and re-fires hook jobs (slow).
+  # Skip a healthy deployed release outright; `helm uninstall` forces a real redeploy.
+  if [[ "$status" == "deployed" ]] && _openg2p_release_pods_healthy "$release_name"; then
+    log_skipped "$release_name already deployed and healthy — skipping (helm uninstall to force)"
+    return 0
+  fi
+
+  log_step "Copying $release_name chart to working directory"
+  rm -rf "$chart_work"
+  mkdir -p "$chart_work"
+  cp -r "$chart_src/." "$chart_work/"
+  log_ok
+
+  log_step "Updating FQDNs in $release_name values"
+  apply_domain_to_file "$chart_work/values.yaml" "$GAZELLE_DOMAIN"
+  log_ok
+
+  log_step "Fetching $release_name chart dependencies"
+  ensure_helm_dependencies "$chart_work"
+  log_ok
+
+  # No `--wait`: on large charts helm's rate-limited readiness poll stalls for minutes and
+  # can mark the release "failed" even when pods came up. We apply and return, then judge
+  # readiness from real pod state via _wait_for_openg2p_release_ready() below. --qps raises
+  # the client limit for the apply itself.
+  log_step "Deploying $release_name"
+  if ! helm upgrade --install \
+    --qps "${OPENG2P_HELM_QPS:-50}" \
+    --timeout "${startup_timeout:-1200}s" \
+    "$release_name" "$chart_work" \
+    -n "$OPENG2P_NAMESPACE"; then
+    log_warn "helm upgrade $release_name failed"
+    return 1
+  fi
+  log_ok
+
+  # Per-release readiness gate: "really deployed" means the pods are actually Ready,
+  # not merely that helm applied the manifests (we deploy without --wait). Returns
+  # non-zero on timeout or terminal pod failure so the caller can record/skip it
+  # instead of the whole deploy sticking on one module.
+  _wait_for_openg2p_release_ready "$release_name" "${startup_timeout:-1200}"
+}
+
+#------------------------------------------------------------------------------
+# Function : _openg2p_preflight_secrets
+# Description: Idempotently stubs secrets a module's chart mounts unconditionally but
+#              that Gazelle's split-release layout never creates (upstream assumes one
+#              monolithic install). Without them init containers die with
+#              CreateContainerConfigError. Placeholder passwords — enough to boot; real
+#              cross-module DB access is a follow-up (see g2p-bridge values.yaml).
+#   $1 = module name
+#------------------------------------------------------------------------------
+_openg2p_preflight_secrets() {
+  local module="$1"
+  case "$module" in
+    pbms)
+      # PBMS bg-task pods mount the social-registry postgres secret. When SR is disabled
+      # it is never created, so stub it. Guarded: if SR is enabled it deploys first (earlier
+      # in OPENG2P_MODULES) and creates the real secret, so this is skipped.
+      if ! kubectl get secret social-registry-postgresql -n "$OPENG2P_NAMESPACE" >/dev/null 2>&1; then
+        log_step "Pre-creating pbms prerequisite secret 'social-registry-postgresql'"
+        kubectl create secret generic social-registry-postgresql -n "$OPENG2P_NAMESPACE" \
+          --from-literal="postgres-password=placeholder" \
+          --dry-run=client -o yaml | kubectl apply -f - >/dev/null 2>&1
+        log_ok
+      fi
+      ;;
+    g2p-bridge)
+      local s
+      # secret name : key  (the Keycloak OIDC client secret + cross-module DB user secrets)
+      for s in "openg2p-g2p-bridge-openg2p:client_secret" "pbms:pbms-db-user" "registry:registry-db-user"; do
+        local name="${s%%:*}" key="${s##*:}"
+        if ! kubectl get secret "$name" -n "$OPENG2P_NAMESPACE" >/dev/null 2>&1; then
+          log_step "Pre-creating g2p-bridge prerequisite secret '$name'"
+          kubectl create secret generic "$name" -n "$OPENG2P_NAMESPACE" \
+            --from-literal="$key=placeholder" \
+            --dry-run=client -o yaml | kubectl apply -f - >/dev/null 2>&1
+          log_ok
+        fi
+      done
+      ;;
+  esac
+}
+
+#------------------------------------------------------------------------------
+# Function : _openg2p_postdeploy
+# Description: Idempotent per-module fixups that must run AFTER the module's pods are
+#              ready (unlike _openg2p_preflight_secrets which runs before). Safe to run
+#              on every deploy/redeploy.
+#   $1 = module name
+#------------------------------------------------------------------------------
+_openg2p_postdeploy() {
+  local module="$1"
+  case "$module" in
+    pbms)
+      # Required: the pbms-core image does not apply ODOO_PASSWORD to the admin row, so
+      # without this fixup a fresh deploy is locked out of the Odoo UI.
+      _openg2p_pbms_fix_admin_login
+      # Wire up the PBMS->PHEE connector (installs the payment addons). Needs pod
+      # network egress. Idempotent — re-running short-circuits already-applied steps.
+      _openg2p_pbms_setup_phee
+      ;;
+  esac
+}
+
+#------------------------------------------------------------------------------
+# Function : _openg2p_pbms_setup_phee
+# Description: Runs the idempotent g2p_payment_phee enablement script. Non-fatal: a
+#              failure logs a warning and does not abort the deploy.
+#------------------------------------------------------------------------------
+_openg2p_pbms_setup_phee() {
+  local script="${BASE_DIR}/src/utils/openg2p/setup-pbms-phee.sh"
+  [[ -x "$script" || -f "$script" ]] || { log_warn "setup-pbms-phee.sh not found at $script — skipping PHEE setup"; return 0; }
+  log_with_level "$INFO" "Enabling g2p_payment_phee connector on PBMS (this runs setup-pbms-phee.sh)"
+  if ! bash "$script"; then
+    log_warn "g2p_payment_phee setup did not complete — run $script manually"
+  fi
+}
+
+#------------------------------------------------------------------------------
+# Function : _openg2p_pbms_fix_admin_login
+# Description: Resets the PBMS Odoo admin user's login/password (via Odoo's ORM, so the
+#              hash is valid) to match the 'pbms-odoo' secret — the image bootstrap does
+#              not, leaving a fresh install locked out. Idempotent.
+#              Creds: login "admin@openg2p.org", password from:
+#                kubectl get secret pbms-odoo -n openg2p \
+#                  -o jsonpath='{.data.odoo-password}' | base64 -d
+#------------------------------------------------------------------------------
+_openg2p_pbms_fix_admin_login() {
+  local pod pw db="pbmsdb" email="admin@openg2p.org"
+  pod=$(kubectl get pods -n "$OPENG2P_NAMESPACE" --no-headers 2>/dev/null \
+    | awk '/^pbms-odoo-/ && $3=="Running"{print $1; exit}')
+  [[ -z "$pod" ]] && { log_with_verbose_check "$debug" "$DEBUG" "pbms odoo pod not found — skipping admin fixup"; return 0; }
+
+  pw=$(kubectl get secret pbms-odoo -n "$OPENG2P_NAMESPACE" -o jsonpath='{.data.odoo-password}' 2>/dev/null | base64 -d)
+  [[ -z "$pw" ]] && { log_warn "pbms-odoo secret has no odoo-password — skipping admin fixup"; return 0; }
+
+  log_step "Aligning PBMS Odoo admin login/password (login: admin or $email)"
+  # Run inside the odoo pod via its shell so the password is hashed by Odoo itself.
+  # base id 2 = the built-in admin user. Set login=email AND password; commit.
+  kubectl exec -n "$OPENG2P_NAMESPACE" "$pod" -- bash -lc "
+    odoo shell -c /etc/odoo/odoo.conf -d '$db' --no-http <<PYEOF 2>/dev/null | grep -q PBMS_ADMIN_OK && exit 0 || exit 1
+u = env['res.users'].browse(2)
+u.write({'login': '$email', 'password': '$pw'})
+env.cr.commit()
+print('PBMS_ADMIN_OK')
+PYEOF
+  " >/dev/null 2>&1 \
+    && log_ok \
+    || log_warn "PBMS admin login fixup did not complete — set it manually (odoo shell on the pbms-odoo pod)"
+}
+
+#------------------------------------------------------------------------------
+# Function : _openg2p_module_enabled
+# Description: Returns "true"/"false" for a module from its OPENG2P_*_ENABLED config.
+#------------------------------------------------------------------------------
+_openg2p_module_enabled() {
+  local module="$1"
+  local val
+  case "$module" in
+    social-registry) val="${OPENG2P_SOCIAL_REGISTRY_ENABLED:-true}" ;;
+    pbms)            val="${OPENG2P_PBMS_ENABLED:-true}" ;;
+    spar)            val="${OPENG2P_SPAR_ENABLED:-true}" ;;
+    g2p-bridge)      val="${OPENG2P_G2P_BRIDGE_ENABLED:-true}" ;;
+    *)               val="false" ;;
+  esac
+  echo "$val" | tr '[:upper:]' '[:lower:]'
+}
+
+#------------------------------------------------------------------------------
+# Function : _clean_openg2p_release
+# Description: Uninstalls one helm release and clears any orphaned objects it left
+#              (failed first-revision installs leave objects Helm never recorded).
+#              Deletes synchronously so a following reinstall never races stragglers.
+#   $1 = helm release name (also the object name prefix)
+#------------------------------------------------------------------------------
+_clean_openg2p_release() {
+  local release_name="$1"
+  helm uninstall "$release_name" -n "$OPENG2P_NAMESPACE" --wait --timeout 300s 2>/dev/null || true
+
+  # Workloads first (release their volumes), then everything else, PVCs last. STS PVCs
+  # are retained by k8s on delete — remove them explicitly or postgres reuses stale data.
+  local kind
+  for kind in deployment statefulset replicaset job; do
+    kubectl get "$kind" -n "$OPENG2P_NAMESPACE" --no-headers 2>/dev/null \
+      | awk -v p="^${release_name}-" '$1 ~ p || $1 == "'"$release_name"'" {print $1}' \
+      | xargs -r kubectl delete "$kind" -n "$OPENG2P_NAMESPACE" --wait=true --timeout=120s 2>/dev/null >/dev/null || true
+  done
+
+  kubectl get pods -n "$OPENG2P_NAMESPACE" --no-headers 2>/dev/null \
+    | awk -v p="^${release_name}-" '$1 ~ p {print $1}' \
+    | xargs -r kubectl delete pod -n "$OPENG2P_NAMESPACE" --force --grace-period=0 2>/dev/null >/dev/null || true
+
+  for kind in service secret configmap networkpolicy poddisruptionbudget ingress \
+              serviceaccount virtualservice gateway servicemonitor flow output; do
+    kubectl get "$kind" -n "$OPENG2P_NAMESPACE" --no-headers 2>/dev/null \
+      | awk -v p="^${release_name}-" '$1 ~ p || $1 == "'"$release_name"'" {print $1}' \
+      | xargs -r kubectl delete "$kind" -n "$OPENG2P_NAMESPACE" --wait=true --timeout=120s 2>/dev/null >/dev/null || true
+  done
+
+  # PVCs last, matched as a substring: STS PVCs are named "<template>-<release>-<sts>-<n>"
+  # so the release name is not at the start — a prefix match would miss them.
+  kubectl get pvc -n "$OPENG2P_NAMESPACE" --no-headers 2>/dev/null \
+    | awk -v r="${release_name}-" '$1 ~ ("^" r) || index($1, "-" r) > 0 {print $1}' \
+    | xargs -r kubectl delete pvc -n "$OPENG2P_NAMESPACE" --wait=true --timeout=120s 2>/dev/null >/dev/null || true
+}
+
+#------------------------------------------------------------------------------
+# Function : _openg2p_release_pods
+# Description: Echoes the pod lines belonging to a release (by "<release>-" name prefix),
+#              dropping leftover Failed pods whose owning Job has already succeeded — a
+#              first-attempt-failed-then-retried Job pod is not a deployment failure but
+#              would otherwise keep the readiness wait from ever settling.
+#   $1 = release name (pod name prefix)
+#------------------------------------------------------------------------------
+_openg2p_release_pods() {
+  local release_name="$1"
+  # Names of Jobs with ≥1 success (jsonpath, not column-guessing — layout varies by
+  # kubectl version). Their failed retry pods are stale artifacts to drop below.
+  local succeeded_jobs
+  succeeded_jobs=$(kubectl get jobs -n "$OPENG2P_NAMESPACE" \
+    -o jsonpath='{range .items[?(@.status.succeeded>=1)]}{.metadata.name}{"\n"}{end}' 2>/dev/null)
+
+  kubectl get pods -n "$OPENG2P_NAMESPACE" --no-headers 2>/dev/null \
+    | awk -v p="^${release_name}-" -v sj="$succeeded_jobs" '
+        BEGIN { n=split(sj, J, "\n") }
+        $1 !~ p { next }
+        # Keep pods that are NOT in a failed/error-ish phase regardless of Job status.
+        $3 != "Error" && $3 != "Failed" && $3 !~ /BackOff|CreateContainer|InvalidImage/ { print; next }
+        # For failed-ish pods, drop them only if they belong to an already-succeeded Job.
+        {
+          for (i=1; i<=n; i++) {
+            if (J[i] != "" && index($1, J[i] "-") == 1) next   # stale replica of a done Job → skip
+          }
+          print   # genuinely-failed pod of a not-yet-succeeded workload → keep
+        }
+      '
+}
+
+#------------------------------------------------------------------------------
+# Function : _openg2p_release_pods_healthy
+# Description: Returns 0 if the release has ≥1 pod and none are not-ready (ignoring
+#              Completed/Succeeded jobs). Point-in-time check.
+#   $1 = release name (pod name prefix)
+#------------------------------------------------------------------------------
+_openg2p_release_pods_healthy() {
+  local release_name="$1"
+  local pods bad
+  pods=$(_openg2p_release_pods "$release_name")
+  [[ -z "$pods" ]] && return 1
+  # Any pod not Running/Completed, or Running but not all containers Ready → unhealthy
+  bad=$(echo "$pods" | awk '
+    $3=="Completed" || $3=="Succeeded" {next}
+    $3!="Running" {print; next}
+    {split($2,a,"/"); if (a[1]!=a[2] || a[1]==0) print}')
+  [[ -z "$bad" ]]
+}
+
+#------------------------------------------------------------------------------
+# Function : _openg2p_release_pods_terminal
+# Description: Echoes pods in a durably-terminal state that will not self-heal:
+#              CreateContainer*/InvalidImageName (wrong Secret/ConfigMap/image) and
+#              chronic CrashLoopBackOff (restarts >= threshold). Transient states
+#              (ImagePullBackOff from pull-QPS, a single early crash) are NOT terminal —
+#              they clear on their own. The caller only acts after a persistence window.
+#   $1 = release name (pod name prefix)
+#------------------------------------------------------------------------------
+_openg2p_release_pods_terminal() {
+  local release_name="$1"
+  # restartCount at/above which a CrashLoopBackOff is considered chronic (not first-boot)
+  local crash_restart_threshold="${OPENG2P_CRASH_RESTART_THRESHOLD:-5}"
+  _openg2p_release_pods "$release_name" | awk -v thr="$crash_restart_threshold" '
+    $3=="Completed" || $3=="Succeeded" {next}
+    # Config/image-spec errors never self-heal → durably terminal regardless of restarts.
+    $3 ~ /CreateContainerConfigError|CreateContainerError|InvalidImageName/ {print; next}
+    $3 ~ /^Init:.*(CreateContainerConfigError|CreateContainerError|InvalidImageName)/ {print; next}
+    # CrashLoopBackOff only counts as terminal once restarts are chronic ($4 = RESTARTS,
+    # which may be like "7 (2m ago)" so take the leading integer).
+    $3 ~ /CrashLoopBackOff/ || $3 ~ /^Init:.*CrashLoopBackOff/ {
+      r=$4; sub(/[^0-9].*/,"",r); if (r=="" ) r=0;
+      if (r+0 >= thr) print;
+      next
+    }
+  '
+}
+
+#------------------------------------------------------------------------------
+# Function : _wait_for_openg2p_release_ready
+# Description: Per-release readiness gate (polls only one release's pods by name prefix,
+#              so one broken module never blocks a healthy one). Returns 0 once the pods
+#              stay Ready for N consecutive polls; 1 on timeout or a durable failure that
+#              persists past the grace window. Caller warns and continues either way.
+#   $1 = release name (pod name prefix)
+#   $2 = timeout seconds (default: startup_timeout, else 600)
+# Env tunables: OPENG2P_TERMINAL_GRACE_SECS (180), OPENG2P_CRASH_RESTART_THRESHOLD (5).
+#------------------------------------------------------------------------------
+_wait_for_openg2p_release_ready() {
+  local release_name="$1"
+  local timeout="${2:-${startup_timeout:-600}}"
+  local interval=10
+  local required_stable=3      # consecutive all-ready polls before we trust it
+  # How long a durable-terminal condition must persist before we give up. Long on purpose:
+  # a missing Secret is often created seconds later by a sibling init Job.
+  local terminal_grace_secs="${OPENG2P_TERMINAL_GRACE_SECS:-180}"
+  local terminal_strikes_needed=$(( terminal_grace_secs / interval ))
+  (( terminal_strikes_needed < 1 )) && terminal_strikes_needed=1
+  local elapsed=0 stable=0 terminal_strikes=0
+
+  log_step "Waiting for $release_name pods to be ready"
+
+  while true; do
+    if [[ "$elapsed" -ge "$timeout" ]]; then
+      log_warn "$release_name pods did not become ready within ${timeout}s — continuing"
+      _openg2p_release_pods "$release_name" | awk '
+        $3=="Completed"||$3=="Succeeded"{next}
+        {split($2,a,"/"); if(a[1]!=a[2]||a[1]==0) print "      ⏳ "$1" ("$3")"}'
+      return 1
+    fi
+
+    # No pods yet? The release may still be creating them — keep waiting (within timeout).
+    if [[ -z "$(_openg2p_release_pods "$release_name")" ]]; then
+      stable=0; terminal_strikes=0
+      sleep "$interval"; elapsed=$((elapsed + interval)); continue
+    fi
+
+    # Durable failure persisting for terminal_grace_secs → give up on this release. The
+    # strike counter resets the instant the condition clears, so transient backoffs don't trip it.
+    if [[ -n "$(_openg2p_release_pods_terminal "$release_name")" ]]; then
+      terminal_strikes=$((terminal_strikes + 1))
+      stable=0
+      log_with_verbose_check "$debug" "$DEBUG" \
+        "$release_name has durably-failing pod(s) — strike $terminal_strikes/$terminal_strikes_needed (${terminal_grace_secs}s grace)"
+      if [[ "$terminal_strikes" -ge "$terminal_strikes_needed" ]]; then
+        log_warn "$release_name has pod(s) stuck in a durable failure state for >${terminal_grace_secs}s — continuing without it"
+        _openg2p_release_pods_terminal "$release_name" | awk '{print "      ✗ "$1" ("$3", restarts="$4")"}'
+        return 1
+      fi
+      sleep "$interval"; elapsed=$((elapsed + interval)); continue
+    fi
+    terminal_strikes=0
+
+    if _openg2p_release_pods_healthy "$release_name"; then
+      stable=$((stable + 1))
+      log_with_verbose_check "$debug" "$DEBUG" "$release_name all pods ready — stable $stable/$required_stable"
+      [[ "$stable" -ge "$required_stable" ]] && { log_ok; return 0; }
+    else
+      stable=0
+      log_with_verbose_check "$debug" "$DEBUG" "$release_name pods still starting — waiting ${interval}s..."
+    fi
+
+    sleep "$interval"; elapsed=$((elapsed + interval))
+  done
+}
+
+#------------------------------------------------------------------------------
+# Function : _promote_pending_release
+# Description: Rewrites a stuck pending-install/pending-upgrade helm release record to
+#              "deployed" (helm --wait was interrupted before it returned). Edits the
+#              release secret's embedded status JSON + the status label. No data loss.
+#   $1 = release name
+#------------------------------------------------------------------------------
+_promote_pending_release() {
+  local release_name="$1"
+  # Newest release secret for this release (highest version)
+  local secret
+  secret=$(kubectl get secret -n "$OPENG2P_NAMESPACE" \
+    -l "owner=helm,name=${release_name}" --no-headers 2>/dev/null \
+    | awk '{print $1}' | sort -t. -k5 -n | tail -1)
+  [[ -z "$secret" ]] && return 1
+
+  # release data = base64(base64(gzip(json))); flip info.status to deployed, re-encode
+  local new
+  new=$(kubectl get secret -n "$OPENG2P_NAMESPACE" "$secret" -o jsonpath='{.data.release}' 2>/dev/null \
+    | base64 -d | base64 -d | gunzip 2>/dev/null \
+    | python3 -c "import sys,json; d=json.load(sys.stdin); d['info']['status']='deployed'; sys.stdout.write(json.dumps(d))" 2>/dev/null \
+    | gzip | base64 -w0 | base64 -w0)
+  [[ -z "$new" ]] && return 1
+
+  kubectl patch secret -n "$OPENG2P_NAMESPACE" "$secret" --type=merge \
+    -p "{\"data\":{\"release\":\"$new\"}}" >/dev/null 2>&1 || return 1
+  kubectl label secret -n "$OPENG2P_NAMESPACE" "$secret" status=deployed --overwrite >/dev/null 2>&1
+}
+
+#------------------------------------------------------------------------------
+# Function : clean_openg2p
+# Description: Removes all OpenG2P resources — modules first, then commons,
+#              then drops the namespace.
+#------------------------------------------------------------------------------
+clean_openg2p() {
+  log_step "Removing OpenG2P"
+  local module
+  for module in "${OPENG2P_MODULES[@]}"; do
+    helm uninstall "$module" -n "$OPENG2P_NAMESPACE" --wait 2>/dev/null || true
+  done
+  helm uninstall openg2p-commons -n "$OPENG2P_NAMESPACE" --wait 2>/dev/null || true
+  delete_resources_in_namespace_matching_pattern "$OPENG2P_NAMESPACE"
+  log_ok
+}

--- a/src/environmentSetup/environmentSetup.sh
+++ b/src/environmentSetup/environmentSetup.sh
@@ -138,6 +138,9 @@ add_hosts() {
 
         local MIFOSXHOSTS=( mifos.$DOMAIN )
         local ALL_GAZELLE_HOSTS=( "${MIFOSXHOSTS[@]}" "${PHEEHOSTS[@]}" "${VNEXTHOSTS[@]}" )
+        local OPENG2PHOSTS=( openg2p.$DOMAIN social-registry.$DOMAIN \
+            pbms.$DOMAIN spar.$DOMAIN g2p-bridge.$DOMAIN \
+            keycloak.$DOMAIN minio.$DOMAIN )
 
         # Determine which IP to use.
         #

--- a/src/utils/openg2p/setup-pbms-phee.sh
+++ b/src/utils/openg2p/setup-pbms-phee.sh
@@ -1,0 +1,301 @@
+#!/usr/bin/env bash
+#------------------------------------------------------------------------------
+# setup-pbms-phee.sh -- enable the OpenG2P g2p_payment_phee connector on a running
+# Gazelle PBMS (Odoo) so PBMS can issue payment batches to Payment Hub EE.
+#
+# Runs a sequence of idempotent steps against the live cluster, driven via
+# `kubectl exec ... odoo shell` on the running pbms-odoo pod. Called from
+# openg2p.sh after PBMS deploys; safe to re-run. Failures log a WARN and continue.
+#
+# Steps (see the step_* functions below for detail):
+#   1   Download the addon repos as tarballs into the PVC and point Odoo
+#       at them via ODOO_ADDONS_DIR (set in openg2p-pbms/values.yaml).
+#   1b  Confirm ODOO_ADDONS_DIR points at the downloaded repos.
+#   2   Cast amount_issued to int in payment_manager.py (PHEE's parseInt throws on
+#       the float, silently zeroing the batch total). Patched before the install so
+#       the single post-install restart reloads the patched source too.
+#   3   Stub the Enterprise-only base.module_payment_sepa_direct_debit xmlid that
+#       g2p_programs references but Community lacks (else install crashes), then
+#       install PBMS_MODULES.
+#   4   Set batch_type_header=csv on the PHEE payment manager (default "type" makes
+#       PHEE 500).
+#------------------------------------------------------------------------------
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUN_DIR="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+CONFIG_FILE="${RUN_DIR}/config/config.ini"
+
+# shellcheck source=/dev/null
+source "${RUN_DIR}/src/utils/logger.sh"
+
+# --- addon sources (step 1) — repo:branch, fetched as <branch>.tar.gz from GitHub ---
+ADDON_REPOS=(
+  "openg2p-registry:17.0-1.5"
+  "openg2p-program:17.0-1.3"
+)
+ADDONS_DIR="/bitnami/odoo/extraaddons"
+# Modules to install (the rest are baked into the image). Installing g2p_payment_phee
+# pulls the full g2p_programs tree transitively (slow). pbms_theme_extension is
+# deliberately excluded — it depends on `website` and 500s the Community login page.
+PBMS_MODULES=(g2p_social_registry_importer g2p_payment_phee)
+# The float->int patch target inside the downloaded addon (step 2).
+PHEE_PM_FILE="${ADDONS_DIR}/openg2p-program/g2p_payment_phee/models/payment_manager.py"
+ODOO_DB="pbmsdb"
+# Gazelle helm release is `pbms`, so the odoo Deployment is `pbms-odoo`.
+ODOO_DEPLOY="pbms-odoo"
+
+OPENG2P_NAMESPACE="$(crudini --get "$CONFIG_FILE" openg2p OPENG2P_NAMESPACE 2>/dev/null || echo openg2p)"
+NS="$OPENG2P_NAMESPACE"
+
+# Verbose flag for log_with_verbose_check. openg2p.sh runs us in a fresh subshell
+# (bash setup-pbms-phee.sh) and does not export `debug`, so it is always unset here;
+# under `set -u` an unbound "$debug" would abort. Default it so the script runs.
+debug="${debug:-false}"
+
+#------------------------------------------------------------------------------
+# Helpers
+#------------------------------------------------------------------------------
+_find_pbms_pod() {
+  kubectl get pods -n "$NS" --no-headers 2>/dev/null \
+    | awk '/^pbms-odoo-/ && $3=="Running"{print $1; exit}'
+}
+
+# Pipe a python heredoc (on stdin) into `odoo shell` in the pod, succeeding only
+# when $2 (sentinel) is printed. $1 = pod. Mirrors _openg2p_pbms_fix_admin_login.
+_odoo_shell() {
+  local pod="$1" sentinel="$2"
+  kubectl exec -i -n "$NS" "$pod" -- \
+    bash -lc "odoo shell -c /etc/odoo/odoo.conf -d '$ODOO_DB' --no-http 2>/dev/null" \
+    | grep -q "$sentinel"
+}
+
+_restart_odoo() {
+  log_step "Restarting $ODOO_DEPLOY to reload modules/source"
+  if kubectl rollout restart "deploy/$ODOO_DEPLOY" -n "$NS" >/dev/null 2>&1 \
+     && kubectl rollout status "deploy/$ODOO_DEPLOY" -n "$NS" --timeout=300s >/dev/null 2>&1; then
+    log_ok
+  else
+    log_warn "rollout of $ODOO_DEPLOY did not complete — restart it manually so new modules/source load"
+  fi
+}
+
+# The bg-task deployments write ir_module_module periodically; a concurrent write during
+# a module install triggers Postgres "could not serialize access" and aborts it. Scale
+# them to 0 for the install, back up after.
+BGTASK_DEPLOYS=(pbms-api pbms-celery-beat-producer pbms-celery-worker)
+_bgtask_scale() {
+  local replicas="$1"
+  kubectl scale deploy "${BGTASK_DEPLOYS[@]}" -n "$NS" --replicas="$replicas" >/dev/null 2>&1
+}
+
+# The addon repos' Python deps (schwifty, rstr, cbor2, ...) install into ephemeral
+# /usr/local/lib, so a freshly-rolled odoo pod is missing them until the values.yaml
+# postStart hook runs. Skip fast when the hook already installed them (import check),
+# else install so this works on a pre-redeploy pod without the hook.
+_pip_install_addon_deps() {
+  local pod="$1"
+  if kubectl exec -n "$NS" "$pod" -- python3 -c 'import schwifty, rstr' >/dev/null 2>&1; then
+    log_with_verbose_check "$debug" "$DEBUG" "addon Python deps already present — skipping pip install"
+    return 0
+  fi
+  log_step "Installing addon Python deps (schwifty, rstr, ...)"
+  kubectl exec -n "$NS" "$pod" -- bash -lc '
+    unset SSL_CERT_FILE REQUESTS_CA_BUNDLE
+    pip install -q --trusted-host pypi.org --trusted-host files.pythonhosted.org \
+      -r /bitnami/odoo/extraaddons/openg2p-registry/requirements.txt \
+      -r /bitnami/odoo/extraaddons/openg2p-program/requirements.txt rstr' >/dev/null 2>&1 \
+    && log_ok || log_warn "addon dep pip-install failed — check pod network egress"
+}
+
+#------------------------------------------------------------------------------
+# Step 1 — download addon repos into the PVC. Idempotent: skips a repo that
+# already has content. curl+tar because the image has no git.
+#------------------------------------------------------------------------------
+step_download_addons() {
+  local pod="$1" entry repo branch url
+  for entry in "${ADDON_REPOS[@]}"; do
+    repo="${entry%%:*}"
+    branch="${entry##*:}"
+    url="https://github.com/OpenG2P/${repo}/archive/refs/heads/${branch}.tar.gz"
+    log_step "Fetching addon repo ${repo}@${branch}"
+    kubectl exec -n "$NS" "$pod" -- bash -c "
+      set -e
+      mkdir -p '${ADDONS_DIR}'
+      dest='${ADDONS_DIR}/${repo}'
+      if [ -d \"\$dest\" ] && [ \"\$(ls -A \"\$dest\" 2>/dev/null | wc -l)\" -gt 5 ]; then
+        echo ADDON_PRESENT; exit 0
+      fi
+      mkdir -p \"\$dest\"
+      curl -sSL '${url}' -o /tmp/${repo}.tgz
+      tar xzf /tmp/${repo}.tgz -C \"\$dest\" --strip-components=1
+      rm -f /tmp/${repo}.tgz
+      echo ADDON_FETCHED
+    " >/dev/null 2>&1 \
+      && log_ok \
+      || log_warn "could not fetch ${repo}@${branch} into ${ADDONS_DIR} (check pod network egress)"
+  done
+}
+
+#------------------------------------------------------------------------------
+# Step 1b — confirm Odoo is pointed at the addon dirs (ODOO_ADDONS_DIR is set in
+# values.yaml; here we only check, since a live env edit would be reverted on upgrade).
+#------------------------------------------------------------------------------
+step_check_addons_dir() {
+  local pod="$1" env_val
+  log_step "Checking ODOO_ADDONS_DIR includes the addon repos"
+  env_val="$(kubectl exec -n "$NS" "$pod" -- bash -lc 'echo "${ODOO_ADDONS_DIR:-}"' 2>/dev/null)"
+  if [[ "$env_val" == *"${ADDONS_DIR}/openg2p-program"* ]]; then
+    log_ok
+  else
+    log_warn "ODOO_ADDONS_DIR does not include ${ADDONS_DIR}/openg2p-* (got: '${env_val:-<unset>}')."
+    log_warn "  Add it to src/deployer/helm/openg2p/openg2p-pbms/values.yaml (odoo.extraEnvVars) and redeploy:"
+    log_warn "    ./run.sh -m deploy -a openg2p"
+  fi
+}
+
+#------------------------------------------------------------------------------
+# Step 3 — enterprise stub + module install. Refreshes the module list, stubs the
+# missing xmlid, then installs PBMS_MODULES. Idempotent (skips installed).
+#------------------------------------------------------------------------------
+step_stub_and_install() {
+  local pod="$1"
+  # Eliminate DB write contention for the duration of the install (see _bgtask_scale).
+  log_step "Scaling down PBMS bg-task during install"
+  _bgtask_scale 0 && log_ok || log_warn "could not scale bg-task down — install may hit serialization errors"
+  log_step "Stubbing enterprise xmlid + installing PBMS modules (slow: ~10-15m)"
+  # MODULES python list is built from PBMS_MODULES: first element quoted, then
+  # ', "elem"' for the rest — yields ["a", "b", ...] inside the heredoc.
+  _odoo_shell "$pod" PHEE_MODULES_OK <<PYEOF
+try:
+    env.ref("base.module_payment_sepa_direct_debit")
+except Exception:
+    stub = env["ir.module.module"].search([("name","=","payment_sepa_direct_debit")], limit=1)
+    if not stub:
+        stub = env["ir.module.module"].create({
+            "name": "payment_sepa_direct_debit",
+            "state": "uninstalled",
+            "shortdesc": "SEPA Direct Debit (stub for Community)",
+        })
+    if not env["ir.model.data"].search([("module","=","base"),("name","=","module_payment_sepa_direct_debit")], limit=1):
+        env["ir.model.data"].create({
+            "module": "base",
+            "name": "module_payment_sepa_direct_debit",
+            "model": "ir.module.module",
+            "res_id": stub.id,
+            "noupdate": True,
+        })
+    env.cr.commit()
+env["ir.module.module"].update_list()
+env.cr.commit()
+MODULES = ["${PBMS_MODULES[0]}"$(printf ', "%s"' "${PBMS_MODULES[@]:1}")]
+for name in MODULES:
+    m = env["ir.module.module"].search([("name","=",name)], limit=1)
+    if not m:
+        print("MISSING_MODULE", name)
+        continue
+    if m.state in ("installed", "to upgrade", "to install"):
+        continue
+    m.button_immediate_install()
+    env.cr.commit()
+print("PHEE_MODULES_OK")
+PYEOF
+  if [[ $? -eq 0 ]]; then log_ok; else log_warn "module install did not complete — check odoo logs on $pod, then re-run"; fi
+  # Web workers hold a stale registry after install; restart so new models load.
+  _restart_odoo
+  # Ensure the addon deps are on the new pod (postStart usually does this; belt-and-suspenders).
+  pod="$(_find_pbms_pod)"; [[ -n "$pod" ]] || { log_error "pbms-odoo pod gone after restart"; return 1; }
+  _pip_install_addon_deps "$pod"
+  # Restore bg-task now that the heavy install is done.
+  log_step "Scaling PBMS bg-task back up"
+  _bgtask_scale 1 && log_ok || log_warn "could not scale bg-task back up — run: kubectl scale deploy ${BGTASK_DEPLOYS[*]} -n $NS --replicas=1"
+}
+
+#------------------------------------------------------------------------------
+# Step 4 — batch_type_header=csv on the PHEE payment manager(s). Default "type"
+# makes PHEE 500. Also aligns payee_id_type to phone (proven default). Idempotent.
+# Managers may not exist yet (created via UI) — that's fine.
+#------------------------------------------------------------------------------
+step_batch_header() {
+  local pod="$1"
+  log_step "Setting batch_type_header=csv on PHEE payment manager(s)"
+  _odoo_shell "$pod" PHEE_HEADER_OK <<'PYEOF'
+Mgr = env.get('g2p.program.payment.manager.phee')
+n = 0
+if Mgr is not None:
+    for m in Mgr.sudo().search([]):
+        changed = False
+        if 'batch_type_header' in m._fields and m.batch_type_header != 'csv':
+            m.batch_type_header = 'csv'; changed = True
+        if 'payee_id_type' in m._fields and m.payee_id_type != 'phone':
+            m.payee_id_type = 'phone'; changed = True
+        if changed:
+            n += 1
+    env.cr.commit()
+print('PHEE_HEADER_OK', n)
+PYEOF
+  if [[ $? -eq 0 ]]; then log_ok; else log_warn "could not set batch_type_header — set it on the PHEE payment manager manually (must be 'csv')"; fi
+}
+
+#------------------------------------------------------------------------------
+# Step 2 — float->int amount patch: wrap the CSV-row payment_id.amount_issued in
+# int(). Idempotent. Runs BEFORE the install (step 3) so the single post-install
+# restart reloads the patched source too — the downloaded file already exists from
+# step 1.
+#------------------------------------------------------------------------------
+step_patch_amount() {
+  local pod="$1"
+  log_step "Patching amount_issued float->int in payment_manager.py"
+  kubectl exec -n "$NS" "$pod" -- bash -c "
+    set -e
+    f='${PHEE_PM_FILE}'
+    [ -f \"\$f\" ] || { echo NO_FILE; exit 3; }
+    if grep -q 'int(payment_id.amount_issued)' \"\$f\"; then echo ALREADY_PATCHED; exit 0; fi
+    # Only the standalone CSV-row emission line (trailing comma), not the
+    # 'amount_issued': entitlement_id.initial_amount dict assignment elsewhere.
+    sed -i -E 's/^([[:space:]]*)payment_id\.amount_issued,[[:space:]]*\$/\1int(payment_id.amount_issued),/' \"\$f\"
+    grep -q 'int(payment_id.amount_issued)' \"\$f\" && echo PATCHED || { echo PATCH_FAILED; exit 4; }
+  " >/dev/null 2>&1
+  local rc=$?
+  if [[ $rc -eq 0 ]]; then log_ok
+  else log_warn "amount_issued patch not applied (rc=$rc) — edit ${PHEE_PM_FILE} manually (wrap the CSV-row amount in int())"; fi
+}
+
+#------------------------------------------------------------------------------
+# main
+#------------------------------------------------------------------------------
+main() {
+  log_section "Enabling g2p_payment_phee on PBMS (namespace: $NS)"
+
+  command -v kubectl  >/dev/null 2>&1 || { log_error "kubectl not found on PATH"; exit 1; }
+  command -v crudini  >/dev/null 2>&1 || { log_error "crudini not found on PATH"; exit 1; }
+
+  local pod
+  pod="$(_find_pbms_pod)"
+  if [[ -z "$pod" ]]; then
+    log_error "no Running pbms-odoo pod in namespace '$NS' — deploy PBMS first (./run.sh -m deploy -a openg2p)"
+    exit 1
+  fi
+  log_with_level "$INFO" "Using pod: $pod"
+
+  step_download_addons  "$pod"
+  step_check_addons_dir "$pod"
+  # Patch before installing, so the single post-install restart reloads the patched
+  # source too — avoids a second pod rollout and pip reinstall.
+  step_patch_amount     "$pod"
+  step_stub_and_install "$pod"
+  # re-resolve the pod: the module-install restart rolls a new pod
+  pod="$(_find_pbms_pod)"; [[ -n "$pod" ]] || { log_error "pbms-odoo pod gone after restart"; exit 1; }
+  step_batch_header     "$pod"
+
+  log_step "Verifying /web/login serves (200)"
+  local code
+  code="$(kubectl exec -n "$NS" "$pod" -- bash -lc 'curl -s -o /dev/null -w "%{http_code}" http://localhost:8069/web/login' 2>/dev/null)"
+  if [[ "$code" == "200" ]]; then log_ok; else log_warn "login returned HTTP $code — check: kubectl logs -n $NS $pod | grep -i error"; fi
+
+  log_banner "g2p_payment_phee setup complete"
+  log_with_level "$INFO" "Verify: kubectl exec -n $NS \$(kubectl get po -n $NS -o name | grep pbms-odoo | head -1) -- ls $ADDONS_DIR"
+  log_with_level "$INFO" "Then trigger a PBMS->PHEE batch and confirm total > 0 (no fileName/NumberFormat errors)."
+}
+
+main "$@"


### PR DESCRIPTION
Jira Ticket: https://mifosforge.jira.com/browse/GAZ-295?atlOrigin=eyJpIjoiNjhlOTE2MDdiZjk4NDBlZDk2OWUxZmQzZTU3MTRhNjMiLCJwIjoiaiJ9

Integrate openg2p deployment into mifos gazelle as 4th DPG alongside Mifosx, Phee and vnext

- src/deployer/openg2p.sh — new: deploy/cleanup orchestration for OpenG2P
- src/deployer/helm/openg2p/* — new: 5 chart wrappers (commons, pbms, social-registry, spar, g2p-bridge)
- src/deployer/manifests/openg2p/* — new: Istio + operator CRDs (cause istio objects are emited by commons-keycloak)
- src/utils/openg2p/setup-pbms-phee.sh — additional odoo extensions setup in pbms
- src/commandline/commandline.sh — register openg2p as a valid app
- src/deployer/deployer.sh — wire openg2p deploy/cleanup case arms
- src/environmentSetup/environmentSetup.sh — add OpenG2P /etc/hosts entries
- config/config.ini — add [openg2p] section with per-module toggles

commannd to run opengp2 : `./run.sh -m deploy -a openg2p`