### PR TITLE
GAZ-345: Add preflight to demo-credit-bureau.sh so it fails clearly if MifosX is not deployed

### DIFF
--- a/src/utils/demo-credit-bureau.sh
+++ b/src/utils/demo-credit-bureau.sh
@@ -10,6 +10,8 @@ set -euo pipefail
 
 RED='\033[0;31m'; GREEN='\033[0;32m'; BLUE='\033[0;34m'; YELLOW='\033[0;33m'; RESET='\033[0m'
 
+fail() { echo -e "${RED}ERROR: $*${RESET}" >&2; exit 1; }
+
 NAMESPACE="mifosx"
 CB_SERVICE="credit-bureau"
 CB_PORT=8081
@@ -41,6 +43,13 @@ done
 for tool in kubectl jq curl; do
   command -v "$tool" >/dev/null 2>&1 || { echo -e "${RED}Error: '$tool' is required.${RESET}"; exit 1; }
 done
+
+# Preflight: MifosX and the Credit Bureau module must be deployed, otherwise the
+# port-forward below fails silently and the demo just hangs.
+kubectl get namespace "$NAMESPACE" >/dev/null 2>&1 \
+  || fail "namespace '$NAMESPACE' not found — is MifosX deployed? Run: ./run.sh -m deploy -a mifosx"
+kubectl get svc "$CB_SERVICE" -n "$NAMESPACE" >/dev/null 2>&1 \
+  || fail "service '$CB_SERVICE' not found in '$NAMESPACE' — is the Credit Bureau module deployed? Run: ./run.sh -m deploy -a mifosx"
 
 # --- Start port-forward to the ClusterIP service --------------------------------
 echo -e "${BLUE}Connecting to $CB_SERVICE in namespace $NAMESPACE ...${RESET}"


### PR DESCRIPTION
**Summary**

Adds a preflight to `src/utils/demo-credit-bureau.sh` so it fails immediately with a clear message when MifosX isn't deployed, instead of backgrounding a port-forward and hanging before a vague error. Matches the preflight already in `demo-message-gateway.sh` and `demo-loan-module.sh`.

## Note

- Adds a `fail()` helper plus checks that the `mifosx` namespace and `credit-bureau` service exist.
- Verified: `./demo-credit-bureau.sh -n doesnotexist` now exits with "`Is MifosX deployed? Run: .run.sh -m deploy -a mifosx"
`