### PR TITLE
GAZ-324: choose the payment rail in the agri demo

### DIFF
--- a/demos/openspp/run_demo.sh
+++ b/demos/openspp/run_demo.sh
@@ -18,6 +18,9 @@ CONFIG="$REPO/config/config.ini"
 
 PAYEE_TENANT="bluebank"
 PROGRAM_NAME="Agri subsidy Q3"
+# Which rail pays. Empty leaves the choice to the payment script. Set to connector or
+# bridge to force one:  PAY_MODE=bridge bash demos/openspp/run_demo.sh
+PAY_MODE="${PAY_MODE:-}"
 DOMAIN="$(crudini --get "$CONFIG" general GAZELLE_DOMAIN 2>/dev/null || echo mifos.gazelle.test)"
 
 log() { echo -e "\n\033[1;34m==> $*\033[0m"; }
@@ -111,8 +114,11 @@ register_payees_in_oracle() {
 # Pays each approved entitlement through Payment Hub and prints the number of subsidies
 # paid on its last stdout line, which is what this function returns.
 bridge_to_phee() {
+    # Passed only when asked, so an empty value never overrides the script's own choice.
+    local rail=()
+    [[ -n "$PAY_MODE" ]] && rail=(--pay-mode "$PAY_MODE")
     python3 "$BRIDGE" --openspp-url "$OPENSPP_URL" --config "$CONFIG" \
-        --program-name "$PROGRAM_NAME" --payee-tenant "$PAYEE_TENANT" | tail -1
+        --program-name "$PROGRAM_NAME" --payee-tenant "$PAYEE_TENANT" "${rail[@]}" | tail -1
 }
 
 # Check each beneficiary got a deposit matching their subsidy amount in bluebank.

--- a/src/utils/openspp/openspp-agri-demo.py
+++ b/src/utils/openspp/openspp-agri-demo.py
@@ -49,6 +49,9 @@ CREDIT_POLL_TRIES = 15
 CREDIT_POLL_INTERVAL = 8   # seconds -> up to 2 min per payment
 # Cap on the audit rows read when checking a transfer. Each row costs one extra call.
 AUDIT_ROWS_SCANNED = 25
+# The connector sends one batch per cron run, so it waits longer than the bridge.
+CONNECTOR_POLL_TRIES = 45   # -> up to 6 min per payment
+CONNECTOR_MODULE = "spp_payment_phee"
 
 
 def _load(name, path):
@@ -59,6 +62,8 @@ def _load(name, path):
 
 
 gen = _load("gen_mifos_vnext", DATA_DIR / "generate-mifos-vnext-data.py")
+# Reused for its module installer, so both scripts install a module the same way.
+loader = _load("openspp_loader", Path(__file__).resolve().parent / "load-openspp-agri-data.py")
 
 
 def fineract_headers(tenant):
@@ -103,6 +108,52 @@ def read_approved_entitlements(call, program_name):
                     "amount": e["initial_amount"], "name": e["partner_id"][1],
                     "cycle_id": e["cycle_id"][0] if e.get("cycle_id") else None})
     return out
+
+
+def find_program_id(call, program_name):
+    """The programme id, needed to attach a payment manager to it."""
+    prog = call("spp.program", "search", [["name", "=", program_name]])
+    if not prog:
+        sys.exit(f"ERROR: program '{program_name}' not found in OpenSPP")
+    return prog[0]
+
+
+def connector_state(call):
+    """State of the native connector module, or None when this image does not carry it.
+
+    Three answers, not two: missing, present but not installed, or installed. An image
+    installs only the modules it is told to, so present but not installed is a normal
+    state after a fresh deploy, and the connector can still be used.
+    """
+    domain = [["name", "=", CONNECTOR_MODULE]]
+    rec = call("ir.module.module", "search_read", domain, fields=["state"])
+    if not rec:
+        # A new module shows up only after the list is refreshed.
+        call("ir.module.module", "update_list")
+        rec = call("ir.module.module", "search_read", domain, fields=["state"])
+    return rec[0]["state"] if rec else None
+
+
+def ensure_manager(call, program_id, model, m2m_field, name, extra_vals):
+    """Configure a program manager of one kind, once.
+
+    A program holds one manager of each kind, so nothing is created when it already
+    has one. The concrete record on its own is not enough either: the program reads
+    its managers through a wrapper that points at the record (manager_ref_id).
+    """
+    if call("spp.program", "read", [program_id], fields=[m2m_field])[0][m2m_field]:
+        return None
+
+    found = call(model, "search", [["name", "=", name], ["program_id", "=", program_id]])
+    if found:
+        mgr_id = found[0]
+    else:
+        vals = {"name": name, "program_id": program_id}
+        vals.update(extra_vals)
+        mgr_id = call(model, "create", vals)
+    call("spp.program", "write", [program_id],
+         {m2m_field: [(0, 0, {"manager_ref_id": f"{model},{mgr_id}"})]})
+    return mgr_id
 
 
 def pending_payment(call, entitlement_id):
