### PR TITLE
GAZ-194: Deploy OpenSPP to Kubernetes

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -150,3 +150,21 @@ OPENG2P_SOCIAL_REGISTRY_ENABLED = false
 OPENG2P_PBMS_ENABLED = false
 OPENG2P_SPAR_ENABLED = false
 OPENG2P_G2P_BRIDGE_ENABLED = false
+
+[openspp]
+# Enable or disable OpenSPP2 deployment. OpenSPP is optional (not a core app) and is OFF by default
+# so it never alters existing -a all deployments.
+enabled = false
+# Namespace and Helm release name for OpenSPP.
+OPENSPP_NAMESPACE = openspp
+OPENSPP_RELEASE_NAME = openspp
+# OpenSPP2 (Odoo 19) application image. Build-only upstream (no published image yet): build the
+# OpenSPP2 Dockerfile 'production' target and load it into the cluster's container runtime
+# (docker save ... | sudo k3s ctr images import -).
+OPENSPP_IMAGE_REPOSITORY = ghcr.io/openmf/openspp
+OPENSPP_IMAGE_TAG = 19.0
+# Password file paths on this machine - read by the installer and stored as a K8s Secret
+# (mastercard.sh pattern). Leave EMPTY to use the local-dev defaults (admin/admin login, fixed db
+# password) which also keep redeploys idempotent. Set a file path for prod/remote real secrets.
+OPENSPP_DB_PASSWORD_FILE =
+OPENSPP_ADMIN_PASSWORD_FILE =

