### PR TITLE
GAZ-318: Deploy Loan Assessment (reactive loan module) as a MifosX module

### DIFF
--- a/src/deployer/helm/infra/values.yaml
+++ b/src/deployer/helm/infra/values.yaml
@@ -361,4 +361,6 @@ postgresql:
           CREATE DATABASE mifos_flowable;
         03-create-messagegateway-db.sql: |
           CREATE DATABASE messagegateway;
+        04-create-loanrisk-db.sql: |
+          CREATE DATABASE loanrisk;
 

--- a/src/deployer/manifests/mifosx/fineract-server-deployment.yaml
+++ b/src/deployer/manifests/mifosx/fineract-server-deployment.yaml
@@ -65,6 +65,29 @@ spec:
               name: fineract-etcfonts
             - mountPath: /nativelibs
               name: fineract-nativelibs
+        # Enable the external-event types the Loan Assessment module consumes.
+        # Runs after the DB dump restore and before Fineract boots, so the app
+        # reads the enabled config at startup. Only the "default" tenant is set:
+        # the module calls Fineract back with a single, fixed tenant id.
+        - name: enable-loan-events
+          image: postgres:16-alpine
+          env:
+            - name: PGPASSWORD
+              value: "postgrespw"
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              until pg_isready -h postgres.infra.svc.cluster.local -p 5432 -U postgres; do
+                echo "waiting for postgres..."; sleep 3
+              done
+              psql -h postgres.infra.svc.cluster.local -U postgres -d fineract_default -v ON_ERROR_STOP=1 -c \
+                "UPDATE m_external_event_configuration SET enabled = true WHERE type IN (
+                   'LoanCreatedBusinessEvent','LoanApplicationModifiedBusinessEvent',
+                   'LoanRejectedBusinessEvent','LoanWithdrawnByApplicantBusinessEvent',
+                   'DocumentCreatedBusinessEvent','DocumentDeletedBusinessEvent');"
+              echo "loan/document external events enabled on tenant 'default'"
       containers:
         - env:
             - name: JAVA_TOOL_OPTIONS
@@ -136,6 +159,13 @@ spec:
               value: "/opt/nativelibs"
             - name: FONTCONFIG_PATH
               value: "/etc/fonts"
+            # External events -> Kafka, consumed by the Loan Assessment module.
+            - name: FINERACT_EXTERNAL_EVENTS_ENABLED
+              value: "true"
+            - name: FINERACT_EXTERNAL_EVENTS_KAFKA_ENABLED
+              value: "true"
+            - name: FINERACT_EXTERNAL_EVENTS_KAFKA_BOOTSTRAP_SERVERS
+              value: "kafka.infra.svc.cluster.local:9092"
           #image: openmf/fineract:develop
           #image: openmf/fineract:1.11
           image: openmf/fineract:1.14.0

--- a/src/deployer/manifests/mifosx/loan-module-deployment.yaml
+++ b/src/deployer/manifests/mifosx/loan-module-deployment.yaml
@@ -1,0 +1,93 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: loan-module
+    tier: backend
+  name: loan-module
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: loan-module
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: loan-module
+        tier: backend
+    spec:
+      initContainers:
+        - name: ensure-loanrisk-db
+          image: postgres:16-alpine
+          env:
+            - name: PGPASSWORD
+              value: "postgrespw"
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              until pg_isready -h postgres.infra.svc.cluster.local -p 5432 -U postgres; do
+                echo "waiting for postgres..."; sleep 3
+              done
+              if psql -h postgres.infra.svc.cluster.local -U postgres -tAc \
+                   "SELECT 1 FROM pg_database WHERE datname='loanrisk'" | grep -q 1; then
+                echo "loanrisk DB already exists"
+              else
+                echo "creating loanrisk DB"
+                createdb -h postgres.infra.svc.cluster.local -U postgres loanrisk
+              fi
+      containers:
+        - name: loan-module
+          image: kanishksingh23/mifos-x-reactive-loan-module:09082026
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: SPRING_R2DBC_URL
+              value: "r2dbc:postgresql://postgres.infra.svc.cluster.local:5432/loanrisk"
+            - name: SPRING_R2DBC_USERNAME
+              value: "postgres"
+            - name: SPRING_R2DBC_PASSWORD
+              value: "postgrespw"
+            - name: SPRING_LIQUIBASE_URL
+              value: "jdbc:postgresql://postgres.infra.svc.cluster.local:5432/loanrisk"
+            - name: SPRING_LIQUIBASE_USER
+              value: "postgres"
+            - name: SPRING_LIQUIBASE_PASSWORD
+              value: "postgrespw"
+            - name: SPRING_KAFKA_BOOTSTRAP_SERVERS
+              value: "kafka.infra.svc.cluster.local:9092"
+            - name: FINERACT_BASE_URL
+              value: "http://fineract-server:8080/fineract-provider/api/v1"
+            - name: FINERACT_USERNAME
+              value: "mifos"
+            - name: FINERACT_PASSWORD
+              value: "password"
+            - name: FINERACT_TENANT_ID
+              value: "default"
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 20
+            failureThreshold: 3
+          resources:
+            requests:
+              memory: "384Mi"
+              cpu: "100m"
+            limits:
+              memory: "640Mi"
+              cpu: "500m"
+      restartPolicy: Always

