### PR TITLE
GAZ-323: fix stale wording in the OpenSPP image and ingress docs

### DIFF
--- a/docs/BUILDING-IMAGES.md
+++ b/docs/BUILDING-IMAGES.md
@@ -1,8 +1,9 @@
 # Building images for Gazelle
 
-Most Gazelle components run images pulled from a registry. Some are **build-only**: they are not
-published anywhere, so they have to be built on the machine and loaded into the cluster's container
-runtime. `src/utils/build-and-import-image.sh` does both, for the architecture of the host it runs on.
+Most Gazelle components run images pulled from a registry. Some have no image published upstream, so
+someone has to build them, and there are two ways to get the result to the cluster: load it into the
+cluster's container runtime, or push it to a registry the cluster can pull from.
+`src/utils/build-and-import-image.sh` does both, for the architecture of the host it runs on.
 
 ## Quick start
 
@@ -26,10 +27,14 @@ Run `src/utils/build-and-import-image.sh --help` for all options.
 | `--push` | one or more platforms | pushed to the registry |
 
 They are separate on purpose. A multi-platform build produces a **manifest list**, an index that
-points to one image per architecture, and only a registry can store one. It cannot be exported with
-`docker save`, so it cannot be imported into a local cluster. Asking for several platforms without
-`--push` therefore fails with that explanation instead of producing something the local path cannot
-use.
+points to one image per architecture. Docker's classic image store cannot load one: `--load` fails with
+`docker exporter does not currently support exporting manifest lists`. The containerd image store does
+hold manifest lists, and it is [the default storage backend for Docker Engine 29.0 and later on fresh
+installations](https://docs.docker.com/engine/storage/containerd/), so this is about the image store
+rather than about registries. Even there the local path would not gain anything: `ctr images import`
+imports a single platform unless you pass `--all-platforms`, and building the other architecture on this
+machine means emulation, which is much slower than a native build. So asking for several platforms
+without `--push` fails with that explanation instead of paying for a build nobody uses.
 
 ## Architecture detection
 
@@ -48,6 +53,12 @@ instance, with nothing to remember.
   runtime and needs root. It resolves the user that owns the built image from `$SUDO_USER`, so it
   also works over a non-interactive ssh and in a pipeline, as long as `sudo` does not ask for a
   password.
+- **Registry credentials for `--push`.** The registry comes from the image name
+  (`ghcr.io/openmf/openspp` -> ghcr.io; a bare name -> Docker Hub). Credentials come from
+  `docker login <registry>`, which stores them in `$HOME/.docker/config.json`; this utility does not
+  handle authentication. For ghcr.io, GitHub needs a personal access token with the `write:packages`
+  scope. This is unrelated to `config.ini [dockerhub]`, which `src/utils/k3s-docker-login.sh` uses so
+  the **cluster can pull**, not so you can push.
 - **Disk space on the node.** k3s garbage-collects images when the disk fills up. A build-only image
   cannot be pulled back, so keep the node's root filesystem below about 85% or it may be evicted and
   have to be built again.

--- a/src/deployer/helm/openspp/values.yaml
+++ b/src/deployer/helm/openspp/values.yaml
@@ -12,11 +12,13 @@ arch: amd64
 
 # --- Odoo / OpenSPP application -----------------------------------------------------------
 odoo:
-  # OpenSPP2 image, built from the OpenSPP2 Dockerfile "production" target and loaded into the
-  # cluster (build-only upstream; no published image yet). Override repository/tag at deploy time.
+  # OpenSPP2 image. Upstream publishes none, so this is either built and loaded into the cluster or
+  # pulled from wherever repository points. Override repository/tag at deploy time.
   image:
     repository: ghcr.io/openmf/openspp
     tag: "19.0"
+    # IfNotPresent means a node that already has this tag keeps it. Re-pushing the same tag does not
+    # reach those nodes; use a new tag when the contents change.
     pullPolicy: IfNotPresent
   replicas: 1
   # Module installed on first boot. The container self-initialises (the entrypoint installs base
@@ -105,9 +107,8 @@ secrets:
 
 # --- Ingress (NGINX) ----------------------------------------------------------------------
 # Exposes Odoo over HTTPS via the shared ingress-nginx. Enabled + host are set by openspp.sh at
-# deploy time (host = OPENSPP_DOMAIN from config.ini, which defaults to openspp.${GAZELLE_DOMAIN});
-# the self-signed TLS secret is created there too. The host is left empty here on purpose so there
-# is no hardcoded domain in the chart.
+# deploy time (host = openspp.${GAZELLE_DOMAIN}); the self-signed TLS secret is created there too.
+# The host is left empty here on purpose so there is no hardcoded domain in the chart.
 ingress:
   enabled: false
   className: nginx

--- a/src/utils/build-and-import-image.sh
+++ b/src/utils/build-and-import-image.sh
@@ -8,8 +8,9 @@
 #   --push  : build for one or more platforms and push to a registry.
 #
 # Why the default path is single-architecture: a multi-platform build produces a manifest
-# list, which only a registry can store. It cannot be exported with 'docker save', so it
-# cannot be imported into k3s. Ask for --push when you want a multi-platform image.
+# list, and Docker's classic image store cannot load one. Even where it can, the local
+# import takes a single platform unless asked for all of them, and building the other
+# architecture here means emulation. Ask for --push when you want a multi-platform image.
 #
 # The import step reuses src/utils/import-local-image-to-k3s.sh instead of duplicating it.
 
@@ -35,6 +36,8 @@ showUsage() {
     cat << EOF
 Usage: $(basename "$0") [OPTIONS]
 Build a container image with docker buildx and load it into the local k3s cluster.
+By default the image is built for the host architecture and imported into k3s.
+Use --no-import to build only, or --push to publish to a registry instead.
 
 Required:
     -n, --name         image name, e.g. ghcr.io/openmf/openspp
@@ -46,7 +49,8 @@ Optional:
         --target       build stage to stop at, e.g. production
         --platform     platform list (default: linux/<host arch>)
         --push         push to the registry instead of importing into k3s
-                       (required for a multi-platform build)
+                       (required for a multi-platform build;
+                        run 'docker login <registry>' first)
         --build-arg    build argument, repeatable, e.g. --build-arg FOO=bar
         --builder      buildx builder to use (default: the built-in "default" builder)
         --no-import    build only, do not import into k3s
@@ -120,8 +124,8 @@ HOST_ARCH="$(detect_arch)"
 # instead of producing something that cannot be imported into k3s.
 if [[ "$PLATFORM" == *,* && "$PUSH" != true ]]; then
     error "Multi-platform build requested ($PLATFORM) without --push.
-A multi-platform build produces a manifest list, which only a registry can store: it cannot be
-exported with 'docker save' and therefore cannot be imported into k3s.
+A multi-platform build produces a manifest list. Docker's classic image store cannot load one, and the
+local import takes a single platform, so the extra builds would cost resources and not be used.
 Either add --push, or build a single platform (default: linux/${HOST_ARCH})."
 fi
 

--- a/src/utils/test-scripts/verify-endpoints.sh
+++ b/src/utils/test-scripts/verify-endpoints.sh
@@ -88,6 +88,8 @@ check_endpoint "Redpanda Console"             "http://redpanda-console.${GAZELLE
 check_endpoint "Minio Console"                "http://minio-console.${GAZELLE_DOMAIN}"                    false
 check_endpoint "Zeebe Operate"                "http://zeebe-operate.${GAZELLE_DOMAIN}"                    false
 check_endpoint "PHEE Bulk Processor"          "https://bulk-processor.${GAZELLE_DOMAIN}"                  false
+# Not critical: OpenSPP is optional and off by default, so it is often not deployed.
+check_endpoint "OpenSPP"                      "https://openspp.${GAZELLE_DOMAIN}/web/login"               false
 check_endpoint "PHEE Connector Bulk"          "https://connector-bulk.${GAZELLE_DOMAIN}"                  false
 check_endpoint "PHEE Mojaloop Connector"      "https://mojaloop.${GAZELLE_DOMAIN}"                        false
 check_endpoint "PHEE AMS Mifos Connector"     "https://ams-mifos.${GAZELLE_DOMAIN}"                       false

--- a/tests/openspp/circleci-job.yml
+++ b/tests/openspp/circleci-job.yml
@@ -37,7 +37,8 @@ commands:
           command: bash tests/openspp/smoke.sh
 
 jobs:
-  # OpenSPP2 is amd64-only (postgis/postgis:18-3.6-alpine has no arm64), so it has no arm64 job.
+  # amd64 only: the official postgis/postgis image publishes no arm64 manifest, so an arm64 job would
+  # need an arm64 PostGIS image passed in. OpenSPP itself does run on arm64.
   deploy-test-openspp-amd64:
     machine:
       image: ubuntu-2004:current


### PR DESCRIPTION
## Summary
Five pieces of text that say something no longer true, or that were promised in a previous review. No behaviour change except one line added to an endpoint checker.

## Ticket
GAZ-323 (sub-task of gaz 192, OpenSPP integration). These are the wording fixes deferred on gaz 317, where the PR was approved as it was and the fixes moved to a follow-up, plus three comments that went stale as later work landed.

## What is included
- **`src/utils/build-and-import-image.sh`**: the multi-platform explanation in the header and in the error message; the `--help` now states what the default does and that `--push` needs a login.
- **`docs/BUILDING-IMAGES.md`**: the same explanation, and registry credentials added to Requirements.
- **`src/deployer/helm/openspp/values.yaml`**: a comment naming a configuration key that no longer exists.
- **`tests/openspp/circleci-job.yml`**: a comment calling OpenSPP amd64-only.
- **`src/utils/test-scripts/verify-endpoints.sh`**: OpenSPP added to the informational checks.

## Out of scope
Anything that changes what the deploy does. The build-if-missing work is gaz 321 (PR #170).

## How it works

### 1. The multi-platform paragraph was wrong
It said a manifest list is something "only a registry can store". The limit belongs to Docker's **classic image store**, not to registries: the containerd image store does hold manifest lists, and it is [the default storage backend for Docker Engine 29.0 and later on fresh installations](https://docs.docker.com/engine/storage/containerd/).

The reasons that do hold are different, and they are what the text says now: `--load` fails with `docker exporter does not currently support exporting manifest lists`, `ctr images import` takes a single platform unless asked for all of them, and building the other architecture locally means emulation. So the default path stays single-architecture because the extra builds would not be used, not because a registry is the only place a manifest list can live.

Rewritten in the three places it appeared.

### 2. `--help` never said what the default does
It described `--no-import` but never stated that without it the image is built for the host architecture and imported into k3s, which is what prompted the question in the review. It says so now, and `--push` mentions the `docker login` it needs.

### 3. Registry credentials were not written down
Added to Requirements: the registry comes from the image name, credentials come from `docker login`, ghcr.io needs a token with `write:packages`, and none of this is related to `config.ini [dockerhub]`, which exists so the **cluster can pull**.

### 4. Two comments that went stale
The chart comment said the ingress host comes from `OPENSPP_DOMAIN` in `config.ini`. That key was removed during the review of gaz 201 and the host is derived from `GAZELLE_DOMAIN`, so the comment pointed at something that does not exist.

The parked CI job said "OpenSPP2 is amd64-only". OpenSPP does run on arm64; what is amd64-only is the official PostGIS image, which is why that job has no arm64 variant. The comment now says which of the two is the constraint.

### 5. The endpoint checker did not know about OpenSPP
`verify-endpoints.sh` checks MifosX, vNext and Payment Hub but not OpenSPP. Added to the **informational** list, not the critical one, because OpenSPP is optional and off by default, so it is often not deployed and must not fail the run.

## Evidence
The error message quoted in the doc was reproduced on Docker 29.1.3:

```console
$ docker buildx build --platform linux/amd64,linux/arm64 --load -t probe:test - <<< 'FROM alpine:3.20'
ERROR: failed to build: docker exporter does not currently support exporting manifest lists
```

The rendered help:

```console
$ bash src/utils/build-and-import-image.sh --help
Usage: build-and-import-image.sh [OPTIONS]
Build a container image with docker buildx and load it into the local k3s cluster.
By default the image is built for the host architecture and imported into k3s.
Use --no-import to build only, or --push to publish to a registry instead.
```

Both YAML files parse, and both scripts pass `bash -n`.

## Checklist
- [x] The sentence that was wrong appears nowhere in the tree.
- [x] The removed configuration key is mentioned nowhere.
- [x] Both scripts pass `bash -n`, both YAML files parse.
- [x] The quoted error message was reproduced.
- [x] No change to what any deploy does.

## AI usage
`claude-code` was used to help explain concepts, test the code, and with documentation. All output was reviewed, tested (see Evidence) and adjusted by the author.
