### PR TITLE
GAZ-319: Deploy message-gateway (SMS) as a MifosX module

### DIFF
--- a/src/deployer/helm/infra/values.yaml
+++ b/src/deployer/helm/infra/values.yaml
@@ -359,4 +359,6 @@ postgresql:
         # tables inside this database on first startup (schema-update=true).
         02-create-workflow-db.sql: |
           CREATE DATABASE mifos_flowable;
+        03-create-messagegateway-db.sql: |
+          CREATE DATABASE messagegateway;
 

--- a/src/deployer/manifests/mifosx/message-gateway-deployment.yaml
+++ b/src/deployer/manifests/mifosx/message-gateway-deployment.yaml
@@ -1,0 +1,81 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: message-gateway
+    tier: backend
+  name: message-gateway
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: message-gateway
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: message-gateway
+        tier: backend
+    spec:
+      initContainers:
+        - name: ensure-messagegateway-db
+          image: postgres:16-alpine
+          env:
+            - name: PGPASSWORD
+              value: "postgrespw"
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              until pg_isready -h postgres.infra.svc.cluster.local -p 5432 -U postgres; do
+                echo "waiting for postgres..."; sleep 3
+              done
+              if psql -h postgres.infra.svc.cluster.local -U postgres -tAc \
+                   "SELECT 1 FROM pg_database WHERE datname='messagegateway'" | grep -q 1; then
+                echo "messagegateway DB already exists"
+              else
+                echo "creating messagegateway DB"
+                createdb -h postgres.infra.svc.cluster.local -U postgres messagegateway
+              fi
+      containers:
+        - name: message-gateway
+          image: openmf/message-gateway:pull-85-1581967
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: DB_URL
+              value: "jdbc:postgresql://postgres.infra.svc.cluster.local:5432/messagegateway"
+            - name: DB_USERNAME
+              value: "postgres"
+            - name: DB_PASSWORD
+              value: "postgrespw"
+            - name: DB_DRIVER
+              value: "org.postgresql.Driver"
+          ports:
+            - containerPort: 9191
+              protocol: TCP
+            - containerPort: 5009
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 9191
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 9191
+            initialDelaySeconds: 60
+            periodSeconds: 20
+            failureThreshold: 3
+          resources:
+            requests:
+              memory: "512Mi"
+              cpu: "250m"
+            limits:
+              memory: "1Gi"
+              cpu: "1000m"
+      restartPolicy: Always

--- a/src/deployer/manifests/mifosx/message-gateway-deployment.yaml
+++ b/src/deployer/manifests/mifosx/message-gateway-deployment.yaml
@@ -41,7 +41,7 @@ spec:
               fi
       containers:
         - name: message-gateway
-          image: openmf/message-gateway:pull-85-1581967
+          image: openmf/message-gateway:dev-51abedb
           imagePullPolicy: IfNotPresent
           env:
             - name: DB_URL

--- a/src/deployer/manifests/mifosx/message-gateway-service.yaml
+++ b/src/deployer/manifests/mifosx/message-gateway-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    description: "Service for the Mifos message-gateway (SMS & messaging) component"
+  labels:
+    app: message-gateway
+    tier: backend
+  name: message-gateway
+spec:
+  ports:
+    - name: http
+      protocol: TCP
+      port: 9191
+      targetPort: 9191
+    - name: callback
+      protocol: TCP
+      port: 5009
+      targetPort: 5009
+  selector:
+    app: message-gateway


### PR DESCRIPTION
**Summary**

Adds the openMF message-gateway (SMS & messaging) component to the MifosX deployment:
- `message-gateway-deployment.yaml`: Deployment with an initContainer that creates the `messagegateway` DB on the shared Postgres; container on ports 9191 (REST/actuator) + 5009 (Camel callback); actuator health probes.
- `message-gateway-service.yaml`: ClusterIP Service (9191 + 5009).
- `infra/values.yaml`: `CREATE DATABASE messagegateway` in the Postgres init.

Verified via `./run.sh -m deploy -a mifosx`: pod healthy on the shared Postgres, Flyway applies the Postgres migrations, and a Dummy-provider send returns DELIVERED.

**Note**

Image is openmf/message-gateway:`dev-51abedb`, the official CI build from dev after both message-gateway PRs merged ([#85 Postgres](https://github.com/openMF/message-gateway/pull/85) +[ #86 type fix)](https://github.com/openMF/message-gateway/pull/86). Verified on the cluster: Fineract SMS campaign → gateway → DELIVERED end-to-end.
