### PR TITLE
GAZ-314: end-to-end agri demo, OpenSPP to Payment Hub to MifosX

### DIFF
--- a/demos/openspp/oracle-upsert.js
+++ b/demos/openspp/oracle-upsert.js
@@ -1,0 +1,23 @@
+// Register the demo payees in the vNext ALS built-in oracle.
+//
+// The switch resolves a party from account-lookup.builtinOracleParties. The FSPIOP
+// _interop admin API writes to the HTTP oracle instead, which the ALS does not read for
+// these parties, so the entries are written here directly.
+//
+// Run with mongosh inside the mongodb pod. Input arrives in environment variables:
+//   PAYEES  MSISDN separated by spaces, e.g. "0495700001 0495700002"
+//   FSP_ID  the payee bank that owns them, e.g. bluebank
+
+const payees = process.env.PAYEES.trim().split(/\s+/);
+const fspId = process.env.FSP_ID;
+
+payees.forEach(function (partyId) {
+    db.builtinOracleParties.updateOne(
+        { partyId: partyId, partyType: "MSISDN" },
+        { $set: { partyId: partyId, partyType: "MSISDN", fspId: fspId, currency: "USD" } },
+        { upsert: true }
+    );
+});
+
+print("  builtinOracleParties agri count: " +
+      db.builtinOracleParties.countDocuments({ partyId: { $in: payees } }));