--- a/src/deployer/manifests/mifosx/loan-module-ingress.yaml
+++ b/src/deployer/manifests/mifosx/loan-module-ingress.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: loan-module-ingress
+  annotations:
+    ingress.kubernetes.io/ssl-redirect: "false"
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: loan-module.mifos.gazelle.test
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: loan-module
+            port:
+              number: 8080

--- a/src/deployer/manifests/mifosx/loan-module-service.yaml
+++ b/src/deployer/manifests/mifosx/loan-module-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    description: "Service for the Mifos reactive loan risk-assessment module"
+  labels:
+    app: loan-module
+    tier: backend
+  name: loan-module
+spec:
+  ports:
+    - name: http
+      protocol: TCP
+      port: 8080
+      targetPort: 8080
+  selector:
+    app: loan-module

--- a/src/deployer/mifosx.sh
+++ b/src/deployer/mifosx.sh
@@ -89,6 +89,7 @@ deploy_mifosx_from_yaml() {
     apply_domain_to_file "$MIFOSX_MANIFESTS_DIR/web-app-ingress.yaml" "$GAZELLE_DOMAIN"
     apply_domain_to_file "$MIFOSX_MANIFESTS_DIR/mifos-workflow-ingress.yaml" "$GAZELLE_DOMAIN"
     apply_domain_to_file "$MIFOSX_MANIFESTS_DIR/credit-bureau-ingress.yaml" "$GAZELLE_DOMAIN"
+    apply_domain_to_file "$MIFOSX_MANIFESTS_DIR/loan-module-ingress.yaml" "$GAZELLE_DOMAIN"
     log_ok
 
     check_mifosx_images "$MIFOSX_MANIFESTS_DIR"


### PR DESCRIPTION
**Summary**

Deploys the Loan Assessment module as a MifosX component. It is a reactive (WebFlux + R2DBC) service that consumes Fineract loan and document business events from Kafka and records a per-loan risk-assessment record.

- New `loan-module` Deployment / Service / Ingress.
- Owns the `loanrisk` database on the shared Postgres (created in `helm/infra/values.yaml`, and ensured at runtime by an initContainer so redeploys are self-healing).
- Wires Fineract to publish external events to the shared Kafka (`FINERACT_EXTERNAL_EVENTS_ENABLED` / `_KAFKA_ENABLED` / `_KAFKA_BOOTSTRAP_SERVERS`).
- Enables the six event types the module handles (four loan + two document) on the `default` tenant, via an initContainer that runs after the DB dump restore and before Fineract boots, so Fineract reads them enabled at startup.

Verified with `./run.sh -m deploy -a mifosx`: the loan-module pod comes up, the initContainer enables the events, and a loan submitted in Fineract flows through Kafka into the module's `loanrisk` DB (aggregator + snapshot).

**Note**

- The module image (`kanishksingh23/mifos-x-reactive-loan-module:09082026`) is a personal-namespace, multi-arch build until it is published under openMF.
- Requires the Dockerfile base fix in [#51](https://github.com/openMF/mifos-x-reactive-loan-module/pull/51) to build.
- The module calls Fineract back with a single fixed tenant id (`default`), so events are enabled only on that tenant to avoid cross-tenant callback mismatches.