@@ -320,6 +371,107 @@ def ensure_payer_funds(headers, payer_msisdn, total_needed):
         print(f"Payer funded: +{topup} (was {balance}, needs {total_needed})", file=sys.stderr)
 
 
+def pay_via_connector(call, payee_headers, payable, program_id, program_name,
+                      payer_msisdn, writeback=True):
+    """Let OpenSPP send the payments itself, through its native payment manager.
+
+    The whole cycle leaves in one call and a cron drains the queue, so this waits longer
+    than the bridge. Returns how many credits were confirmed in MifosX.
+    """
+    def call_ok(model, method, *cargs):
+        # These cycle methods return nothing, and XML-RPC cannot marshal that.
+        try:
+            return call(model, method, *cargs)
+        except xmlrpc.client.Fault as fault:
+            if "cannot marshal None" in str(fault):
+                return None
+            raise
+
+    cycle_id = next((e.get("cycle_id") for e in payable if e.get("cycle_id")), None)
+    if not cycle_id:
+        sys.exit("ERROR: no cycle id on the approved entitlements")
+    # Keyed by entitlement, not by beneficiary: one beneficiary can have several, and a
+    # shared baseline would count the same credit twice.
+    baselines = {e["id"]: savings_balance(payee_headers, e["acct"]) for e in payable}
+    # Everything goes out in one call, so a balance that cannot be read stops the run
+    # before any money moves.
+    unreadable = [e["msisdn"] for e in payable if baselines[e["id"]] is None]
+    if unreadable:
+        sys.exit(f"ERROR: could not read the balance of {len(unreadable)} payee(s) "
+                 f"before sending: {', '.join(unreadable)}")
+    # The cycle needs a payment manager before it can send, and it is wired here rather
+    # than by the loader, which also runs on images without the module. One payment per
+    # batch: the payer position is shared, and bigger batches ran into timeouts.
+    ensure_manager(call, program_id, "spp.program.payment.manager.phee",
+                   "payment_manager_ids", f"{program_name} PHEE payments",
+                   {"payer_id": payer_msisdn, "max_batch_size": 1})
+    print(f"Connector: prepare_payment on cycle {cycle_id}...", file=sys.stderr)
+    # A prepare with nothing to do reports a notification, not an error. Counting on both
+    # sides tells the new batches from the ones an earlier run left behind, so a run with
+    # nothing to send stops here instead of waiting for credits that cannot arrive.
+    batch_domain = [["cycle_id", "=", cycle_id]]
+    before = call("spp.payment.batch", "search_count", batch_domain)
+    call_ok("spp.cycle", "prepare_payment", [cycle_id])
+    time.sleep(2)
+    batches = call("spp.payment.batch", "search_count", batch_domain) - before
+    if batches <= 0:
+        sys.exit("ERROR: OpenSPP created no payment batches for this cycle, so there is "
+                 "nothing to send. An entitlement is only payable again when all of its "
+                 "earlier payments failed, so a database that already paid them needs a "
+                 "fresh deploy.")
+    print(f"Connector: {batches} batch(es) queued, one sent per cron run...", file=sys.stderr)
+    call_ok("spp.cycle", "send_payment", [cycle_id])
+
+    paid = 0
+    for e in payable:
+        amount = int(round(e["amount"]))
+        credited = False
+        for _ in range(CONNECTOR_POLL_TRIES):
+            if credit_seen(payee_headers, e["acct"], baselines[e["id"]], amount):
+                credited = True
+                break
+            time.sleep(CREDIT_POLL_INTERVAL)
+        if not credited:
+            print(f"  ERROR {e['name']} ({e['msisdn']}): sent but credit not seen "
+                  f"(still in flight)", file=sys.stderr)
+            continue
+        paid += 1
+        msg = f"  OK {e['name']} ({e['msisdn']}) acct {e['acct']}: credited USD {amount}"
+        if writeback:
+            call("spp.entitlement", "write", [e["id"]], {"state": "rdpd2ben"})
+            close_payment_as_paid(call, e["id"], amount)
+            msg += " - marked Paid in OpenSPP"
+        print(msg, file=sys.stderr)
+    return paid
+
+
+def choose_pay_mode(call, asked):
+    """Pick the rail: the native connector when the image carries it, the bridge otherwise.
+
+    The bridge needs nothing extra, so it is the safe default. An explicit 'connector'
+    fails when the module is missing, because reporting a rail that was never used is
+    worse than stopping.
+    """
+    if asked == "bridge":
+        print("Paying through the channel/transfer bridge (asked for)", file=sys.stderr)
+        return "bridge"
+
+    state = connector_state(call)
+    if state is None:
+        if asked == "connector":
+            sys.exit(f"ERROR: {CONNECTOR_MODULE} is not in this OpenSPP image, so --pay-mode "
+                     f"connector cannot be honoured. Use --pay-mode bridge or auto.")
+        print(f"WARN: {CONNECTOR_MODULE} is not in this OpenSPP image, falling back to the "
+              f"channel/transfer bridge", file=sys.stderr)
+        return "bridge"
+
+    if state != "installed":
+        print(f"{CONNECTOR_MODULE} is available but not installed yet", file=sys.stderr)
+        loader.ensure_module_installed(call, CONNECTOR_MODULE)
+    print(f"Paying through OpenSPP's native connector ({CONNECTOR_MODULE})", file=sys.stderr)
+    return "connector"
+
+
 def main():
     ap = argparse.ArgumentParser(description="Bridge OpenSPP2 approved entitlements -> PHEE channel/transfer -> MifosX")
     ap.add_argument("--openspp-url", default="http://localhost:8069")
