### PR TITLE
GAZ-341: reach OpenSPP through the Gazelle ingress in the credit demo

### DIFF
--- a/demos/openspp/run_credit_demo.sh
+++ b/demos/openspp/run_credit_demo.sh
@@ -22,13 +22,14 @@ PROGRAM_NAME="Agri subsidy Q3"
 # a machine deployed without that ingress needs.
 ORIGINATION="${ORIGINATION:-}"
 DOMAIN="$(crudini --get "$CONFIG" general GAZELLE_DOMAIN 2>/dev/null || echo mifos.gazelle.test)"
+OPENSPP_HOST="openspp.$DOMAIN"
 
 log() { echo -e "\n\033[1;34m==> $*\033[0m"; }
 ok()  { echo -e "\033[1;32mOK $*\033[0m"; }
 err() { echo -e "\033[1;31mFAIL $*\033[0m"; }
 
 PF_PID=""
-OPENSPP_URL=""
+OPENSPP_URL="${OPENSPP_URL:-}"   # set by open_openspp_channel, or given in the environment
 cleanup() { [ -n "$PF_PID" ] && kill "$PF_PID" 2>/dev/null || true; }
 trap cleanup EXIT
 
@@ -44,11 +45,57 @@ check_namespaces() {
     done
 }
 
-# OpenSPP is reached over a port-forward, with the local port left to kubectl: a fixed one can
-# already be taken, and if what holds it is another forward the demo would talk to a different
-# OpenSPP without saying so.
+# Wait up to a minute for Odoo to answer. -k because the ingress certificate is self-signed.
+wait_for_openspp_health() {
+    local url="$1" code=000 i
+    for i in $(seq 12); do
+        code=$(curl -k -s -o /dev/null -w '%{http_code}' "$url/web/health") || code=000
+        [ "$code" = "200" ] && break
+        sleep 5
+    done
+    echo "  openspp health=$code"
+    [ "$code" = "200" ]
+}
+
+# True when the Gazelle ingress serves OpenSPP here. The curl exit code tells the cases
+# apart: 6 the hostname does not resolve, 7 nothing listens on it. A 404 means nginx has no
+# rule for this host, retried because a new Ingress takes a moment to be picked up. Any
+# other reply means the rule is there, so a pod still starting is left to the health wait.
+ingress_available() {
+    local code rc i
+    for i in 1 2 3; do
+        if code=$(curl -k -s -m 5 -o /dev/null -w '%{http_code}' "https://$OPENSPP_HOST/web/health"); then
+            rc=0
+        else
+            rc=$?
+        fi
+        case "$rc" in
+            0) [ "$code" = "404" ] || return 0 ;;
+            6) echo "  ingress not usable: $OPENSPP_HOST does not resolve" ; return 1 ;;
+            7) echo "  ingress not usable: nothing is listening on $OPENSPP_HOST:443" ; return 1 ;;
+            *) echo "  ingress not usable: curl exit $rc on https://$OPENSPP_HOST" ; return 1 ;;
+        esac
+        sleep 2
+    done
+    echo "  ingress not usable: no ingress rule for $OPENSPP_HOST (nginx returned 404)"
+    return 1
+}
+
+# Say which OpenSPP this is, because a hostname and kubectl can point at different clusters.
+report_openspp_target() {
+    local ip ctx
+    # python3 and not getent, which does not exist on macOS.
+    ip=$(python3 -c "import socket, sys; print(socket.gethostbyname(sys.argv[1]))" \
+         "$OPENSPP_HOST" 2>/dev/null || echo unknown)
+    ctx=$(kubectl config current-context 2>/dev/null || echo unknown)
+    echo "  $OPENSPP_HOST resolves to $ip, kubectl context is $ctx"
+}
+
+# Fallback channel. The local port is left to kubectl: a fixed one can already be taken, and
+# if what holds it is another forward the demo would talk to a different OpenSPP without
+# saying so.
 open_openspp_portforward() {
-    log "Port-forward to OpenSPP (svc/openspp-odoo 8069)"
+    echo "  falling back to a port-forward (svc/openspp-odoo 8069)"
     kubectl port-forward -n openspp svc/openspp-odoo :8069 >/tmp/openspp-credit-pf.log 2>&1 &
     PF_PID=$!
     local port="" i
@@ -63,15 +110,24 @@ open_openspp_portforward() {
     fi
     OPENSPP_URL="http://localhost:$port"
     echo "  forwarding on $OPENSPP_URL"
+}
 
-    local code=000
-    for i in $(seq 12); do
-        sleep 5
-        code=$(curl -s -o /dev/null -w '%{http_code}' "$OPENSPP_URL/web/health") || code=000
-        [ "$code" = "200" ] && break
-    done
-    echo "  openspp health=$code"
-    if [ "$code" != "200" ]; then
+# OpenSPP is reached over the Gazelle ingress, like every other service in this demo. The
+# port-forward is the fallback for a machine where that hostname does not resolve, such as
+# one set up against a remote cluster. OPENSPP_URL overrides both.
+open_openspp_channel() {
+    log "Reach OpenSPP"
+    if [ -n "$OPENSPP_URL" ]; then
+        echo "  using OPENSPP_URL from the environment: $OPENSPP_URL"
+    elif ingress_available; then
+        OPENSPP_URL="https://$OPENSPP_HOST"
+        echo "  using the Gazelle ingress: $OPENSPP_URL"
+        report_openspp_target
+    else
+        open_openspp_portforward
+    fi
+
+    if ! wait_for_openspp_health "$OPENSPP_URL"; then
         err "OpenSPP did not answer on $OPENSPP_URL after a minute"
         exit 1
     fi
@@ -94,7 +150,7 @@ decide_and_lend() {
 
 main() {
     check_namespaces
-    open_openspp_portforward
+    open_openspp_channel
     load_registry
 
     log "Decide the credit from the registry and open the loans"

--- a/docs/OPENSPP.md
+++ b/docs/OPENSPP.md
@@ -337,8 +337,9 @@ bash demos/openspp/run_credit_demo.sh
 Payment Hub and the switch are not involved: the bank lends to its own client, so no money crosses
 institutions.
 
-It reaches OpenSPP over a `kubectl port-forward`, and says which port it opened. MifosX and the
-workflow engine it reads by hostname, so the Gazelle names still have to resolve.
+It reaches OpenSPP the same way the subsidy demo does, over the Gazelle ingress with the port-forward
+as the fallback. MifosX and the workflow engine it reads by hostname, so the Gazelle names still have
+to resolve.
 
 ### How the registry decides
 

--- a/src/utils/openspp/openspp-agri-credit.py
+++ b/src/utils/openspp/openspp-agri-credit.py
@@ -22,7 +22,6 @@ import argparse
 import datetime
 import importlib.util
 import sys
-import xmlrpc.client
 from pathlib import Path
 
 import requests
@@ -87,10 +86,10 @@ def openspp_call(url, db, user, password):
     Odoo's XML-RPC API keeps no session, so the database, user id and password travel on
     every call and the closure carries them.
     """
-    uid = xmlrpc.client.ServerProxy(f"{url}/xmlrpc/2/common").authenticate(db, user, password, {})
+    uid = loader.xmlrpc_proxy(f"{url}/xmlrpc/2/common").authenticate(db, user, password, {})
     if not uid:
         sys.exit(f"ERROR: OpenSPP auth failed for {user}@{db}")
-    models = xmlrpc.client.ServerProxy(f"{url}/xmlrpc/2/object")
+    models = loader.xmlrpc_proxy(f"{url}/xmlrpc/2/object")
 
     def call(model, method, *args, **keywords):
         return models.execute_kw(db, uid, password, model, method, list(args), keywords)


### PR DESCRIPTION
## Summary
The subsidy demo reaches OpenSPP through the Gazelle ingress since gaz 320, with a port-forward as
the fallback. The credit demo, which landed later in gaz 338, still reaches it only over a
port-forward. Two demos in the same directory, described in the same guide, arriving at the same
service in two different ways.

This gives the credit demo the channel the subsidy demo already has. Nothing stops working today, so
this is consistency rather than a fix: the credit demo already needs `mifos.<domain>` and
`workflow.<domain>` to resolve, so the port-forward was only covering one of the three names.

## Ticket
GAZ-341, sub-task of gaz 192. Cut off current `dev`.

## What is included
- `demos/openspp/run_credit_demo.sh`: the port-forward block is replaced by the channel selection the
  subsidy demo uses, fallback included.
- `src/utils/openspp/openspp-agri-credit.py`: the XML-RPC proxies come from the loader helper, so they
  accept the self-signed ingress certificate.
- `docs/OPENSPP.md`: the credit demo section says which channel it uses.

## How it works
The channel code is copied from `demos/openspp/run_demo.sh`, not written again: the ingress is used
when the OpenSPP hostname answers, a port-forward when it does not, and `OPENSPP_URL` overrides both.
`curl` exit codes 6 and 7 tell "the name does not resolve" apart from "nothing listens there", and a
404 means nginx has no rule for that host. Each case prints why it was not usable.

`xmlrpc.client` has no equivalent to `verify=False`, so it needs an `SSLContext` to talk to the
ingress. That helper already exists in `load-openspp-agri-data.py`, and the credit script already
imports that module, so it is reused rather than copied a third time.

## Checklist
- [x] Clean deployment, direct rail: five loans opened over the ingress, with the amounts the guide
      documents. A second run opens none.
- [x] Both module installs the demo does, `spp_starter_farmer_registry` and `spp_scoring`, go through
      nginx now, and both went through untouched.
- [x] The workflow rail runs over the same channel.
- [x] The fallback was forced by pointing the domain at a name that does not resolve, and it said why
      before falling back.
- [x] `OPENSPP_URL` from the environment wins over both, on a full run.
- [x] No new dependency.

## AI usage
`claude-code` was used to help explain concepts, test the code, and with documentation. All output
was reviewed, tested and adjusted by the author.