### PR TITLE
GAZ-319: Expose the message gateway through an ingress

### DIFF
--- a/src/deployer/manifests/mifosx/message-gateway-ingress.yaml
+++ b/src/deployer/manifests/mifosx/message-gateway-ingress.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: message-gateway-ingress
+  annotations:
+    ingress.kubernetes.io/ssl-redirect: "false"
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: message-gateway.mifos.gazelle.test
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: message-gateway
+            port:
+              number: 9191

--- a/src/deployer/mifosx.sh
+++ b/src/deployer/mifosx.sh
@@ -90,6 +90,7 @@ deploy_mifosx_from_yaml() {
     apply_domain_to_file "$MIFOSX_MANIFESTS_DIR/mifos-workflow-ingress.yaml" "$GAZELLE_DOMAIN"
     apply_domain_to_file "$MIFOSX_MANIFESTS_DIR/credit-bureau-ingress.yaml" "$GAZELLE_DOMAIN"
     apply_domain_to_file "$MIFOSX_MANIFESTS_DIR/loan-module-ingress.yaml" "$GAZELLE_DOMAIN"
+    apply_domain_to_file "$MIFOSX_MANIFESTS_DIR/message-gateway-ingress.yaml" "$GAZELLE_DOMAIN"
     log_ok
 
     check_mifosx_images "$MIFOSX_MANIFESTS_DIR"

--- a/src/environmentSetup/environmentSetup.sh
+++ b/src/environmentSetup/environmentSetup.sh
@@ -155,7 +155,8 @@ add_hosts() {
             zeebeops.$DOMAIN zeebe-operate.$DOMAIN zeebe-gateway.$DOMAIN \
             notifications.$DOMAIN )
 
-        local MIFOSXHOSTS=( mifos.$DOMAIN workflow.$DOMAIN credit-bureau.$DOMAIN )
+        local MIFOSXHOSTS=( mifos.$DOMAIN workflow.$DOMAIN credit-bureau.$DOMAIN \
+            loan-module.$DOMAIN message-gateway.$DOMAIN )
         local OPENSPPHOSTS=( openspp.$DOMAIN )
         local OPENG2PHOSTS=( openg2p.$DOMAIN social-registry.$DOMAIN \
             pbms.$DOMAIN spar.$DOMAIN g2p-bridge.$DOMAIN \


### PR DESCRIPTION
## Summary

The message gateway was deployed without an ingress, so the only way to reach it
was `kubectl port-forward`, unlike every other Gazelle service.

- Add `message-gateway-ingress.yaml` on `message-gateway.<GAZELLE_DOMAIN>`,
  pointing to the REST API port `9191`.
- Add that hostname to `MIFOSXHOSTS` so `setup-env.sh` writes its `/etc/hosts` entry.
- Add an `apply_domain_to_file` call for the new ingress in `mifosx.sh`. Domain
  substitution is applied per file rather than across the manifest directory, so a
  new ingress does not pick it up on its own.

Verified with `./run.sh -m deploy -a mifosx`: all five MifosX ingresses are created
with the substituted domain, and the message gateway returns 200 on
`/actuator/health` through the ingress.

## Note

- Also fixes the loan module hostname (GAZ-318), a one-line change.
  `loan-module-ingress.yaml` shipped with the host `loan-module.<GAZELLE_DOMAIN>`,
  but that hostname was never added to `MIFOSXHOSTS`, so `setup-env.sh` never wrote
  its `/etc/hosts` entry and the ingress could not be resolved by name. Both
  hostnames live on the same `MIFOSXHOSTS` line, so the fix comes in here rather
  than as a separate PR. Verified the same way `loan-module` returns 200 on
  `/actuator/health` through its ingress.
- Existing installations need `sudo ./setup-env.sh -u $USER` to be re-run to pick up the
  two new `/etc/hosts` entries.