@@ -334,6 +486,9 @@ def main():
     ap.add_argument("--no-writeback", action="store_true", help="do not mark entitlements paid in OpenSPP")
     ap.add_argument("--no-payer-topup", action="store_true",
                     help="do not auto-fund the payer even if its balance is short")
+    ap.add_argument("--pay-mode", choices=["auto", "connector", "bridge"], default="auto",
+                    help="which rail pays: auto uses OpenSPP's native connector when the "
+                         "image carries it and the bridge otherwise (default: auto)")
     args = ap.parse_args()
 
     cfg = gen.load_config(str(args.config))
@@ -375,6 +530,16 @@ def main():
     total_needed = sum(int(round(e["amount"])) for e in payable)
     if not args.no_payer_topup:
         ensure_payer_funds(payer_headers, payer_msisdn, total_needed)
+
+    # The rail is decided and reported before anything is sent.
+    if choose_pay_mode(call, args.pay_mode) == "connector":
+        paid = pay_via_connector(call, payee_headers, payable,
+                                 find_program_id(call, args.program_name), args.program_name,
+                                 payer_msisdn, writeback=not args.no_writeback)
+        print(f"\nOK: {paid}/{len(payable)} agri subsidies disbursed via the native connector.",
+              file=sys.stderr)
+        print(paid)   # stdout: count for the orchestrator
+        return
 
     transfer_url = f"https://channel.{domain}/channel/transfer"
     paid = 0


### PR DESCRIPTION
## Summary
The agri demo pays through a bridge: the demo script itself posts each subsidy to Payment Hub. OpenSPP is only the source of the entitlements and the place the result is written back, so it never takes part in the payment. OpenSPP can do it itself through a native payment manager, and this PR lets the demo use it when it is available.

The rail is decided at run time. If the OpenSPP image carries the `spp_payment_phee` module, the demo installs it if needed and lets OpenSPP issue the payments. If the image does not carry it, the demo pays through the bridge exactly as it does today. Every run prints which rail it used, and either can be forced.

The bridge path is not modified and not re-indented: the connector path is a new function with an early return.

