### PR TITLE
GAZ-342: Fix workflow wait-fineract init hanging on ARM64 when apk add curl fails

### DIFF
--- a/src/deployer/manifests/mifosx/fineract-server-deployment.yaml
+++ b/src/deployer/manifests/mifosx/fineract-server-deployment.yaml
@@ -26,7 +26,8 @@ spec:
             - -c
             - |
               set -e
-              apk add --no-cache curl python3 font-dejavu fontconfig >/dev/null
+              apk add --no-cache curl python3 font-dejavu fontconfig \
+                || { echo "ERROR: apk add failed (curl/python3/fonts) — is the Alpine mirror reachable?"; exit 1; }
               echo "Downloading MifosReportingPlugin-1.14.0..."
               curl -fsSL -o /tmp/mrp.zip \
                 "https://sourceforge.net/projects/mifos/files/mifos-plugins/MifosReportingPlugin/MifosReportingPlugin-1.14.0.zip/download"

--- a/src/deployer/manifests/mifosx/mifos-workflow-deployment.yaml
+++ b/src/deployer/manifests/mifosx/mifos-workflow-deployment.yaml
@@ -35,15 +35,14 @@ spec:
               done
               echo "Postgres is reachable."
         - name: wait-fineract
-          image: alpine:3.20
+          image: busybox:1.36
           command:
             - /bin/sh
             - -c
             - |
-              apk add --no-cache curl >/dev/null
               url="http://fineract-server:8080/fineract-provider/actuator/health/readiness"
               echo "Waiting for Fineract readiness ($url)..."
-              until curl -fsS "$url" >/dev/null 2>&1; do
+              until wget -q --spider "$url"; do
                 echo "  fineract not ready yet — retrying in 5s"; sleep 5
               done
               echo "Fineract is ready."


### PR DESCRIPTION
## Summary

On a fresh deploy on ARM64 (OCI ARM64 / Pi / busy nodes), the `mifos-workflow` pod hangs forever, its `wait-fineract` init container loops on "fineract not ready yet", and the module never starts.

**Root cause:** the init container installs curl at pod start (`apk add --no-cache curl >/dev/null`) and, if that fails on ARM64/busy nodes, the failure is masked (`>/dev/null`) and unchecked, so the following `until curl … 2>&1` loop can never succeed and spins silently forever.

- `wait-fineract` -> switched to `busybox:1.36` + `wget -q --spider` (busybox bundles wget -> no runtime install -> failure mode eliminated). Matches the `wait-postgres` init right above it.
- `fineract-server` reporting init -> same `apk` pattern (needs python3+fonts, can't be busybox); made the apk failure loud + fatal instead of masked, so it's visible in logs.

## Note

- Verified on a live cluster: workflow and Fineract both come up `1/1`, `restarts=0`, all mifosx pods healthy; busybox `wget --spider` returns correct exit codes for every readiness state (200 -> ready, connection-refused/non-2xx -> keep waiting).
- Not yet run on ARM64 hardware, but the workflow fix removes the failing `apk` step entirely.
- Root cause identified by @tdaly61  debugging on ARM64.