--- a/src/commandline/commandline.sh
+++ b/src/commandline/commandline.sh
@@ -155,7 +155,7 @@ load_config_from_file() {
 
     # Read app enablement flags and construct the 'apps' variable
     local enabled_apps_list=""
-    local valid_apps=("infra" "vnext" "paymenthub" "mifosx" "mastercard-demo" "openg2p")
+    local valid_apps=("infra" "vnext" "paymenthub" "mifosx" "mastercard-demo" "openg2p" "openspp")
 
     for app_name in "${valid_apps[@]}"; do
         local app_enabled=$(crudini --get "$config_path" "$app_name" enabled 2>/dev/null)
@@ -237,7 +237,7 @@ show_usage() {
     -m mode .............. deploy|cleanapps (required)
     -u user .............. non-root user for k8s operations (optional, defaults to \$USER)
     -a apps .............. Comma-separated list of apps or 'all' (optional)
-                           Valid: vnext paymenthub mifosx infra mastercard-demo openg2p setup-data all
+                           Valid: vnext paymenthub mifosx infra mastercard-demo openg2p openspp setup-data all
     -e environment ....... local (default) | remote
     -d debug ............. true|false (optional, default=false)
     -r redeploy .......... true|false (optional, default=true)
@@ -310,7 +310,7 @@ validate_inputs() {
             log_warn "No apps specified via -a or config file. Defaulting to 'all'."
             apps="all"
         fi
-        local ALL_VALID_APPS="infra vnext paymenthub mifosx mastercard-demo openg2p setup-data all"
+        local ALL_VALID_APPS="infra vnext paymenthub mifosx mastercard-demo openg2p openspp setup-data all"
         local CORE_APPS="infra vnext paymenthub mifosx openg2p"
 
         local current_apps_array

--- a/src/deployer/deployer.sh
+++ b/src/deployer/deployer.sh
@@ -7,6 +7,7 @@ source "$RUN_DIR/src/deployer/mifosx.sh" || { echo "FATAL: Could not source mifo
 source "$RUN_DIR/src/deployer/paymenthub.sh" || { echo "FATAL: Could not source paymenthub.sh. Check RUN_DIR: $RUN_DIR"; exit 1; }
 source "$RUN_DIR/src/deployer/mastercard.sh" || { echo "FATAL: Could not source mastercard.sh. Check RUN_DIR: $RUN_DIR"; exit 1; }
 source "$RUN_DIR/src/deployer/openg2p.sh" || { echo "FATAL: Could not source openg2p.sh. Check RUN_DIR: $RUN_DIR"; exit 1; }
+source "$RUN_DIR/src/deployer/openspp.sh" || { echo "FATAL: Could not source openspp.sh. Check RUN_DIR: $RUN_DIR"; exit 1; }
 source "$RUN_DIR/src/utils/helpers.sh" || { echo "FATAL: Could not source helpers.sh. Check RUN_DIR: $RUN_DIR"; exit 1; }
 
 #------------------------------------------------------------
@@ -294,6 +295,11 @@ delete_apps() {
       "openg2p")
         clean_openg2p
         ;;
+      "openspp")
+        log_step "Removing OpenSPP"
+        cleanup_openspp
+        log_ok
+        ;;
       *)
         log_error "Invalid app '$app' for deletion. This should have been caught by validate_inputs."
         show_usage
@@ -320,7 +326,9 @@ deploy_apps() {
   # Ensure infra is up before any DPG deployment. The idempotency guard inside
   # deploy_infrastructure makes this a no-op if infra is already running.
   # Skip when infra itself is being deployed — its case arm handles that below.
-  if [[ "$appsToDeploy" != *"infra"* ]]; then
+  # Also skip for an OpenSPP-only deploy: OpenSPP brings its own PostGIS DB and does not use
+  # the shared infra chart.
+  if [[ "$appsToDeploy" != *"infra"* && "$appsToDeploy" != "openspp" ]]; then
     deploy_infrastructure "false"
   fi
 
@@ -359,6 +367,12 @@ deploy_apps() {
         ;;
       "openg2p")
         deploy_openg2p
+        ;;
+      "openspp")
+        if [[ "$redeploy" == "true" ]]; then
+          cleanup_openspp
+        fi
+        deploy_openspp
         ;;
       *)
         log_error "Unknown application '$app'. This should have been caught by validation."

--- a/src/deployer/helm/openspp/.helmignore
+++ b/src/deployer/helm/openspp/.helmignore
@@ -1,0 +1,11 @@
+# Patterns to ignore when building Helm packages.
+.DS_Store
+.git/
+.gitignore
+*.tmp
+*.bak
+*.orig
+*.swp
+*.tgz
+.idea/
+.vscode/

--- a/src/deployer/helm/openspp/Chart.yaml
+++ b/src/deployer/helm/openspp/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+name: openspp
+description: Gazelle-owned Helm wrapper chart for OpenSPP2 (Odoo 19 + PostGIS 18).
+type: application
+version: 0.2.0
+appVersion: "19.0"
+home: https://github.com/openMF/mifos-gazelle
+sources:
+  - https://github.com/OpenSPP/OpenSPP2
+  - https://github.com/openMF/mifos-gazelle
+maintainers:
+  - name: Ismael Sallami
+    email: ismengineer23@gmail.com
+# No chart dependencies: the PostGIS database is a hand-written StatefulSet
+# (templates/postgis-statefulset.yaml) rather than a bitnami/postgresql subchart, because OpenSPP
+# needs the geospatial extension provided by the postgis/postgis:18-3.6-alpine image.

--- a/src/deployer/helm/openspp/templates/_helpers.tpl
+++ b/src/deployer/helm/openspp/templates/_helpers.tpl
@@ -1,0 +1,73 @@
+{{/*
+Template helpers for the OpenSPP chart: resource naming, common labels, per-component selector
+labels, the Secret name, the PostGIS service name, and the shared database-connection env block.
+*/}}
+
+{{- define "openspp.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "openspp.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name (include "openspp.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Common labels applied to every object. */}}
+{{- define "openspp.labels" -}}
+app.kubernetes.io/name: {{ include "openspp.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: openspp
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" }}
+{{- end -}}
+
+{{/* Per-component selector labels. */}}
+{{- define "openspp.odoo.selectorLabels" -}}
+app: openspp-odoo
+tier: backend
+{{- end -}}
+
+{{- define "openspp.postgis.selectorLabels" -}}
+app: openspp-postgis
+tier: database
+{{- end -}}
+
+{{/* Name of the Secret to use (created here, or a pre-existing one). */}}
+{{- define "openspp.secretName" -}}
+{{- if .Values.secrets.existingSecret -}}
+{{- .Values.secrets.existingSecret -}}
+{{- else -}}
+{{- printf "%s-secrets" (include "openspp.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/* PostGIS headless service name (also the StatefulSet serviceName). */}}
+{{- define "openspp.postgis.serviceName" -}}
+{{- printf "%s-postgis" (include "openspp.fullname" .) -}}
+{{- end -}}
+
+{{/* Shared DB-connection env block (OpenSPP2 vars), used by the Odoo and jobworker Deployments.
+The entrypoint aborts if any of these is missing. */}}
+{{- define "openspp.odoo.dbEnv" -}}
+- name: DB_HOST
+  value: {{ include "openspp.postgis.serviceName" . | quote }}
+- name: DB_PORT
+  value: {{ .Values.postgis.port | quote }}
+- name: DB_NAME
+  value: {{ .Values.postgis.database | quote }}
+- name: DB_USER
+  value: {{ .Values.postgis.user | quote }}
+- name: DB_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "openspp.secretName" . }}
+      key: db-password
+- name: ODOO_ADMIN_PASSWD
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "openspp.secretName" . }}
+      key: odoo-admin-password
+{{- end -}}

--- a/src/deployer/helm/openspp/templates/jobworker-deployment.yaml
+++ b/src/deployer/helm/openspp/templates/jobworker-deployment.yaml
@@ -1,0 +1,62 @@
+{{- if .Values.jobworker.enabled }}
+# OpenSPP2 background job worker (upstream "queue-worker"): processes async queue jobs in a
+# separate process, using the same image and DB connection as Odoo. No HTTP, no filestore.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "openspp.fullname" . }}-jobworker
+  labels:
+    {{- include "openspp.labels" . | nindent 4 }}
+    app: openspp-jobworker
+    tier: worker
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: openspp-jobworker
+  template:
+    metadata:
+      labels:
+        {{- include "openspp.labels" . | nindent 8 }}
+        app: openspp-jobworker
+        tier: worker
+    spec:
+      {{- if .Values.arch }}
+      nodeSelector:
+        kubernetes.io/arch: {{ .Values.arch }}
+      {{- end }}
+      # Wait until Odoo has INITIALISED the DB (ir_module_module exists), not just until Postgres is
+      # up. Both odoo and this worker run the same entrypoint, which tries to init the DB on an empty
+      # database; starting the worker only after odoo has initialised avoids racing for the init lock.
+      initContainers:
+        - name: wait-for-db-init
+          image: "{{ .Values.postgis.image.repository }}:{{ .Values.postgis.image.tag }}"
+          imagePullPolicy: {{ .Values.postgis.image.pullPolicy }}
+          env:
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "openspp.secretName" . }}
+                  key: db-password
+          command:
+            - sh
+            - -c
+            - |
+              until psql -h {{ include "openspp.postgis.serviceName" . }} -p {{ .Values.postgis.port }} -U {{ .Values.postgis.user }} -d {{ .Values.postgis.database }} -tAc "select 1 from ir_module_module limit 1" >/dev/null 2>&1; do
+                echo "waiting for odoo to initialise the database..."; sleep 5;
+              done
+      containers:
+        - name: jobworker
+          image: "{{ .Values.odoo.image.repository }}:{{ .Values.odoo.image.tag }}"
+          imagePullPolicy: {{ .Values.odoo.image.pullPolicy }}
+          # args (not command): keep the image entrypoint, which generates /etc/odoo/odoo.conf before
+          # running the runner (without it the addons_path is wrong and job_worker won't import).
+          args:
+            ["python", "/mnt/extra-addons/odoo-job-worker/job_worker_runner.py", "-c", "/etc/odoo/odoo.conf"]
+          env:
+            {{- include "openspp.odoo.dbEnv" . | nindent 12 }}
+            - name: LOG_LEVEL
+              value: {{ .Values.odoo.env.LOG_LEVEL | quote }}
+          resources:
+            {{- toYaml .Values.jobworker.resources | nindent 12 }}
+{{- end }}

--- a/src/deployer/helm/openspp/templates/odoo-deployment.yaml
+++ b/src/deployer/helm/openspp/templates/odoo-deployment.yaml
@@ -1,0 +1,103 @@
+# OpenSPP2 (Odoo 19) application Deployment: web + longpolling ports, a database-wait init
+# container, and HTTP health probes against /web/health. The container self-initialises on first
+# boot (the entrypoint installs base then ODOO_INIT_MODULES), so there is no separate init Job.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "openspp.fullname" . }}-odoo
+  labels:
+    {{- include "openspp.labels" . | nindent 4 }}
+    {{- include "openspp.odoo.selectorLabels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.odoo.replicas }}
+  # Recreate (not RollingUpdate): the filestore PVC is ReadWriteOnce, so two pods can't mount it.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "openspp.odoo.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "openspp.labels" . | nindent 8 }}
+        {{- include "openspp.odoo.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- if .Values.arch }}
+      nodeSelector:
+        kubernetes.io/arch: {{ .Values.arch }}
+      {{- end }}
+      # Wait for PostGIS before Odoo boots (the postgis image carries pg_isready).
+      initContainers:
+        - name: wait-for-db
+          image: "{{ .Values.postgis.image.repository }}:{{ .Values.postgis.image.tag }}"
+          imagePullPolicy: {{ .Values.postgis.image.pullPolicy }}
+          command:
+            - sh
+            - -c
+            - |
+              until pg_isready -h {{ include "openspp.postgis.serviceName" . }} -p {{ .Values.postgis.port }} -U {{ .Values.postgis.user }}; do
+                echo "waiting for postgis..."; sleep 3;
+              done
+      containers:
+        - name: odoo
+          image: "{{ .Values.odoo.image.repository }}:{{ .Values.odoo.image.tag }}"
+          imagePullPolicy: {{ .Values.odoo.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.odoo.ports.http }}
+              protocol: TCP
+            - name: longpolling
+              containerPort: {{ .Values.odoo.ports.longpolling }}
+              protocol: TCP
+          env:
+            # Database connection + admin password (from the Secret).
+            {{- include "openspp.odoo.dbEnv" . | nindent 12 }}
+            # Module installed on first boot (entrypoint self-init).
+            - name: ODOO_INIT_MODULES
+              value: {{ .Values.odoo.modules | quote }}
+            - name: DB_SSLMODE
+              value: {{ .Values.odoo.env.DB_SSLMODE | quote }}
+            - name: DB_FILTER
+              value: {{ .Values.odoo.env.DB_FILTER | quote }}
+            - name: LIST_DB
+              value: {{ .Values.odoo.env.LIST_DB | quote }}
+            - name: PROXY_MODE
+              value: {{ .Values.odoo.env.PROXY_MODE | quote }}
+            - name: LOG_LEVEL
+              value: {{ .Values.odoo.env.LOG_LEVEL | quote }}
+            - name: ODOO_WORKERS
+              value: {{ .Values.odoo.env.workers | quote }}
+            - name: ODOO_CRON_THREADS
+              value: {{ .Values.odoo.env.cronThreads | quote }}
+          volumeMounts:
+            - name: filestore
+              mountPath: /var/lib/odoo
+          # First boot self-initialises the DB (can take a few minutes), so gate the other probes
+          # behind a startupProbe with a generous budget.
+          startupProbe:
+            httpGet:
+              path: /web/health
+              port: http
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 40
+          readinessProbe:
+            httpGet:
+              path: /web/health
+              port: http
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /web/health
+              port: http
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 6
+          resources:
+            {{- toYaml .Values.odoo.resources | nindent 12 }}
+      volumes:
+        - name: filestore
+          persistentVolumeClaim:
+            claimName: {{ include "openspp.fullname" . }}-filestore

--- a/src/deployer/helm/openspp/templates/odoo-filestore-pvc.yaml
+++ b/src/deployer/helm/openspp/templates/odoo-filestore-pvc.yaml
@@ -1,0 +1,16 @@
+# PersistentVolumeClaim for the Odoo filestore (/var/lib/odoo). The Odoo workload is a Deployment
+# (not a StatefulSet), so its PVC is a standalone object referenced by name.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "openspp.fullname" . }}-filestore
+  labels:
+    {{- include "openspp.labels" . | nindent 4 }}
+    {{- include "openspp.odoo.selectorLabels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.odoo.filestore.accessMode }}
+  storageClassName: {{ .Values.odoo.filestore.storageClass }}
+  resources:
+    requests:
+      storage: {{ .Values.odoo.filestore.size }}

--- a/src/deployer/helm/openspp/templates/odoo-service.yaml
+++ b/src/deployer/helm/openspp/templates/odoo-service.yaml
@@ -1,0 +1,22 @@
+# ClusterIP Service for Odoo (HTTP + longpolling). External exposure via the NGINX ingress is
+# added separately; the longpolling port requires the WebSocket upgrade annotation there.
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "openspp.fullname" . }}-odoo
+  labels:
+    {{- include "openspp.labels" . | nindent 4 }}
+    {{- include "openspp.odoo.selectorLabels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: {{ .Values.odoo.ports.http }}
+      targetPort: http
+      protocol: TCP
+    - name: longpolling
+      port: {{ .Values.odoo.ports.longpolling }}
+      targetPort: longpolling
+      protocol: TCP
+  selector:
+    {{- include "openspp.odoo.selectorLabels" . | nindent 4 }}

--- a/src/deployer/helm/openspp/templates/postgis-service.yaml
+++ b/src/deployer/helm/openspp/templates/postgis-service.yaml
@@ -1,0 +1,18 @@
+# Headless Service (clusterIP: None) that gives the PostGIS StatefulSet a stable in-cluster DNS
+# name for the Odoo pod and the jobworker to connect to.
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "openspp.postgis.serviceName" . }}
+  labels:
+    {{- include "openspp.labels" . | nindent 4 }}
+    {{- include "openspp.postgis.selectorLabels" . | nindent 4 }}
+spec:
+  clusterIP: None
+  ports:
+    - name: postgres
+      port: {{ .Values.postgis.port }}
+      targetPort: postgres
+      protocol: TCP
+  selector:
+    {{- include "openspp.postgis.selectorLabels" . | nindent 4 }}

--- a/src/deployer/helm/openspp/templates/postgis-statefulset.yaml
+++ b/src/deployer/helm/openspp/templates/postgis-statefulset.yaml
@@ -1,0 +1,87 @@
+# PostGIS 18 database as a StatefulSet: a stable network identity and a per-replica PVC via
+# volumeClaimTemplates.
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "openspp.postgis.serviceName" . }}
+  labels:
+    {{- include "openspp.labels" . | nindent 4 }}
+    {{- include "openspp.postgis.selectorLabels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "openspp.postgis.serviceName" . }}
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "openspp.postgis.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "openspp.labels" . | nindent 8 }}
+        {{- include "openspp.postgis.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- if .Values.arch }}
+      nodeSelector:
+        kubernetes.io/arch: {{ .Values.arch }}   # postgis/postgis:18-3.6-alpine is amd64-only
+      {{- end }}
+      containers:
+        - name: postgis
+          image: "{{ .Values.postgis.image.repository }}:{{ .Values.postgis.image.tag }}"
+          imagePullPolicy: {{ .Values.postgis.image.pullPolicy }}
+          ports:
+            - name: postgres
+              containerPort: {{ .Values.postgis.port }}
+              protocol: TCP
+          env:
+            - name: POSTGRES_DB
+              value: {{ .Values.postgis.database | quote }}
+            - name: POSTGRES_USER
+              value: {{ .Values.postgis.user | quote }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "openspp.secretName" . }}
+                  key: db-password
+            # initdb args on first init (upstream production setting).
+            - name: POSTGRES_INITDB_ARGS
+              value: {{ .Values.postgis.initdbArgs | quote }}
+          volumeMounts:
+            # Mount the PVC at /var/lib/postgresql (as the upstream compose), letting the image use
+            # its default PGDATA subdir under it.
+            - name: data
+              mountPath: /var/lib/postgresql
+            # Shared memory at /dev/shm (in-memory emptyDir); PostGIS can crash on large queries
+            # without enough shared memory.
+            - name: dshm
+              mountPath: /dev/shm
+          # Health checks via pg_isready.
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", {{ .Values.postgis.user | quote }}, "-d", {{ .Values.postgis.database | quote }}]
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          livenessProbe:
+            exec:
+              command: ["pg_isready", "-U", {{ .Values.postgis.user | quote }}, "-d", {{ .Values.postgis.database | quote }}]
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 6
+          resources:
+            {{- toYaml .Values.postgis.resources | nindent 12 }}
+      volumes:
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: {{ .Values.postgis.shmSize }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - {{ .Values.postgis.storage.accessMode }}
+        storageClassName: {{ .Values.postgis.storage.storageClass }}
+        resources:
+          requests:
+            storage: {{ .Values.postgis.storage.size }}

--- a/src/deployer/helm/openspp/templates/secret.yaml
+++ b/src/deployer/helm/openspp/templates/secret.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.secrets.create }}
+# Database and Odoo passwords as a Kubernetes Secret. The values below are placeholders; at deploy
+# time they are populated from file paths in config.ini (the src/deployer/mastercard.sh pattern) or
+# overridden with helm --set.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "openspp.secretName" . }}
+  labels:
+    {{- include "openspp.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  db-password: {{ .Values.secrets.dbPassword | quote }}
+  odoo-admin-password: {{ .Values.secrets.odooAdminPassword | quote }}
+{{- end }}

--- a/src/deployer/helm/openspp/values.yaml
+++ b/src/deployer/helm/openspp/values.yaml
@@ -1,0 +1,104 @@
+# Default values for the OpenSPP2 (Odoo 19) Helm chart. Parametrised so the chart works across the
+# local / mac / remote targets, in the style of src/deployer/helm/infra/values.yaml.
+
+# Override the generated resource name prefix (otherwise it becomes <release>-openspp-*).
+fullnameOverride: openspp
+nameOverride: ""
+
+# --- Image architecture -------------------------------------------------------------------
+# postgis/postgis:18-3.6-alpine is amd64-only (verified), so the stack is amd64 for now.
+# Set arch: "" to disable the nodeSelector (e.g. on a single-arch cluster).
+arch: amd64
+
+# --- Odoo / OpenSPP application -----------------------------------------------------------
+odoo:
+  # OpenSPP2 image, built from the OpenSPP2 Dockerfile "production" target and loaded into the
+  # cluster (build-only upstream; no published image yet). Override repository/tag at deploy time.
+  image:
+    repository: ghcr.io/openmf/openspp
+    tag: "19.0"
+    pullPolicy: IfNotPresent
+  replicas: 1
+  # Module installed on first boot. The container self-initialises (the entrypoint installs base
+  # then this module), so there is no separate init Job. spp_base_common is the real foundation
+  # module ("spp_base" does not exist in OpenSPP2).
+  modules: "spp_base_common"
+  env:
+    DB_SSLMODE: "prefer"
+    DB_FILTER: "^openspp$"
+    LIST_DB: "False"
+    PROXY_MODE: "false"     # set "true" when Odoo runs behind a reverse proxy / ingress
+    LOG_LEVEL: "info"
+    # Odoo runtime sizing (upstream production defaults).
+    workers: "2"
+    cronThreads: "1"
+  ports:
+    http: 8069        # Odoo web
+    longpolling: 8072 # Odoo longpolling / websockets
+  filestore:
+    # PVC for /var/lib/odoo (Odoo attachments / filestore).
+    size: 5Gi
+    storageClass: local-path   # k3s default StorageClass
+    accessMode: ReadWriteOnce
+  # Requests are a scheduling floor (kept small so the pod fits on small nodes); limits allow bursting.
+  resources:
+    requests:
+      cpu: "500m"
+      memory: 1Gi
+    limits:
+      cpu: "2"
+      memory: 2Gi
+
+# --- Background job worker ----------------------------------------------------------------
+# OpenSPP2 runs async queue jobs in a separate worker process (upstream "queue-worker" service),
+# not in-process like the old Doodba setup. Same image, own Deployment. It runs the standalone
+# runner via the image entrypoint (see jobworker-deployment.yaml) so odoo.conf is generated first.
+jobworker:
+  enabled: true
+  resources:
+    requests:
+      cpu: "250m"
+      memory: 512Mi
+    limits:
+      cpu: "1"
+      memory: 1Gi
+
+# --- PostGIS 18 database ------------------------------------------------------------------
+postgis:
+  image:
+    repository: postgis/postgis
+    tag: "18-3.6-alpine"
+    pullPolicy: IfNotPresent
+  database: openspp     # POSTGRES_DB (matches DB_NAME on the Odoo side)
+  user: odoo            # POSTGRES_USER (matches DB_USER)
+  port: 5432
+  # Passed to POSTGRES_INITDB_ARGS on first init (upstream production setting).
+  initdbArgs: "--encoding=UTF8 --locale=C"
+  # Shared memory for PostGIS, mounted as an in-memory emptyDir at /dev/shm. PostGIS can crash on
+  # large queries without enough shared memory.
+  shmSize: 4Gi
+  storage:
+    # PVC for /var/lib/postgresql (via the StatefulSet volumeClaimTemplates).
+    size: 10Gi
+    storageClass: local-path
+    accessMode: ReadWriteOnce
+  # Requests kept small so the pod schedules on small nodes; limits allow bursting.
+  resources:
+    requests:
+      cpu: "250m"
+      memory: 1Gi
+    limits:
+      cpu: "2"
+      memory: 2Gi
+
+# --- Secrets ------------------------------------------------------------------------------
+# The defaults below are PLACEHOLDERS. At deploy time they are populated from file paths in
+# config.ini converted to this Secret (the src/deployer/mastercard.sh pattern), or overridden
+# with helm install (--set secrets.dbPassword=...). Never commit real secrets.
+# OpenSPP2 has no separate master password: ODOO_ADMIN_PASSWD is also the DB-management password.
+secrets:
+  # Set create: false to reference a pre-existing Secret named existingSecret instead.
+  create: true
+  existingSecret: ""
+  dbPassword: "CHANGE_ME"
+  odooAdminPassword: "CHANGE_ME"

--- a/src/deployer/openspp.sh
+++ b/src/deployer/openspp.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+# OpenSPP deployment script for Mifos-Gazelle.
+# Deploys OpenSPP2 (Odoo 19 + PostGIS 18) from the Gazelle-owned Helm chart
+# at src/deployer/helm/openspp/. OpenSPP is self-contained (brings its own PostGIS DB),
+# so it does NOT depend on the shared infra chart.
+
+# Do NOT use 'set -e': this script is sourced by deployer.sh and would affect the parent shell.
+# Do NOT source commandline.sh here (circular dependency). Config values (OPENSPP_*) and the
+# logging helpers (log_section/log_step/log_ok/log_banner/log_with_verbose_check, INFO/WARNING/DEBUG)
+# are already in the environment when deployer.sh sources this file.
+
+# Expand a leading ~ to the user's home directory.
+expand_tilde() {
+    local path="$1"
+    if [[ "$path" == "~"* ]]; then
+        path="${HOME}${path:1}"
+    fi
+    echo "$path"
+}
+
+# Resolve a password: a host file path wins (mastercard.sh pattern, for prod/remote), else a known
+# local-dev default, else a random value. $1 = file path (may be empty), $2 = dev default (optional).
+# A fixed default also keeps redeploys idempotent: a random db password would not match the one
+# PostGIS already persisted in its PVC.
+openspp_resolve_secret() {
+    local path default
+    path=$(expand_tilde "${1:-}")
+    default="${2:-}"
+    if [ -n "$path" ] && [ -f "$path" ]; then
+        tr -d '\n' < "$path"
+    elif [ -n "$default" ]; then
+        echo "$default"
+    elif command -v openssl &> /dev/null; then
+        openssl rand -hex 16
+    else
+        date +%s | sha256sum | head -c 32
+    fi
+}
+
+openspp_check_prerequisites() {
+    OPENSPP_NAMESPACE="${OPENSPP_NAMESPACE:-openspp}"
+    OPENSPP_RELEASE_NAME="${OPENSPP_RELEASE_NAME:-openspp}"
+    OPENSPP_IMAGE_REPOSITORY="${OPENSPP_IMAGE_REPOSITORY:-ghcr.io/openmf/openspp}"
+    OPENSPP_IMAGE_TAG="${OPENSPP_IMAGE_TAG:-19.0}"
+
+    if ! command -v kubectl &> /dev/null; then
+        log_error "kubectl not found. Please install kubectl (or run setup-env.sh first)."
+        exit 1
+    fi
+    if ! command -v helm &> /dev/null; then
+        log_error "helm not found. Please install helm (or run setup-env.sh first)."
+        exit 1
+    fi
+    if ! kubectl get nodes &> /dev/null; then
+        log_error "Kubernetes cluster not reachable. Start k3s / run: sudo ./setup-env.sh"
+        exit 1
+    fi
+    # Build-only image: must be preloaded in the cluster (not published to a registry yet).
+    # Fail fast here instead of hanging on an ImagePullBackOff during pod startup.
+    if ! kubectl get nodes -o jsonpath='{.items[*].status.images[*].names[*]}' 2>/dev/null \
+        | tr ' ' '\n' | grep -qx "${OPENSPP_IMAGE_REPOSITORY}:${OPENSPP_IMAGE_TAG}"; then
+        log_error "Image ${OPENSPP_IMAGE_REPOSITORY}:${OPENSPP_IMAGE_TAG} not found in the cluster (build-only)."
+        log_error "Import it and redeploy:  docker save ${OPENSPP_IMAGE_REPOSITORY}:${OPENSPP_IMAGE_TAG} | sudo k3s ctr images import -"
+        exit 1
+    fi
+    log_with_verbose_check "$debug" "$INFO" "Using image ${OPENSPP_IMAGE_REPOSITORY}:${OPENSPP_IMAGE_TAG}"
+}
+
+# Deploy the Helm chart with helm upgrade --install (idempotent) and WITHOUT --wait.
+# OpenSPP2 has no init Job (the container self-initialises), so we let helm create the resources
+# and then wait for the Deployment to become Ready separately (openspp_wait_ready).
+openspp_deploy_chart() {
+    local chart_dir="$RUN_DIR/src/deployer/helm/openspp"
+    if [ ! -d "$chart_dir" ]; then
+        log_error "OpenSPP chart not found: $chart_dir"
+        exit 1
+    fi
+
+    # OpenSPP2 has no separate master password: the admin password is also the DB-management one.
+    # Local-dev defaults (admin/admin = upstream OpenSPP2 default); override via the *_FILE paths.
+    local db_pw admin_pw
+    db_pw=$(openspp_resolve_secret "${OPENSPP_DB_PASSWORD_FILE:-}" "openspp")
+    admin_pw=$(openspp_resolve_secret "${OPENSPP_ADMIN_PASSWORD_FILE:-}" "admin")
+
+    local helm_args=(
+        upgrade --install "$OPENSPP_RELEASE_NAME" "$chart_dir"
+        -n "$OPENSPP_NAMESPACE" --create-namespace
+        --timeout "${startup_timeout:-900}s"
+        --set "odoo.image.repository=${OPENSPP_IMAGE_REPOSITORY}"
+        --set "odoo.image.tag=${OPENSPP_IMAGE_TAG}"
+        --set "secrets.dbPassword=${db_pw}"
+        --set "secrets.odooAdminPassword=${admin_pw}"
+    )
+
+    if [[ "$debug" == "true" ]]; then
+        helm "${helm_args[@]}"
+    else
+        helm "${helm_args[@]}" > /dev/null 2>&1
+    fi
+    local rc=$?
+    if [ $rc -ne 0 ]; then
+        log_error "helm upgrade --install failed for release '$OPENSPP_RELEASE_NAME' (exit $rc)."
+        exit 1
+    fi
+}
+
+openspp_wait_ready() {
+    # PostGIS first, then Odoo. Odoo self-initialises on first boot (installs base + the module),
+    # gated behind its startupProbe, so this rollout wait can take a few minutes on a clean install.
+    kubectl rollout status statefulset/openspp-postgis -n "$OPENSPP_NAMESPACE" --timeout=180s > /dev/null 2>&1
+    if ! kubectl rollout status deployment/openspp-odoo -n "$OPENSPP_NAMESPACE" --timeout=300s > /dev/null 2>&1; then
+        # Most common cause: the build-only image isn't in the cluster yet.
+        if kubectl get pods -n "$OPENSPP_NAMESPACE" \
+            -o jsonpath='{.items[*].status.containerStatuses[*].state.waiting.reason}' 2>/dev/null \
+            | grep -q 'ImagePullBackOff\|ErrImagePull'; then
+            log_error "Image ${OPENSPP_IMAGE_REPOSITORY}:${OPENSPP_IMAGE_TAG} not found in the cluster."
+            log_error "It is build-only; import it:  docker save ${OPENSPP_IMAGE_REPOSITORY}:${OPENSPP_IMAGE_TAG} | sudo k3s ctr images import -"
+        fi
+        return 1
+    fi
+    return 0
+}
+
+# Smoke test: /web/login must return 200 AND the OpenSPP module must be installed.
+openspp_verify() {
+    local local_port=18069
+    kubectl port-forward "svc/openspp-odoo" "${local_port}:8069" -n "$OPENSPP_NAMESPACE" > /dev/null 2>&1 &
+    local pf_pid=$!
+    sleep 5
+
+    local code
+    code=$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:${local_port}/web/login" 2>/dev/null)
+    kill "$pf_pid" > /dev/null 2>&1
+
+    if [ "$code" != "200" ]; then
+        log_warn "Smoke test: /web/login returned HTTP '${code}' (expected 200). Check the Odoo pod logs."
+        return 1
+    fi
+
+    # /web/login returns 200 even on an empty Odoo, so confirm the module is really installed.
+    local installed
+    installed=$(kubectl exec -n "$OPENSPP_NAMESPACE" "${OPENSPP_RELEASE_NAME:-openspp}-postgis-0" -- \
+        psql -U odoo -d openspp -tAc \
+        "SELECT 1 FROM ir_module_module WHERE name = 'spp_base_common' AND state = 'installed'" \
+        2>/dev/null | tr -d '[:space:]')
+    if [ "$installed" != "1" ]; then
+        log_warn "Smoke test: OpenSPP module not installed (Odoo is empty). Check the Odoo pod logs."
+        return 1
+    fi
+
+    log_with_verbose_check "$debug" "$INFO" "Smoke test OK: /web/login 200 and OpenSPP module installed"
+    return 0
+}
+
+cleanup_openspp() {
+    OPENSPP_NAMESPACE="${OPENSPP_NAMESPACE:-openspp}"
+    OPENSPP_RELEASE_NAME="${OPENSPP_RELEASE_NAME:-openspp}"
+
+    helm uninstall "$OPENSPP_RELEASE_NAME" -n "$OPENSPP_NAMESPACE" > /dev/null 2>&1
+    kubectl delete namespace "$OPENSPP_NAMESPACE" --ignore-not-found=true > /dev/null 2>&1
+}
+
+deploy_openspp() {
+    log_section "Deploying OpenSPP"
+    openspp_check_prerequisites
+    log_with_verbose_check "$debug" "$DEBUG" "Namespace: $OPENSPP_NAMESPACE  Release: $OPENSPP_RELEASE_NAME"
+
+    log_step "Deploying OpenSPP Helm chart (installs modules on first boot; this can take a few minutes)"
+    openspp_deploy_chart
+    log_ok
+
+    log_step "Waiting for PostGIS and Odoo to become Ready"
+    if ! openspp_wait_ready; then
+        log_failed "OpenSPP did not become Ready"
+        exit 1
+    fi
+    log_ok
+
+    log_step "Smoke test (/web/login + OpenSPP module)"
+    if ! openspp_verify; then
+        log_failed "OpenSPP smoke test"
+        exit 1
+    fi
+    log_ok
+
+    log_banner "OpenSPP Deployed"
+    echo "  Namespace: $OPENSPP_NAMESPACE"
+    echo "  Access:    kubectl port-forward svc/openspp-odoo 8069:8069 -n $OPENSPP_NAMESPACE"
+    echo "             then open http://127.0.0.1:8069/web/login"
+    echo
+}
+
+# Main entry point (only used when the script is executed directly, not sourced).
+main() {
+    set -e
+    debug="${debug:-false}"
+    case "${1:-deploy}" in
+        deploy)
+            deploy_openspp
+            ;;
+        undeploy|cleanup)
+            cleanup_openspp
+            ;;
+        verify)
+            debug="true"
+            openspp_verify
+            ;;
+        status)
+            kubectl get all,pvc -n "${OPENSPP_NAMESPACE:-openspp}"
+            ;;
+        *)
+            echo "Usage: $0 {deploy|undeploy|verify|status}"
+            exit 1
+            ;;
+    esac
+}
+
+if [ "${BASH_SOURCE[0]}" -ef "$0" ]; then
+    main "$@"
+fi


### PR DESCRIPTION
## Summary
Gazelle deploys apps on Kubernetes (k3s). OpenSPP has no upstream Helm chart, only a docker-compose stack.
This PR adds a small Helm chart plus an install script and CLI wiring, so `./run.sh -a openspp` deploys
OpenSPP2 (Odoo 19 + PostGIS 18) on k3s next to the other DPGs. OpenSPP has its own PostGIS database, so it
does not use the shared infra chart (that one is MySQL only).

OpenSPP is optional and OFF by default (`[openspp] enabled = false`), so it does not change existing
`-a all` deploys.

## Ticket
GAZ-194 (sub-task of gaz 192, OpenSPP integration).

## What is included
- **Helm chart** `src/deployer/helm/openspp/`: Odoo `Deployment` (web + longpolling), a hand-written PostGIS
  `StatefulSet` (`postgis/postgis:18-3.6-alpine`) with its PVC and a shared-memory volume, a headless PostGIS
  `Service`, the Odoo `Service` (ClusterIP), the Odoo filestore `PVC`, a `Secret` for the DB and admin
  passwords, and a background job-worker `Deployment`. Names, labels and the DB env block live in
  `templates/_helpers.tpl`.
- **Install script** `src/deployer/openspp.sh`: follows the `mastercard.sh` style (check prerequisites, read
  secrets from file paths, `helm upgrade --install`, wait for ready, smoke check, cleanup).
- **CLI wiring**: `src/deployer/deployer.sh` (source + deploy/delete cases + infra skip) and
  `src/commandline/commandline.sh` (`openspp` is a valid app, but not in `CORE_APPS`, so `-a all` stays the same).
- **Config** `config/config.ini`: a new `[openspp]` section (namespace, release, image, secret file paths),
  `enabled = false`.

## Out of scope (separate PRs)
- NGINX ingress + TLS: gaz 201. In this PR you reach OpenSPP with `kubectl port-forward`.
- Docs, smoke test and CI job: gaz 204.
- End-to-end agri demo: its own ticket.

## How it works

### 1. Deploy flow
```mermaid
flowchart TD
  U["run.sh -m deploy -a openspp"]
  CL["commandline.sh<br/>checks openspp, reads flags"]
  DEP["deployer.sh<br/>deploy_apps"]
  SKIP{"does appsToDeploy<br/>include infra?"}
  INFRA["deploy_infrastructure<br/>NGINX, MySQL, Kafka"]
  CASE["case openspp"]
  OSH["openspp.sh<br/>deploy_openspp"]
  HELM["helm upgrade --install<br/>openspp chart"]
  K8S["K8s objects<br/>namespace openspp"]

  U --> CL --> DEP --> SKIP
  SKIP -->|"openspp: skip infra<br/>it has its own PostGIS"| CASE
  SKIP -->|"other apps"| INFRA
  INFRA --> CASE
  CASE --> OSH --> HELM --> K8S
```
An openspp-only deploy skips the infra step, because OpenSPP is self-contained and does not use the shared
infra chart.

### 2. Runtime architecture
```mermaid
flowchart LR
  subgraph NS["namespace openspp"]
    SEC["Secret<br/>db-password + admin-password"]
    SVCOD["Service openspp-odoo<br/>ClusterIP 8069 and 8072"]
    ODOO["Deployment openspp-odoo<br/>Odoo web"]
    JW["Deployment openspp-jobworker<br/>queue worker"]
    SVCPG["Service openspp-postgis<br/>headless, stable DNS"]
    PG["StatefulSet openspp-postgis<br/>PostGIS 18 database"]
    PVCFS["PVC filestore 5Gi<br/>disk, var/lib/odoo"]
    PVCDB["PVC data 10Gi<br/>disk, DB data"]
    SHM["shm 4Gi<br/>RAM, dev/shm"]
  end

  SVCOD --> ODOO
  ODOO -->|"DB_HOST = openspp-postgis"| SVCPG
  JW -->|"same DB"| SVCPG
  SVCPG --> PG
  ODOO -.->|"reads password"| SEC
  JW -.->|"reads password"| SEC
  PG -.->|"POSTGRES_PASSWORD"| SEC
  ODOO --- PVCFS
  PG --- PVCDB
  PG --- SHM
```
Odoo and the job worker reach the database through the `openspp-postgis` Service, and read the passwords
from the same Secret. Odoo sets itself up on first boot (it installs `base` + `spp_base_common`), so there
is no separate init Job.

### 3. Function calls in openspp.sh

```mermaid
sequenceDiagram
  participant D as deployer.sh
  participant O as openspp.sh
  participant H as helm
  participant K as k8s cluster

  D->>O: deploy_openspp
  O->>O: openspp_check_prerequisites
  Note over D,K: kubectl and helm exist, cluster is up,<br/>the build-only image is on the node
  O->>O: openspp_deploy_chart
  O->>O: openspp_resolve_secret (db and admin)
  Note over D,K: password from a config.ini file path,<br/>or a dev default
  O->>H: helm upgrade --install (no --wait)
  H->>K: create Secret, PostGIS, Odoo, jobworker, Services, PVCs
  O->>K: openspp_wait_ready (wait postgis, then odoo)
  O->>K: openspp_verify (web/login 200 + module installed)
  O-->>D: OpenSPP deployed
```

## How to test
Run everything from the mifos-gazelle repo root. The OpenSPP2 image is build-only (there is no published
image yet), so you first build it from source, then load it into the cluster. The source is cloned into
`repos/`, which is git-ignored, so it does not pollute the repo.

```bash
# 1. Clone the OpenSPP2 source into repos/ (git-ignored) and build the image (one time).
git clone --branch v19.0.2.0.0 --depth 1 https://github.com/OpenSPP/OpenSPP2.git repos/OpenSPP2
docker build --target production -t ghcr.io/openmf/openspp:19.0 -f repos/OpenSPP2/docker/Dockerfile repos/OpenSPP2

# 2. Load the built image into the k3s runtime.
#    docker save takes the image from local Docker; k3s ctr import puts it in the cluster.
docker save ghcr.io/openmf/openspp:19.0 | sudo k3s ctr images import -

# 3. Deploy.
./run.sh -m deploy -a openspp

# 4. Check the state (pods 1/1, PVCs Bound).
kubectl get pods,pvc -n openspp

# 5. Open the UI (no ingress in this PR).
kubectl port-forward svc/openspp-odoo 8069:8069 -n openspp
#    then open http://127.0.0.1:8069/web/login   (admin/admin in dev)

# 6. Remove it.
./run.sh -m cleanapps -a openspp
```

## Evidence
The deploy checks itself and fails loudly if something is wrong, in two steps:
- `openspp_wait_ready` waits for the PostGIS and Odoo rollouts (pods Ready).
- `openspp_verify` then confirms `/web/login` returns 200 AND the base module `spp_base_common` is
  `installed` in the database. A 200 alone is not enough (an empty Odoo also returns 200), so the module
  check is the real gate.

Output from deploying this branch on k3s:

```console
$ kubectl get pods,pvc -n openspp
NAME                                    READY   STATUS    RESTARTS   AGE
pod/openspp-jobworker-88b87c778-6wlqr   1/1     Running   0          103s
pod/openspp-odoo-6547f7b6bb-jwdvc       1/1     Running   0          103s
pod/openspp-postgis-0                   1/1     Running   0          103s

NAME                                           STATUS   CAPACITY   ACCESS MODES   STORAGECLASS
persistentvolumeclaim/data-openspp-postgis-0   Bound    10Gi       RWO            local-path
persistentvolumeclaim/openspp-filestore        Bound    5Gi        RWO            local-path

$ kubectl exec -n openspp statefulset/openspp-postgis -- \
    psql -U odoo -d openspp -tAc "select name||'='||state from ir_module_module where name='spp_base_common';"
spp_base_common=installed

$ kubectl exec -n openspp deploy/openspp-odoo -c odoo -- \
    curl -s -o /dev/null -w 'health=%{http_code}\n' http://localhost:8069/web/health
health=200
```

Also validated on a full stack (infra + vNext + PaymentHub + MifosX + OpenSPP2).

## Notes for reviewers
Suggested reading order: `config/config.ini [openspp]`, then `commandline.sh` (how `-a openspp` is accepted
and kept out of `-a all`), then `deployer.sh` (source + cases + infra skip), then `openspp.sh` (functions in
call order), then the chart (`values.yaml`, `_helpers.tpl`, then the templates).

A few design choices, in case they come up:
- **PostGIS is a hand-written StatefulSet, not a bitnami/postgres subchart**: OpenSPP needs the PostGIS
  geospatial image and its memory tuning, which a plain Postgres subchart would not give.
- **The Odoo Deployment uses `strategy: Recreate`**: the filestore PVC is ReadWriteOnce, so two Odoo pods
  cannot mount it at once; the old pod must stop before the new one starts.
- **No `--wait` on the helm call**: the rollout is awaited separately in `openspp_wait_ready`, and the
  install stays idempotent (`helm upgrade --install`).

## Checklist
- [x] Safe to re-run: `helm upgrade --install` (not `helm install`), and no `--wait` (the rollout is waited
  for separately).
- [x] No plaintext secrets: chart values are placeholders; real values come from `config.ini` file paths and
  are passed with `--set` (mastercard.sh style).
- [x] amd64 pinned with `nodeSelector` (`postgis/postgis:18-3.6-alpine` is amd64 only); set `arch: ""` to turn it off.
- [x] `helm lint` is clean; `helm template` renders no Ingress and no leftover secrets.
- [x] `bash -n` passes on `openspp.sh`, `deployer.sh`, `commandline.sh`.
- [x] `-a all` is unchanged (OpenSPP is not in `CORE_APPS`, and `enabled = false`).

## AI usage
`claude-code` was used to help explain concepts, test the code, and with documentation. All output was
reviewed, tested (see How to test) and adjusted by the author.

## Notes and caveats
- **Build-only image**: `ghcr.io/openmf/openspp:19.0` is not published yet. You build it from the OpenSPP2
  source and import it into the node (see How to test). `pullPolicy` is `IfNotPresent`. This will be revisited
  once an official image is published.
- **amd64 only** for now: `postgis/postgis:18-3.6-alpine` has no arm64 build.
- **Dev defaults**: admin/admin login and a fixed DB password keep re-deploys safe against the PostGIS PVC.
  For prod or remote, set real secret file paths in `config.ini`.