## Ticket
GAZ-324 (sub-task of gaz 192, OpenSPP integration). Cut off current `dev`, which already includes the demo (gaz 314, PR #168) and the data loader (gaz 316, PR #164).

This closes the follow-up left open in #168, which removed `--pay-mode` because at that time the demo *required* the connector, and that made it impossible to review without a custom image. With the rail chosen at run time a reviewer whose image lacks the module gets the bridge and the demo still passes.

## What is included
- **Payment script** `src/utils/openspp/openspp-agri-demo.py`: three-state detection of the module, install on demand, `--pay-mode {auto,connector,bridge}`, and the connector path as its own function.
- **Orchestrator** `demos/openspp/run_demo.sh`: a `PAY_MODE` environment variable that forwards the choice.

## Out of scope (separate work)
- Building or publishing the image that carries the module. The module is not upstream, so it travels in an image rather than in this repository.
- The module itself. Its home was settled as upstream OpenSPP, not Gazelle.
- Advancing the programme cycle through its own states. The cycle stays in `Draft` while its entitlements read as paid, which looks wrong in the interface but is unrelated to which rail pays: nothing in the demo has ever written `spp.cycle.state`.

## How it works

### 1. Three states, not two
Asking whether the module is `installed` is not enough. An image installs only the modules it is told to, so right after a fresh deploy the module can be present and **uninstalled**, and the connector rail is still available.

| What the image has | What the demo does |
|---|---|
| the module is not there | bridge, with a warning that says so |
| present, not installed | installs it, then the connector |
| present and installed | the connector |

The lookup refreshes Odoo's module list before giving up, because a new module is only listed once the list is refreshed.

### 2. Installing reuses the loader
The loader already installs a module when it is missing, waits for it and survives the registry reload an install causes. The payment script loads the loader the same way it already loads the vNext data generator, and calls its installer.

### 3. Forcing is explicit
`--pay-mode bridge` never looks at the module. `--pay-mode connector` on an image without it **fails** instead of falling back quietly: reporting a rail that was never used is worse than stopping. Only `auto` falls back, and it says so.

### 4. A prepare that creates nothing stops the run
`prepare_payment` reports a notification, not an error, when it has nothing to do. So the run counts the cycle's batches before and after the call and stops when the number did not grow, instead of polling for credits that cannot arrive.

Counting on both sides is what makes it work on a database that was paid before, because that cycle still holds the batches of the earlier run.

## How to test
Needs a cluster with `openspp`, `paymenthub`, `mifosx` and `vnext` up.

On an image that carries the module, from a fresh OpenSPP database:

```bash
./run.sh -m deploy -a openspp
bash demos/openspp/run_demo.sh
```

Expected: `spp_payment_phee is available but not installed yet`, the install, `Paying through OpenSPP's native connector`, and 5/5 credited and verified in MifosX.

Force the bridge on the same image, which is the regression:

```bash
PAY_MODE=bridge bash demos/openspp/run_demo.sh
```

Expected: `Paying through the channel/transfer bridge (asked for)` and the same 5/5 as before this PR.

Run the connector twice without redeploying, which is the guard:

```bash
PAY_MODE=connector bash demos/openspp/run_demo.sh
```

Expected on the second run: it stops in seconds with `OpenSPP created no payment batches for this cycle`.

On an image without the module, a default run warns and uses the bridge, and `PAY_MODE=connector` fails naming the module.

Repeating the connector run needs a fresh database, for a reason that is upstream's and correct: the module pays an entitlement again only when **all** of its previous payments failed, and OpenSPP refuses to delete a payment in `paid` state.

## Evidence
Against a **remote** cluster, from a laptop, with the four DPGs up and the same image in every run.

- **Connector, clean database**: module detected as present and not installed, installed on demand, payment manager wired, `Connector: 5 batch(es) queued`, 5/5 credited, `E2E demo PASSED`.
- **Forced bridge, clean database**: `Paying through the channel/transfer bridge (asked for)`, 5/5 credited, `E2E demo PASSED`. This is the regression: same output as before this PR.
- **Second run, nothing left to pay**: 0 paid and still `E2E demo PASSED`, with the five credits confirmed in MifosX.
- **Connector against a database that had already been paid**: stops in about two seconds naming the reason, instead of waiting six minutes per payment.
- What the connector left in OpenSPP, read back over RPC: the payment manager with its Payment Hub endpoints, 5 batches each carrying the reference Payment Hub assigned, 5 payments in `reconciled`/`paid`, and the module's two scheduled actions switched on.

The **missing module** case was not run against an image built without it. The rail choice was exercised directly instead, with the Odoo lookup replaced by a stub that answers that the module is not there: `auto` warns and returns the bridge, a forced `connector` stops with an error naming the module, and a forced `bridge` never looks the module up.

## Notes for reviewers

### 1. Why the module is not in this repository
Its home was settled as upstream OpenSPP. This PR only adds the logic to use it when it happens to be present, so nothing here depends on a module upstream has not accepted.

### 2. Why the batches are counted on both sides
I hit this while validating. A prepare with nothing to do returns a notification, and a caller cannot tell that from a successful call, so the run polled for credits that could not arrive. Counting only after the call is not enough either: a cycle that was paid before still holds its old batches, so the count has to grow, not just be non-zero.

### 3. The bridge loop is untouched
The connector path is a separate function with an early return, so the diff adds lines and changes none of the existing payment loop. The bridge is what is merged and what most people will run.

## Checklist
- [x] The bridge payment loop is not touched or re-indented: the diff only adds lines.
- [x] Both rails run end to end from a clean database, on the same image, 5/5 credited and verified in core banking.
- [x] A forced bridge run prints the rail it took and gives the same result as before this PR.
- [x] A re-run with nothing left to pay pays nothing and still passes.
- [x] The module is detected when it is present but not installed, which is the state after a fresh deploy.
- [x] Forcing the connector without the module stops instead of falling back quietly.
- [x] A prepare that creates no batches stops the run instead of polling for credits that cannot arrive.
- [x] No new dependency: standard library plus what the demo already imports.
- [x] `bash -n` and `python3 -m py_compile` clean on the two files.

## AI usage
`claude-code` was used to help explain concepts, test the code, and with documentation. All output was reviewed, tested (see Evidence) and adjusted by the author.