--- a/demos/openspp/run_demo.sh
+++ b/demos/openspp/run_demo.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# End-to-end agri demo: OpenSPP2 -> PHEE -> MifosX.
+# Loads agri data into OpenSPP2, pays each approved entitlement through Payment Hub's
+# channel/transfer and checks the subsidy landed in the beneficiary's MifosX (bluebank)
+# savings account.
+# Idempotent: a re-run only pays entitlements that are still approved.
+# Requires the full stack up: openspp, paymenthub, mifosx and vnext namespaces.
+# Run from anywhere; paths resolve relative to this file.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/../.." && pwd)"
+FIXTURES="$HERE/fixtures"
+LOADER="$REPO/src/utils/openspp/load-openspp-agri-data.py"
+BRIDGE="$REPO/src/utils/openspp/openspp-agri-demo.py"
+VERIFY="$REPO/src/utils/openspp/verify-credit-in-mifosx.py"
+CONFIG="$REPO/config/config.ini"
+
+PAYEE_TENANT="bluebank"
+PROGRAM_NAME="Agri subsidy Q3"
+DOMAIN="$(crudini --get "$CONFIG" general GAZELLE_DOMAIN 2>/dev/null || echo mifos.gazelle.test)"
+
+log() { echo -e "\n\033[1;34m==> $*\033[0m"; }
+ok()  { echo -e "\033[1;32mOK $*\033[0m"; }
+err() { echo -e "\033[1;31mFAIL $*\033[0m"; }
+
+PF_PID=""
+OPENSPP_URL=""          # set by open_openspp_portforward
+cleanup() { [ -n "$PF_PID" ] && kill "$PF_PID" 2>/dev/null || true; }
+trap cleanup EXIT
+
+check_namespaces() {
+    log "Check namespaces"
+    for ns in openspp paymenthub mifosx vnext; do
+        if kubectl get ns "$ns" >/dev/null 2>&1; then
+            echo "  ns/$ns present"
+        else
+            err "namespace $ns missing"
+            exit 1
+        fi
+    done
+}
+
+# OpenSPP is reached over a port-forward, the same way the deployer verifies it and the
+# data loader documents. The local port is left to kubectl: a fixed one can already be
+# taken, and if what holds it is another forward the demo would talk to a different
+# OpenSPP without saying so.
+open_openspp_portforward() {
+    log "Port-forward to OpenSPP (svc/openspp-odoo 8069)"
+    kubectl port-forward -n openspp svc/openspp-odoo :8069 >/tmp/openspp-pf.log 2>&1 &
+    PF_PID=$!
+    local port="" i
+    for i in $(seq 10); do
+        sleep 1
+        port=$(sed -n 's/.*127\.0\.0\.1:\([0-9][0-9]*\).*/\1/p' /tmp/openspp-pf.log | head -1)
+        [ -n "$port" ] && break
+    done
+    if [ -z "$port" ]; then
+        err "port-forward did not start (see /tmp/openspp-pf.log)"
+        exit 1
+    fi
+    OPENSPP_URL="http://localhost:$port"
+    echo "  forwarding on $OPENSPP_URL"
+
+    # Odoo can take about a minute to start serving after a fresh deploy.
+    local code=000
+    for i in $(seq 12); do
+        sleep 5
+        code=$(curl -s -o /dev/null -w '%{http_code}' "$OPENSPP_URL/web/health") || code=000
+        [ "$code" = "200" ] && break
+    done
+    echo "  openspp health=$code"
+    if [ "$code" != "200" ]; then
+        err "OpenSPP did not answer on $OPENSPP_URL after a minute (see /tmp/openspp-pf.log)"
+        exit 1
+    fi
+}
+
+load_agri_data() {
+    log "Load agri data into OpenSPP2 (installs the farmer registry if missing)"
+    python3 "$LOADER" --url "$OPENSPP_URL" --fixtures "$FIXTURES"
+}
+
+# The logic lives in oracle-upsert.js; here only the data. The MSISDN list travels in an
+# environment variable because kubectl exec does not carry the local ones into the
+# container.
+register_payees_in_oracle() {
+    log "Register payees in the vNext ALS built-in oracle (Mongo)"
+    local mongo_uri payees out
+    mongo_uri="mongodb://root:mongoDbPas42@localhost:27017/account-lookup?authSource=admin"
+
+    # The msisdn column of the fixture, found by name so the column order can change.
+    payees=$(awk -F, 'NR==1 {for (i = 1; i <= NF; i++) if ($i == "msisdn") col = i; next}
+                      col && $col ~ /^[0-9]+$/ {print $col}' \
+                      "$FIXTURES/beneficiaries.csv" | tr '\n' ' ')
+    if [ -z "$payees" ]; then
+        err "no MSISDN found in $FIXTURES/beneficiaries.csv"
+        exit 1
+    fi
+
+    if ! out=$(kubectl exec -i -n infra mongodb-0 -c mongodb -- \
+        env PAYEES="$payees" FSP_ID="$PAYEE_TENANT" \
+        mongosh "$mongo_uri" --quiet < "$HERE/oracle-upsert.js" 2>&1); then
+        echo "$out"
+        err "mongo upsert failed (check mongodb-0 / creds)"
+        exit 1
+    fi
+    echo "$out" | grep -vE "Warning|deprecat" || true
+}
+
+# Pays each approved entitlement through Payment Hub and prints the number of subsidies
+# paid on its last stdout line, which is what this function returns.
+bridge_to_phee() {
+    python3 "$BRIDGE" --openspp-url "$OPENSPP_URL" --config "$CONFIG" \
+        --program-name "$PROGRAM_NAME" --payee-tenant "$PAYEE_TENANT" | tail -1
+}
+
+# Check each beneficiary got a deposit matching their subsidy amount in bluebank.
+# When this run paid, ask about THIS run: with a time the verifier reads Fineract's audit,
+# the only place that keeps a clock, so the subsidies of an earlier run on the same day are
+# not mistaken for this one's. When it paid nothing, everything was already paid, so the
+# question is the other one, "is every beneficiary credited", and the day window answers it.
+verify_credit_in_mifosx() {
+    local paid_count="$1"
+    if [ "$paid_count" -gt 0 ] 2>/dev/null; then
+        python3 "$VERIFY" "$DOMAIN" "$FIXTURES/beneficiaries.csv" "$PAYEE_TENANT" \
+            --since "$STARTED_AT"
+    else
+        python3 "$VERIFY" "$DOMAIN" "$FIXTURES/beneficiaries.csv" "$PAYEE_TENANT"
+    fi
+}
+
+main() {
+    # In UTC because that is how Fineract reads the audit filter, and a minute early to
+    # absorb any clock difference with the cluster. Python and not date(1): the GNU and
+    # BSD versions disagree on how to subtract a minute, and python3 is already needed.
+    STARTED_AT="$(python3 -c "import datetime as d; print((d.datetime.now(d.timezone.utc) - d.timedelta(minutes=1)).strftime('%Y-%m-%d %H:%M:%S'))")"
+    echo "  run started at $STARTED_AT UTC"
+
+    check_namespaces
+    open_openspp_portforward
+    load_agri_data
+    register_payees_in_oracle
+
+    log "Pay approved entitlements via PHEE channel/transfer, one at a time"
+    local paid_count
+    paid_count="$(bridge_to_phee)"
+    echo "  subsidies paid=$paid_count"
+
+    log "Verify subsidy credited in MifosX ($PAYEE_TENANT)"
+    sleep 5   # the bridge already confirmed each credit; small settle margin
+    local result=0
+    verify_credit_in_mifosx "$paid_count" || result=1
+
+    if [ "$result" -eq 0 ]; then
+        ok "E2E demo PASSED - $paid_count subsidies paid this run"
+    else
+        err "E2E demo FAILED - $paid_count subsidies paid this run"
+    fi
+    return "$result"
+}
+
+main "$@"

--- a/src/utils/openspp/openspp-agri-demo.py
+++ b/src/utils/openspp/openspp-agri-demo.py
@@ -1,0 +1,485 @@
+#!/usr/bin/env python3
+"""
+GAZ-DEMO bridge: OpenSPP2 -> Payment Hub EE -> MifosX (agri subsidy).
+
+For each APPROVED entitlement of the program in OpenSPP2:
+  1. make sure the beneficiary is a payable payee in the payee bank (Fineract
+     client + savings + interop party + vNext oracle + identity mapper),
+  2. record the payment in OpenSPP as 'sent' and only then disburse it via PHEE's
+     channel/transfer (payer -> payee), the same call as make-payment.sh, which
+     does the real debit/credit through the Mojaloop switch and the ams-mifos
+     connector,
+  3. wait until the payee's MifosX savings account is actually credited, then
+     close that payment as paid and mark the entitlement 'rdpd2ben', which is what
+     shows as "Paid" in the OpenSPP UI.
+
+Idempotent: a re-run only pays entitlements that are still approved. Payment Hub does
+not deduplicate, so the payment is recorded before it is sent and a later run looks that
+record up by its reference instead of sending a second transfer.
+
+NOTE: channel/transfer needs no extra OpenSPP module. The bulk /batchtransactions rail
+ends up on the same one: ph-ee-connector-bulk posts each payment to /channel/transfer,
+which runs PayerFundTransfer for the payer tenant greenbank and books in Fineract.
+Payments go one at a time, each confirmed before the next, so the single-instance
+switch and connectors are not overwhelmed.
+
+Own script per DPG: does NOT modify generate-mifos-vnext-data.py; it reuses its
+Fineract/oracle/mapper helpers. Needs the full stack (OpenSPP2 + PHEE + MifosX +
+vNext) on one machine.
+"""
+
+import argparse
+import datetime
+import importlib.util
+import sys
+import time
+import uuid
+import xmlrpc.client
+from pathlib import Path
+
+import requests
+import urllib3
+
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+DATA_DIR = REPO_ROOT / "src" / "utils" / "data-loading"
+DEFAULT_CONFIG = REPO_ROOT / "config" / "config.ini"
+CREDIT_POLL_TRIES = 15
+CREDIT_POLL_INTERVAL = 8   # seconds -> up to 2 min per payment
+# Cap on the audit rows read when checking a transfer. Each row costs one extra call.
+AUDIT_ROWS_SCANNED = 25
+
+
+def _load(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+gen = _load("gen_mifos_vnext", DATA_DIR / "generate-mifos-vnext-data.py")
+
+
+def fineract_headers(tenant):
+    # Credentials come from the data generator so there is one place to change them.
+    return {"Fineract-Platform-TenantId": tenant, "Authorization": gen.AUTH_HEADER_VALUE,
+            "Content-Type": "application/json", "Accept": "application/json"}
+
+
+def openspp_call(url, db, user, pw):
+    """Return a call(model, method, *args, **kw) bound to verified Odoo credentials.
+
+    Odoo's XML-RPC API keeps no session: execute_kw takes the database, user id and
+    password on every call, so the closure carries them.
+    """
+    uid = xmlrpc.client.ServerProxy(f"{url}/xmlrpc/2/common").authenticate(db, user, pw, {})
+    if not uid:
+        sys.exit(f"ERROR: OpenSPP auth failed for {user}@{db}")
+    models = xmlrpc.client.ServerProxy(f"{url}/xmlrpc/2/object")
+    return lambda model, method, *a, **k: models.execute_kw(db, uid, pw, model, method, list(a), k)
+
+
+def read_approved_entitlements(call, program_name):
+    """Return [{id, msisdn, amount, name, cycle_id}] for the approved entitlements."""
+    prog = call("spp.program", "search", [["name", "=", program_name]])
+    if not prog:
+        sys.exit(f"ERROR: program '{program_name}' not found in OpenSPP")
+    ents = call("spp.entitlement", "search_read",
+                [["state", "=", "approved"], ["program_id", "=", prog[0]]],
+                fields=["partner_id", "initial_amount", "cycle_id"])
+    out = []
+    for e in ents:
+        pid = e["partner_id"][0]                       # M2o -> [id, name]
+        # Skip decommissioned numbers: the registry marks them with a 'disabled' date,
+        # and paying one of those sends the money to a phone nobody owns any more.
+        phones = call("spp.phone.number", "search_read",
+                      [["partner_id", "=", pid], ["disabled", "=", False]],
+                      fields=["phone_no"])
+        if not phones:
+            print(f"  WARN: {e['partner_id'][1]} has no phone number, skipping", file=sys.stderr)
+            continue
+        out.append({"id": e["id"], "msisdn": phones[0]["phone_no"],
+                    "amount": e["initial_amount"], "name": e["partner_id"][1],
+                    "cycle_id": e["cycle_id"][0] if e.get("cycle_id") else None})
+    return out
+
+
+def pending_payment(call, entitlement_id):
+    """The spp.payment of this entitlement with no outcome yet, or None.
+
+    Pending means an empty status: 'paid' and 'failed' are both final and leave the
+    entitlement free to be paid. In Odoo, '=' False also matches an empty column.
+    """
+    pays = call("spp.payment", "search_read",
+                [["entitlement_id", "=", entitlement_id], ["status", "=", False]],
+                fields=["create_date", "name"], limit=1)
+    return pays[0] if pays else None
+
+
+def open_payment_in_openspp(call, entitlement_id, amount, cycle_id=None, account_no=None):
+    """Record the intent to pay in OpenSPP, before sending anything to Payment Hub.
+
+    The entitlement's "Payment Status" is a computed field: it reads the entitlement's
+    spp.payment records and shows "Paid" only when one has status='paid'. The cycle's
+    "Payments" counter also counts spp.payment by cycle_id. The disbursement happens
+    outside OpenSPP, through PHEE, so without this record the UI stays on "Not Paid".
+
+    Created before the transfer and left in state 'sent'. Recording it afterwards would
+    lose any payment whose credit lands after the wait, and the next run would pay again.
+    """
+    vals = {
+        "entitlement_id": entitlement_id,
+        # The model default for name is one uuid built at module load, shared by every
+        # record created without it, so each payment needs its own.
+        "name": str(uuid.uuid4()),
+        "amount_issued": amount,
+        "state": "sent",
+        "is_status_final": False,
+    }
+    if cycle_id:
+        vals["cycle_id"] = cycle_id   # so the cycle's "Payments" counter sees it
+    if account_no:
+        vals["account_number"] = account_no   # which account should receive the money
+    return call("spp.payment", "create", vals)
+
+
+def fail_payment_in_openspp(call, payment_id):
+    """Mark a payment as failed so the entitlement can be paid again."""
+    now = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+    call("spp.payment", "write", [payment_id],
+         {"status": "failed", "is_status_final": True, "status_datetime": now})
+
+
+def close_payment_as_paid(call, entitlement_id, amount):
+    """Close the open spp.payment of this entitlement once the credit is confirmed.
+
+    The payment is already recorded by the time the credit lands, so it is updated rather
+    than duplicated. Idempotent: a paid one is not picked up again.
+    """
+    # Only the ones with no outcome yet: status holds 'paid' or 'failed', and both are
+    # final.
+    pays = call("spp.payment", "search",
+                [["entitlement_id", "=", entitlement_id], ["status", "=", False]])
+    if not pays:
+        return
+    now = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+    call("spp.payment", "write", pays, {
+        "status": "paid", "state": "reconciled", "is_status_final": True,
+        "amount_paid": amount, "payment_datetime": now, "status_datetime": now,
+    })
+
+
+def find_client_id_by_mobile(headers, msisdn):
+    """Fineract client id whose mobileNo == msisdn (the ?mobileNo filter is unreliable)."""
+    # limit=-1 returns every client. Fineract pages at 200 by default, and since the
+    # match happens here, a client past the page would look like it does not exist.
+    data = gen.make_api_request("GET", gen.CLIENTS_API_URL, headers, params={"limit": -1})
+    for c in (data or {}).get("pageItems", []):
+        if c.get("mobileNo") == msisdn:
+            return c.get("id")
+    return None
+
+
+def ensure_payee(headers, tenant, msisdn, payer_tenant):
+    """Ensure MSISDN is a Fineract client with savings + interop + oracle + mapper. Returns acct id."""
+    client_id = find_client_id_by_mobile(headers, msisdn)
+    if client_id:
+        account_id = gen.get_savings_accounts_for_client(headers, client_id)
+        if account_id:
+            gen.register_client_with_vnext(headers, tenant, msisdn)
+            gen.register_beneficiary_with_identity_mapper(tenant, msisdn, account_id, payer_tenant)
+            return account_id
+        # Client without a savings account: reuse it and create the account below.
+    product_id = gen.create_savings_product(headers, f"{tenant}-savings")
+    if not client_id:
+        client_id, _m, _n = gen.create_client(headers, "en", tenant, msisdn)
+        if not client_id:
+            return None
+    account_id, ext_id = gen.create_savings_account(headers, client_id, product_id, "en")
+    if not account_id:
+        return None
+    today = datetime.datetime.now().strftime(gen.DATE_FORMAT)
+    gen.approve_savings_account(gen.API_BASE_URL, headers, account_id, today)
+    gen.activate_savings_account(gen.API_BASE_URL, headers, account_id, today)
+    gen.make_deposit(gen.API_BASE_URL, headers, account_id, 5000, today)
+    gen.register_interop_party(headers, client_id, ext_id, msisdn)
+    gen.register_client_with_vnext(headers, tenant, msisdn)
+    gen.register_beneficiary_with_identity_mapper(tenant, msisdn, account_id, payer_tenant)
+    return account_id
+
+
+def savings_account_no(headers, account_id):
+    """Fineract's human-visible account number, not the internal account id."""
+    d = gen.make_api_request("GET", f"{gen.API_BASE_URL}/savingsaccounts/{account_id}", headers)
+    return (d or {}).get("accountNo")
+
+
+def savings_balance(headers, account_id):
+    """Account balance, or None when it could not be read.
+
+    None is not the same as zero. A failed read taken as a zero baseline would make the
+    next successful read look like the payment had arrived, so the caller has to tell
+    "the account is empty" apart from "I could not ask".
+    """
+    return _balance_field(headers, account_id, "accountBalance")
+
+
+def spendable_balance(headers, account_id):
+    """What the account can actually pay with, or None when it could not be read.
+
+    Funds a transfer put on hold still count in the book balance but cannot be spent,
+    so the payer has to be measured with this one. Falls back to the book balance when
+    Fineract does not report it.
+    """
+    available = _balance_field(headers, account_id, "availableBalance")
+    if available is not None:
+        return available
+    return _balance_field(headers, account_id, "accountBalance")
+
+
+def _balance_field(headers, account_id, field):
+    d = gen.make_api_request("GET", f"{gen.API_BASE_URL}/savingsaccounts/{account_id}", headers)
+    if not d:
+        return None
+    summary = d.get("summary")
+    if not isinstance(summary, dict):
+        return None
+    balance = summary.get(field)
+    if balance is None:
+        return 0.0 if field == "accountBalance" else None
+    try:
+        return float(balance)
+    except (TypeError, ValueError):
+        return None
+
+
+def transfer_booked(headers, transaction_id, since=None):
+    """True when Fineract's audit shows this transfer reference.
+
+    since: only read audit rows after this UTC moment, as 'YYYY-MM-DD HH:MM:SS'.
+    One extra call per row: the audit listing does not carry the payload.
+    """
+    params = {"entityName": "INTERTRANSFER", "limit": AUDIT_ROWS_SCANNED}
+    if since:
+        params.update({"makerDateTimeFrom": since,
+                       "dateFormat": "yyyy-MM-dd HH:mm:ss", "locale": "en"})
+    rows = gen.make_api_request("GET", f"{gen.API_BASE_URL}/audits", headers, params=params)
+    if not rows:
+        return False
+    for row in rows if isinstance(rows, list) else rows.get("pageItems", []):
+        detail = gen.make_api_request("GET", f"{gen.API_BASE_URL}/audits/{row.get('id')}", headers)
+        command = (detail or {}).get("commandAsJson") or ""
+        if transaction_id and transaction_id in command:
+            return True
+    return False
+
+
+def credit_seen(headers, account_id, baseline, amount):
+    """True when the balance has risen by at least amount since baseline.
+
+    An unreadable balance returns False so the caller keeps waiting instead of taking a
+    failed read as proof of anything.
+    """
+    current = savings_balance(headers, account_id)
+    if current is None:
+        return False
+    return current >= baseline + amount - 0.01
+
+
+def get_payer_msisdn(payer_tenant):
+    """The MSISDN of the first client in the payer tenant, which is who pays."""
+    for c in gen.get_clients_from_mifos(fineract_headers(payer_tenant), payer_tenant):
+        if c.get("mobile"):
+            return c["mobile"]
+    sys.exit(f"ERROR: no payer client with MSISDN found in tenant {payer_tenant}")
+
+
+def ensure_payer_funds(headers, payer_msisdn, total_needed):
+    """Make sure the payer account can cover total_needed; top up the shortfall (demo money).
+
+    Idempotent: only deposits when the balance is short. Mirrors the payee seeding in
+    ensure_payee, so the demo stays self-sufficient across runs (each run debits the payer).
+    """
+    client_id = find_client_id_by_mobile(headers, payer_msisdn)
+    if not client_id:
+        return
+    account_id = gen.get_savings_accounts_for_client(headers, client_id)
+    if not account_id:
+        return
+    # Spendable, not book balance: a transfer left hanging keeps its funds on hold, and
+    # topping up against the book balance would leave the payer short by that much.
+    balance = spendable_balance(headers, account_id)
+    if balance is None:
+        print("Payer balance could not be read, skipping the top-up", file=sys.stderr)
+        return
+    if balance < total_needed:
+        topup = total_needed - balance
+        today = datetime.datetime.now().strftime(gen.DATE_FORMAT)
+        gen.make_deposit(gen.API_BASE_URL, headers, account_id, topup, today)
+        print(f"Payer funded: +{topup} (was {balance}, needs {total_needed})", file=sys.stderr)
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Bridge OpenSPP2 approved entitlements -> PHEE channel/transfer -> MifosX")
+    ap.add_argument("--openspp-url", default="http://localhost:8069")
+    ap.add_argument("--openspp-db", default="openspp")
+    ap.add_argument("--openspp-user", default="admin")
+    ap.add_argument("--openspp-password", default="admin")
+    ap.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    ap.add_argument("--program-name", default="Agri subsidy Q3")
+    ap.add_argument("--payer-tenant", default="greenbank")
+    ap.add_argument("--payee-tenant", default="bluebank")
+    ap.add_argument("--currency", default="USD")
+    ap.add_argument("--no-writeback", action="store_true", help="do not mark entitlements paid in OpenSPP")
+    ap.add_argument("--no-payer-topup", action="store_true",
+                    help="do not auto-fund the payer even if its balance is short")
+    args = ap.parse_args()
+
+    cfg = gen.load_config(str(args.config))
+    domain = gen.get_gazelle_domain(cfg)
+    gen.set_global_urls(domain)
+    print(f"Domain: {domain}", file=sys.stderr)
+
+    call = openspp_call(args.openspp_url, args.openspp_db, args.openspp_user, args.openspp_password)
+
+    # Read approved entitlements from OpenSPP.
+    # None left is the idempotent case (a previous run already paid them): report 0, exit ok.
+    ents = read_approved_entitlements(call, args.program_name)
+    if not ents:
+        print("No approved entitlements to pay (already paid). Nothing to do.", file=sys.stderr)
+        print(0)
+        return
+    print(f"Read {len(ents)} approved entitlement(s) from OpenSPP", file=sys.stderr)
+
+    # Ensure each beneficiary is a payable payee (Fineract + oracle + mapper).
+    payee_headers = fineract_headers(args.payee_tenant)
+    for e in ents:
+        e["acct"] = ensure_payee(payee_headers, args.payee_tenant, e["msisdn"], args.payer_tenant)
+        state = "ready" if e["acct"] else "NO ACCOUNT"
+        print(f"  payee {state}: {e['name']} ({e['msisdn']}) acct={e['acct']} USD {e['amount']:.2f}", file=sys.stderr)
+    payable = [e for e in ents if e["acct"]]
+    if not payable:
+        # Not the same as "already paid": there was work to do and no payee could take it.
+        print(f"ERROR: none of the {len(ents)} beneficiaries could be made payable in "
+              f"{args.payee_tenant}, nothing was sent.", file=sys.stderr)
+        print(0)
+        return
+
+    # Disburse, confirm each credit, mark it paid.
+    payer_msisdn = get_payer_msisdn(args.payer_tenant)
+    print(f"Payer MSISDN ({args.payer_tenant}): {payer_msisdn}", file=sys.stderr)
+
+    # Make sure the payer can cover the subsidies (it drains across runs); top up if short.
+    payer_headers = fineract_headers(args.payer_tenant)
+    total_needed = sum(int(round(e["amount"])) for e in payable)
+    if not args.no_payer_topup:
+        ensure_payer_funds(payer_headers, payer_msisdn, total_needed)
+
+    transfer_url = f"https://channel.{domain}/channel/transfer"
+    paid = 0
+    for e in payable:
+        amount = int(round(e["amount"]))
+        # An unresolved payment means the money may already be on its way or already there.
+        # Payment Hub does not deduplicate, so a second transfer would pay twice.
+        reference = None
+        earlier = None if args.no_writeback else pending_payment(call, e["id"])
+        if earlier:
+            print(f"  WARN {e['name']} ({e['msisdn']}): an earlier run already sent this one, "
+                  f"looking for it instead of paying again", file=sys.stderr)
+            # Only the reference settles this: a deposit of the right amount is not
+            # proof, since an earlier run may have left one. create_date bounds the
+            # audit window; Odoo keeps it in UTC, in the format Fineract expects.
+            arrived = bool(earlier.get("name")) and transfer_booked(
+                payee_headers, earlier["name"], since=earlier.get("create_date"))
+            if not arrived:
+                print(f"  ERROR {e['name']} ({e['msisdn']}): that payment is unresolved and "
+                      f"cannot be confirmed, left alone on purpose. Check the account before "
+                      f"forcing it.", file=sys.stderr)
+                continue
+            paid += 1
+            msg = f"  OK {e['name']} ({e['msisdn']}) acct {e['acct']}: the earlier payment did arrive"
+            call("spp.entitlement", "write", [e["id"]], {"state": "rdpd2ben"})
+            close_payment_as_paid(call, e["id"], amount)
+            print(f"{msg} - marked Paid in OpenSPP", file=sys.stderr)
+            continue
+        else:
+            baseline = savings_balance(payee_headers, e["acct"])
+            if baseline is None:
+                print(f"  ERROR {e['name']} ({e['msisdn']}): balance unreadable, not paying so a "
+                      f"re-run can, since the credit could not be verified", file=sys.stderr)
+                continue
+            payload = {
+                "payer": {"partyIdInfo": {"partyIdType": "MSISDN", "partyIdentifier": payer_msisdn}},
+                "payee": {"partyIdInfo": {"partyIdType": "MSISDN", "partyIdentifier": e["msisdn"]}},
+                "amount": {"amount": amount, "currency": args.currency},
+            }
+            headers = {"Platform-TenantId": args.payer_tenant, "X-PayeeDFSP-ID": args.payee_tenant,
+                       "X-CorrelationID": str(uuid.uuid4()), "Content-Type": "application/json", "Accept": "*/*"}
+            # Recorded before the transfer: a credit landing after the wait is not lost,
+            # and the record is what stops a re-run from paying twice. --no-writeback
+            # leaves OpenSPP untouched and therefore without that protection.
+            payment_id = None
+            if not args.no_writeback:
+                payment_id = open_payment_in_openspp(call, e["id"], amount, e.get("cycle_id"),
+                                                     savings_account_no(payee_headers, e["acct"]))
+            try:
+                r = requests.post(transfer_url, json=payload, headers=headers, verify=False, timeout=30)
+            except requests.ReadTimeout:
+                # Sent without an answer: the payment may have gone through, so the record
+                # stays open and the balance below decides.
+                print(f"  WARN {e['name']} ({e['msisdn']}): no reply from channel/transfer, "
+                      f"checking the account anyway", file=sys.stderr)
+            except requests.RequestException as exc:
+                # Never sent: close the record so a later run can pay this one.
+                if payment_id:
+                    fail_payment_in_openspp(call, payment_id)
+                print(f"  ERROR {e['name']} ({e['msisdn']}): transfer not sent "
+                      f"({exc.__class__.__name__})", file=sys.stderr)
+                continue
+            else:
+                if r.status_code != 200:
+                    if payment_id:
+                        fail_payment_in_openspp(call, payment_id)
+                    print(f"  ERROR {e['name']} ({e['msisdn']}): transfer HTTP {r.status_code} {r.text[:150]}", file=sys.stderr)
+                    continue
+                # Payment Hub's reference, stored because Fineract's audit records it.
+                try:
+                    reference = r.json().get("transactionId")
+                except ValueError:
+                    reference = None
+                if reference and payment_id:
+                    call("spp.payment", "write", [payment_id], {"name": reference})
+
+        # Wait until the payee savings account is actually credited.
+        credited = False
+        for _ in range(CREDIT_POLL_TRIES):
+            time.sleep(CREDIT_POLL_INTERVAL)
+            if credit_seen(payee_headers, e["acct"], baseline, amount):
+                credited = True
+                break
+        if not credited and reference:
+            # The balance can move for other reasons, so before calling a transfer lost
+            # Fineract is asked about that exact reference.
+            if transfer_booked(payee_headers, reference):
+                credited = True
+                print(f"  WARN {e['name']} ({e['msisdn']}): the credit was not visible in the "
+                      f"balance, but Fineract booked the transfer", file=sys.stderr)
+        if not credited:
+            print(f"  ERROR {e['name']} ({e['msisdn']}): transfer sent but credit not seen (still in flight)", file=sys.stderr)
+            continue
+
+        paid += 1
+        msg = f"  OK {e['name']} ({e['msisdn']}) acct {e['acct']}: credited USD {amount}"
+        if not args.no_writeback:
+            call("spp.entitlement", "write", [e["id"]], {"state": "rdpd2ben"})   # Status -> Paid to Beneficiary
+            close_payment_as_paid(call, e["id"], amount)                   # Payment Status -> Paid
+            msg += " - marked Paid in OpenSPP"
+        print(msg, file=sys.stderr)
+
+    print(f"\nOK: {paid}/{len(payable)} agri subsidies disbursed & confirmed in MifosX.", file=sys.stderr)
+    print(paid)   # stdout: count for the orchestrator
+
+
+if __name__ == "__main__":
+    main()

--- a/src/utils/openspp/verify-credit-in-mifosx.py
+++ b/src/utils/openspp/verify-credit-in-mifosx.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+# DEMO verification step: check each agri beneficiary got their subsidy in MifosX.
+# For each MSISDN in the beneficiaries CSV, look up the client in the payee tenant,
+# find its savings account, and confirm a deposit matching the subsidy amount exists.
+# Exit code: 0 if every beneficiary was credited, 1 if any is missing.
+#
+# A deposit only counts when it came through the payment rail and is recent enough.
+# Other money in the account could match by chance: deposits made straight against
+# Fineract (no routing code), interest postings (not a deposit) and the subsidies of
+# previous runs (same amount, older date).
+import argparse
+import csv
+import datetime
+import json
+import sys
+
+import requests
+import urllib3
+
+# Fineract demo admin (mifos:password), base64-encoded for HTTP Basic auth.
+FINERACT_BASIC_AUTH = "Basic bWlmb3M6cGFzc3dvcmQ="
+HTTP_TIMEOUT = 30
+AMOUNT_TOLERANCE = 0.01  # floats: treat amounts within one cent as equal.
+# Payment Hub stamps this on every transfer it books through the interoperation rail.
+# A deposit made straight against Fineract carries an empty routing code instead.
+RAIL_ROUTING_CODE = "INTEROPERATION"
+# Only the audit keeps a time; a savings transaction is dated by day. Cap on the rows
+# read, since each one costs an extra call.
+AUDIT_ROWS_SCANNED = 50
+
+
+def a_day(text):
+    """Parse YYYY-MM-DD into the (y, m, d) shape Fineract uses for a transaction date."""
+    d = datetime.datetime.strptime(text, "%Y-%m-%d").date()
+    return (d.year, d.month, d.day)
+
+
+def parse_args():
+    ap = argparse.ArgumentParser(description="Verify agri subsidies were credited in MifosX.")
+    ap.add_argument("domain", help="Gazelle domain, e.g. mifos.gazelle.test")
+    ap.add_argument("csv_path", help="Path to beneficiaries.csv")
+    ap.add_argument("tenant", help="Payee tenant (Fineract tenant id), e.g. bluebank")
+    ap.add_argument("--since", default=None, metavar="WHEN",
+                    help="ignore anything older than this (default: today). A day, "
+                         "YYYY-MM-DD, reads the savings transactions, which Fineract dates "
+                         "by day, so two runs on the same day look the same. Add a time, "
+                         "YYYY-MM-DD HH:MM:SS, to read Fineract's audit instead, which is "
+                         "the only place with a clock and can tell those runs apart.")
+    args = ap.parse_args()
+    args.since_time = None
+    # Validated here so a typo is answered with the usage text and not with a traceback.
+    try:
+        if args.since and " " in args.since:
+            datetime.datetime.strptime(args.since, "%Y-%m-%d %H:%M:%S")
+            args.since_time = args.since
+            args.since = a_day(args.since.split(" ")[0])
+        elif args.since:
+            args.since = a_day(args.since)
+    except ValueError:
+        ap.error(f"--since {args.since!r} is not YYYY-MM-DD or 'YYYY-MM-DD HH:MM:SS'")
+    if not args.since:
+        today = datetime.date.today()
+        args.since = (today.year, today.month, today.day)
+    return args
+
+
+def audited_transfers(get, since_text):
+    """[(account external id, amount)] for rail transfers audited since a moment.
+
+    Fineract audits every interoperation transfer with a millisecond stamp and a payload
+    naming the account and the amount. The listing does not carry that payload, so each
+    row has to be read on its own.
+    """
+    rows = get("audits", entityName="INTERTRANSFER", makerDateTimeFrom=since_text,
+               dateFormat="yyyy-MM-dd HH:mm:ss", locale="en", limit=AUDIT_ROWS_SCANNED)
+    rows = rows if isinstance(rows, list) else rows.get("pageItems", [])
+    transfers = []
+    for row in rows:
+        detail = get(f"audits/{row.get('id')}")
+        try:
+            command = json.loads(detail.get("commandAsJson") or "{}")
+        except (AttributeError, ValueError):
+            continue
+        transfers.append((command.get("accountId"), (command.get("amount") or {}).get("amount")))
+    return transfers
+
+
+def audited_transfer_found(transfers, account_external_id, amount):
+    """True when the audited transfers hold one for this account and amount."""
+    for account, credited in transfers:
+        if not account or account != account_external_id:
+            continue
+        try:
+            if abs(float(credited) - amount) < AMOUNT_TOLERANCE:
+                return True
+        except (TypeError, ValueError):
+            continue
+    return False
+
+
+def is_subsidy_deposit(transaction, amount, since):
+    """True for a deposit of this amount that came through the rail on or after a day.
+
+    The date is compared with 'on or after' and never with equality: the deposit is dated
+    by the connector's clock, which can run a day ahead.
+    """
+    if not transaction.get("transactionType", {}).get("deposit"):
+        return False
+    if not transaction.get("notReversed", True):
+        return False
+    if (transaction.get("paymentDetailData") or {}).get("routingCode") != RAIL_ROUTING_CODE:
+        return False
+    if tuple(transaction.get("date") or ()) < since:
+        return False
+    try:
+        return abs(float(transaction.get("amount")) - amount) < AMOUNT_TOLERANCE
+    except (TypeError, ValueError):
+        return False
+
+
+def main():
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+    args = parse_args()
+    base = f"https://mifos.{args.domain}/fineract-provider/api/v1"
+    headers = {
+        "Fineract-Platform-TenantId": args.tenant,
+        "Authorization": FINERACT_BASIC_AUTH,
+    }
+
+    def get(path, **params):
+        # verify=False: MifosX uses a self-signed cert in Gazelle (like curl -k).
+        # An unreadable answer is a failure, not a traceback: Fineract returns 503
+        # through the ingress while it restarts.
+        try:
+            response = requests.get(f"{base}/{path}", headers=headers, params=params,
+                                    verify=False, timeout=HTTP_TIMEOUT)
+            response.raise_for_status()
+            return response.json()
+        except (requests.RequestException, ValueError) as exc:
+            # Same stream as the results, so the cause reads before its consequence.
+            print(f"  WARN cannot read {path}: {exc.__class__.__name__}")
+            return {}
+
+    with open(args.csv_path) as f:
+        beneficiaries = list(csv.DictReader(f))
+
+    # Read once, not once per beneficiary. limit=-1 returns every client: Fineract pages
+    # at 200 by default and the match happens here, so a client past the page would look
+    # like it does not exist.
+    clients = get("clients", limit=-1).get("pageItems", [])
+    if not clients:
+        print(f"  FAIL: no clients could be read from {args.tenant}")
+        return 1
+
+    # With a time the audit is the source, read once for the whole run.
+    transfers = audited_transfers(get, args.since_time) if args.since_time else None
+
+    all_credited = True
+    for row in beneficiaries:
+        msisdn = row["msisdn"]
+        amount = float(row["amount"])
+
+        match = [c for c in clients if c.get("mobileNo") == msisdn]
+        if not match:
+            print(f"  FAIL {msisdn}: no client in {args.tenant}")
+            all_credited = False
+            continue
+        client_id = match[0]["id"]
+
+        accounts = get(f"clients/{client_id}/accounts")
+        savings = accounts.get("savingsAccounts", [])
+        if not savings:
+            print(f"  FAIL {msisdn}: no savings account")
+            all_credited = False
+            continue
+        account_id = savings[0]["id"]
+
+        account = get(f"savingsaccounts/{account_id}", associations="transactions")
+        if transfers is None:
+            credited = any(is_subsidy_deposit(t, amount, args.since)
+                           for t in account.get("transactions", []))
+        else:
+            credited = audited_transfer_found(transfers, account.get("externalId"), amount)
+        if credited:
+            print(f"  OK {msisdn}: credited USD {amount:.2f} (acct {account_id})")
+        else:
+            since = args.since_time or "%04d-%02d-%02d" % args.since
+            print(f"  FAIL {msisdn}: no subsidy of USD {amount:.2f} through the "
+                  f"payment rail since {since} (acct {account_id})")
+            all_credited = False
+
+    return 0 if all_credited else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
Deploying OpenSPP on its own does not show much. Gazelle exists to show the DPGs working together, so this PR adds a demo that runs the whole line: a farmer registered in OpenSPP gets a crop subsidy, the payment crosses Payment Hub, and the money lands in the beneficiary's savings account in MifosX.

One command does all of it and says whether the money arrived. It is meant to be run by a person on a machine that already has Gazelle deployed.

## Ticket
GAZ-314 (sub-task of gaz 192, OpenSPP integration). Cut off current `dev`, which already includes the OpenSPP deploy (gaz 194) and the agri data loader (gaz 316, PR #164). It does not depend on the ingress PR (gaz 201, #158) nor on the docs PR (gaz 204, #162): the demo talks to Odoo over a port-forward, so no ingress and no hosts entry are needed.

## What is included
- **Orchestrator** `demos/openspp/run_demo.sh`: runs the six steps in order and reports the result.
- **Payment script** `src/utils/openspp/openspp-agri-demo.py`: pays every approved entitlement through Payment Hub and writes the result back into OpenSPP.
- **Verifier** `src/utils/openspp/verify-credit-in-mifosx.py`: checks in core banking that every beneficiary was credited. Exits non-zero when one is missing.
- **Account lookup script** `demos/openspp/oracle-upsert.js`: registers the payees in the switch account lookup.

## Out of scope (separate PRs)
- The native payment connector that lets OpenSPP send the money itself. It lives in an optional Odoo module that does not ship with Gazelle, so a reviewer could not run it.
- Reaching OpenSPP over the ingress instead of a port-forward. See note 4 below.

## How it works

### 1. The six steps
```mermaid
flowchart TD
  A["check the four namespaces are present"] --> B["port-forward to OpenSPP"]
  B --> C["load the agri data (gaz 316 loader)"]
  C --> D["register the payees in the vNext account lookup"]
  D --> E["pay each approved entitlement through Payment Hub"]
  E --> F["verify every beneficiary was credited in MifosX"]
  E --> G["mark the entitlement paid in OpenSPP"]
```

The payment step is the one this PR is about. For each approved entitlement it makes sure the beneficiary is payable in the payee bank, records the payment in OpenSPP, sends the transfer, waits until the credit is visible in core banking, and only then marks it paid.

### 2. Why `channel/transfer`, and one payment at a time
The payments go out one at a time, and each credit is confirmed before the next one is sent. This path needs no extra module inside OpenSPP, and going one at a time keeps a single-instance switch from being overwhelmed, because all the transfers share the same payer position.

### 3. Why the payees are written straight into Mongo
The vNext account lookup service resolves these parties from `account-lookup.builtinOracleParties`. Registering them through the FSPIOP admin API lands them in the HTTP oracle, which is not what the lookup reads for this case, so the transfer fails with `PARTY_NOT_FOUND`.

### 4. Why a port-forward, and why the port is not fixed
The demo reaches OpenSPP the same way the deployer verifies it after installing (`src/deployer/openspp.sh`) and the same way the data loader already documents. The ingress is optional, it is not in `dev`, and it serves a self-signed certificate that Python's XML-RPC client rejects by default, so a port-forward is the path that always works.

The local port is left to `kubectl` instead of being fixed. A fixed port can already be taken, and if what holds it is another forward to a different OpenSPP, the demo would run against that one without saying so.

### 5. Idempotency
A re-run only pays entitlements that are still approved, so a second run pays nothing and still reports success.

Payment Hub does not deduplicate, so the payment record is created in OpenSPP **before** the transfer is sent. If a credit lands after the demo stopped waiting, the record stays open, and the next run looks it up by its Payment Hub reference instead of sending a second transfer. When it cannot be confirmed that way, it is reported and left alone rather than guessed.

## How to test
Needs a real cluster with the full stack up: `openspp`, `paymenthub`, `mifosx` and `vnext`. From the repo root:

```bash
# Start from an empty OpenSPP so the demo has something to pay.
./run.sh -m cleanapps -a openspp
./run.sh -m deploy -a openspp

# Run the demo.
bash demos/openspp/run_demo.sh

# Run it again to see it is idempotent: nothing is paid, and it still passes.
bash demos/openspp/run_demo.sh
```

To watch OpenSPP while it runs, open your own forward on a port you choose, which is the line the deployer prints when it finishes:

```bash
kubectl port-forward svc/openspp-odoo 8069:8069 -n openspp
# then open http://127.0.0.1:8069/web/login
```

## Evidence
First run, from an empty OpenSPP database:

```console
$ bash demos/openspp/run_demo.sh
  run started at 2026-08-02 11:30:36 UTC

==> Port-forward to OpenSPP (svc/openspp-odoo 8069)
  forwarding on http://localhost:33049
  openspp health=200

==> Load agri data into OpenSPP2 (installs the farmer registry if missing)
Module spp_starter_farmer_registry installed
Created program 'Agri subsidy Q3' (id=1)
Created cycle 'Agri subsidy Q3 - Cycle 1' (id=1)
OK: program id=1, cycle id=1, entitlements=5, cash=5, approved=5

==> Register payees in the vNext ALS built-in oracle (Mongo)
  builtinOracleParties agri count: 5

==> Pay approved entitlements via PHEE channel/transfer, one at a time
Payer MSISDN (greenbank): 0413356886
Payer funded: +1000.0 (was 0.0, needs 1000)
  OK Farm Household Flores (0495700005) acct 2: credited USD 200 - marked Paid in OpenSPP
  OK Farm Household Reyes (0495700004) acct 3: credited USD 200 - marked Paid in OpenSPP
  OK Farm Household Garcia (0495700003) acct 4: credited USD 200 - marked Paid in OpenSPP
  OK Farm Household Cruz (0495700002) acct 5: credited USD 200 - marked Paid in OpenSPP
  OK Farm Household Santos (0495700001) acct 6: credited USD 200 - marked Paid in OpenSPP

OK: 5/5 agri subsidies disbursed & confirmed in MifosX.
  subsidies paid=5

==> Verify subsidy credited in MifosX (bluebank)
  OK 0495700001: credited USD 200.00 (acct 6)
  OK 0495700002: credited USD 200.00 (acct 5)
  OK 0495700003: credited USD 200.00 (acct 4)
  OK 0495700004: credited USD 200.00 (acct 3)
  OK 0495700005: credited USD 200.00 (acct 2)
OK E2E demo PASSED - 5 subsidies paid this run
```

Second run, straight after. Nothing is paid again and it still passes:

```console
$ bash demos/openspp/run_demo.sh
==> Port-forward to OpenSPP (svc/openspp-odoo 8069)
  forwarding on http://localhost:41499

==> Load agri data into OpenSPP2 (installs the farmer registry if missing)
OK: program id=1, cycle id=1, entitlements=5, cash=5, approved=0

==> Pay approved entitlements via PHEE channel/transfer, one at a time
No approved entitlements to pay (already paid). Nothing to do.
  subsidies paid=0

==> Verify subsidy credited in MifosX (bluebank)
  OK 0495700001: credited USD 200.00 (acct 6)
  OK 0495700002: credited USD 200.00 (acct 5)
  OK 0495700003: credited USD 200.00 (acct 4)
  OK 0495700004: credited USD 200.00 (acct 3)
  OK 0495700005: credited USD 200.00 (acct 2)
OK E2E demo PASSED - 0 subsidies paid this run
```

The demo writes nothing into the repository:

```console
$ git status --short
?? demos/openspp/oracle-upsert.js
?? demos/openspp/run_demo.sh
?? src/utils/openspp/openspp-agri-demo.py
?? src/utils/openspp/verify-credit-in-mifosx.py
```

## Notes for reviewers
- **CI cannot run this.** It needs four namespaces, a running switch and a core banking instance. It is a demo for a deployed machine, not a test.
- **Beneficiaries are matched by MSISDN**, which is what the whole rail routes on. The MifosX client for each number already exists with a name generated by Gazelle's base data loader, so the same person shows as a farmer household in OpenSPP and under a generated name in core banking.
- **The credit is checked before anything is marked paid.** The demo waits for the money to be visible in the beneficiary's savings account, and confirms against Fineract's audit by the transfer reference when the balance alone is not enough.
- **The credentials in these scripts are the local development defaults** Gazelle already ships.
- **Nothing is written into the repository.** The demo prints its result and leaves no file behind.
- **Placement.** The demo scripts live under `demos/openspp/` and `src/utils/openspp/`, with the rest of the OpenSPP tooling.

## Checklist
- [x] Standard library plus `requests`, which the repo already uses; no new dependency.
- [x] Does not modify `generate-mifos-vnext-data.py` or any existing script; it reuses the base generator's helpers.
- [x] Idempotent: verified by running it twice, the second run pays nothing and still passes.
- [x] Exits non-zero when a beneficiary was not credited.
- [x] Runs on a stock OpenSPP image: no optional module required.
- [x] Writes no file into the repository.
- [x] Verified end to end on a fresh clone of `dev`, with OpenSPP wiped and redeployed first.

## AI usage
`claude-code` was used to help explain concepts, test the code, and with documentation. All output was reviewed, tested (see Evidence) and adjusted by the author.
