### PR TITLE
GAZ-309: Add MifosX Upgrade runbook and VERSIONS.md

### DIFF
--- a/docs/MIFOSX.md
+++ b/docs/MIFOSX.md
@@ -109,7 +109,7 @@ Components deployed into the `mifosx` namespace:
 | Fineract | `fineract-server` pod | `openmf/fineract:1.14.0` | Core banking engine and API |
 | Web App | `web-app` pod + ingress | `openmf/web-app:dev-10d24b8` | Angular user interface |
 | Reports | *inside* `fineract-server` | plugin staged by initContainer | Pentaho formatted reporting |
-| Workflow Engine | `mifos-workflow` pod + ingress | `kanishksingh23/mifos-workflow:07082026` | Flowable BPMN process orchestration |
+| Workflow Engine | `mifos-workflow` pod + ingress | `kanishksingh23/mifos-workflow:21082026` | Flowable BPMN process orchestration |
 | Credit Bureau | `credit-bureau` pod + ingress | `kanishksingh23/mifos-credit-bureau:21082026` | Credit bureau integration |
 | SMS & Messaging | `message-gateway` pod + ingress | `openmf/message-gateway:dev-51abedb` | SMS and email delivery |
 | Loan Assessment | `loan-module` pod + ingress | `kanishksingh23/mifos-x-reactive-loan-module:09082026` | Reactive loan risk assessment |
@@ -159,7 +159,7 @@ Every MifosX component stores its data in one shared PostgreSQL instance. It is 
 | Image | `bitnamilegacy/postgresql:16.6.0` |
 | In-cluster host | `postgres.infra.svc.cluster.local:5432` |
 | Fineract databases | `fineract_tenants`, plus one per tenant — `greenbank`, `bluebank`, `redbank`, `fineract_default` |
-| Module databases | `mifos_flowable` (Workflow Engine) · `creditbureau` (Credit Bureau) |
+| Module databases | `mifos_flowable` (Workflow Engine) · `creditbureau` (Credit Bureau) · `messagegateway` (SMS & Messaging) · `loanrisk` (Loan Assessment) |
 
 MifosX ran on MySQL/MariaDB before Gazelle standardised on PostgreSQL. Sharing a single instance rather than giving each module its own database pod is what keeps the deployment inside Gazelle's 16GB memory budget. Gazelle still runs MySQL, but only for Payment Hub EE — no MifosX component uses it.
 
@@ -221,13 +221,18 @@ curl -X POST http://workflow.<GAZELLE_DOMAIN>/api/v1/auth/authenticate \
   -d '{"username":"mifos","password":"password"}'
 ```
 
-It returns `"authenticated":true`. Confirm with `GET /api/v1/auth/status`, then call the workflow endpoints:
+It returns `"authenticated":true`. Confirm with `GET /api/v1/auth/status`, then start a process. `firstName`, `lastName`, `officeId`, `legalFormId`, `active`, `dateFormat` and `locale` are all required:
 
 ```bash
-curl http://workflow.<GAZELLE_DOMAIN>/api/v1/workflow/client-onboarding/tasks
-
 curl -X POST http://workflow.<GAZELLE_DOMAIN>/api/v1/workflow/client-onboarding/start \
-  -H 'Content-Type: application/json' -d '{ ... }'
+  -H 'Content-Type: application/json' \
+  -d '{
+        "firstName": "Ada", "lastName": "Lovelace",
+        "officeId": 1, "legalFormId": 1, "active": false,
+        "dateFormat": "dd MMMM yyyy", "locale": "en"
+      }'
+
+curl http://workflow.<GAZELLE_DOMAIN>/api/v1/workflow/client-onboarding/tasks
 ```
 
 **Onboard a client end-to-end with one command.** `src/utils/demo-workflow.sh` runs a full client-onboarding process — it authenticates, ensures a loan officer exists, creates a client, approves the verification task (which assigns the officer and activates the client), and confirms the client is **Active** in Fineract:
@@ -289,7 +294,17 @@ An `ensure-messagegateway-db` initContainer creates the database if it does not 
 curl http://message-gateway.<GAZELLE_DOMAIN>/actuator/health
 ```
 
-No SMS or email provider credentials are configured in Gazelle, so the gateway accepts and records requests but cannot deliver to a real handset. Configuring a live provider is a deployment-time decision, not something Gazelle presumes.
+**A message needs a bridge before it can be sent.** `POST /sms` dispatches through the provider bridge named in the request; with no bridge registered the call fails with a 500. Register one first — the gateway ships a built-in `Dummy` provider, which is what Gazelle uses:
+
+```bash
+curl -X POST http://message-gateway.<GAZELLE_DOMAIN>/smsbridges \
+  -H 'Content-Type: application/json' \
+  -H 'Fineract-Platform-TenantId: <tenant>' \
+  -H 'Fineract-Tenant-App-Key: <app key>' \
+  -d '{"phoneNo":"+10000000000","providerName":"Dummy","providerKey":"Dummy","countryCode":"1"}'
+```
+
+No real SMS or email provider credentials are configured in Gazelle, so nothing leaves the cluster: the Dummy provider sets the delivery status from the message body. Configuring a live provider is a deployment-time decision, not something Gazelle presumes.
 
 **Send a message end-to-end with one command.** `src/utils/demo-message-gateway.sh` registers a demo tenant, wires up the built-in Dummy provider, sends a message and polls until the gateway marks it `DELIVERED` — a simulated delivery that exercises the whole Fineract → gateway → provider → status pipeline without a real provider:
 
@@ -369,7 +384,7 @@ Each extension module has its own ingress — browse or `curl` them at `http://w
 
 ### /etc/hosts entries
 
-`setup-env.sh` writes these automatically. If you set the machine up before the workflow and credit bureau ingresses were added, re-run `sudo ./setup-env.sh -u $USER` to pick up the two new hostnames.
+`setup-env.sh` writes these automatically. If you set the machine up before a module's ingress was added, re-run `sudo ./setup-env.sh -u $USER` to pick up its hostname.
 
 ```
 # Linux/macOS
@@ -435,7 +450,7 @@ After publishing, update the `image:` pin in the module's manifest under `src/de
 
 ## Adding a New MifosX Module
 
-The three modules integrated so far follow one pattern. To add a fourth:
+The five extension modules integrated so far follow one pattern. To add another:
 
 1. **Check the database.** Gazelle's MifosX stack is PostgreSQL-only. If the module is tied to MySQL, make it database-agnostic at source — add the PostgreSQL driver alongside the existing one, make the datasource environment-overridable, keep the upstream default unchanged, and remove any hardcoded dialect. That keeps the change upstreamable instead of creating a fork.
 2. **Build a multi-architecture image.** Gazelle targets amd64 and arm64 — an amd64-only image breaks Apple Silicon and Raspberry Pi deployments. Use the repo's own builder rather than raw `docker buildx`; see [Building images for Gazelle](BUILDING-IMAGES.md):
@@ -453,7 +468,7 @@ The three modules integrated so far follow one pattern. To add a fourth:
 
 ## Version Pins
 
-All image tags are pinned — no `:latest`. The current pins live in the manifests under `src/deployer/manifests/mifosx/`; the components and their tags are listed in the table under [How It Fits into Mifos Gazelle](#how-it-fits-into-mifos-gazelle).
+All image tags are pinned — no `:latest`. [VERSIONS.md](../src/deployer/manifests/mifosx/VERSIONS.md) is the single source of truth: it lists every application and helper image, the Pentaho plugin, and the shared PostgreSQL, each with the manifest it is pinned in. [UPGRADE-RUNBOOK.md](UPGRADE-RUNBOOK.md) covers adopting a future MifosX release.
 
 ---
 
@@ -462,7 +477,7 @@ All image tags are pinned — no `:latest`. The current pins live in the manifes
 - **Pentaho per-tenant routing needs a fixed plugin release.** The published plugin resolves its datasource in a way that can return another tenant's data. The fix is a two-line change, merged upstream into `openMF/mifos-reporting-plugin` ([PR #513](https://github.com/openMF/mifos-reporting-plugin/pull/513), `pentaho` branch), but **no fixed release has been published yet** and Gazelle installs the published artifact. Until a fixed release ships, treat multi-tenant report output as unreliable. Closing this needs either a new plugin release or a temporary class swap in the initContainer.
 - **The Workflow Engine, Credit Bureau and Loan Assessment images are temporary.** None of those projects publishes a container image, so all three are built from source and currently pushed to a personal DockerHub namespace. All three pins should move to `openMF` images once those are published — see [Building the Module Images](#building-the-module-images) for the build and publish commands.
 - **The Loan Assessment module only sees the `default` tenant.** The `enable-loan-events` initContainer enables external events on that tenant alone, so loan activity on `greenbank`, `bluebank` or `redbank` produces no events for it to consume. Widening it means editing that initContainer in `fineract-server-deployment.yaml`, not the module.
-- **No SMS or email provider is configured.** The message gateway accepts and records requests, but with no provider credentials it cannot deliver to a real handset or mailbox. Wiring a live provider is a deployment-time decision.
+- **No real SMS or email provider is configured.** The message gateway sends through its built-in `Dummy` provider, which simulates delivery inside the cluster — nothing reaches a real handset or mailbox. A message also needs a provider bridge registered before `POST /sms` will accept it; without one the call returns a 500. Wiring a live provider is a deployment-time decision.
 - **`redbank` is not selectable in the web app.** It is seeded and waited on at deploy time, but absent from the web app's tenant list, so it is reachable through the API only.
 
 ---

--- a/docs/MIFOSX.md
+++ b/docs/MIFOSX.md
@@ -301,7 +301,7 @@ curl -X POST http://message-gateway.<GAZELLE_DOMAIN>/smsbridges \
   -H 'Content-Type: application/json' \
   -H 'Fineract-Platform-TenantId: <tenant>' \
   -H 'Fineract-Tenant-App-Key: <app key>' \
-  -d '{"phoneNo":"+10000000000","providerName":"Dummy","providerKey":"Dummy","countryCode":"1"}'
+  -d '{"phoneNo":"+10000000000","providerName":"Dummy","providerKey":"Dummy","countryCode":"1","providerDescription":"Dummy demo provider"}'
 ```
 
 No real SMS or email provider credentials are configured in Gazelle, so nothing leaves the cluster: the Dummy provider sets the delivery status from the message body. Configuring a live provider is a deployment-time decision, not something Gazelle presumes.

--- a/docs/UPGRADE-RUNBOOK.md
+++ b/docs/UPGRADE-RUNBOOK.md
@@ -1,0 +1,96 @@
+# Upgrading MifosX in Mifos Gazelle
+
+A checklist for adopting a future MifosX release. Gazelle currently tracks **25.12.25**; the pins that make up that release line live in [VERSIONS.md](../src/deployer/manifests/mifosx/VERSIONS.md), and [MIFOSX.md](MIFOSX.md) describes what each component is and how to use it.
+
+Most of an upgrade is changing pins and rebuilding the images Gazelle builds itself. Work through the steps in order — later ones assume the pins are already settled.
+
+---
+
+## 1. Find out what changed
+
+MifosX releases are published on [SourceForge](https://sourceforge.net/projects/mifos/files/) using a `YY.MM.DD` scheme, and a release bundles specific versions of Fineract, the web app and PostgreSQL. Read the release notes for the target version and write down the new versions before touching anything.
+
+Check separately whether the **Pentaho reporting plugin** has a release matching the new Fineract. The plugin is versioned independently and is not part of the MifosX release bundle.
+
+## 2. Update the pins
+
+Change [VERSIONS.md](../src/deployer/manifests/mifosx/VERSIONS.md) and the manifests under `src/deployer/manifests/mifosx/` **in the same commit**, so the table never disagrees with what deploys.
+
+Confirm nothing was missed — every `image:` in the manifests should appear in the table:
+
+```bash
+grep -h '^\s*image:' src/deployer/manifests/mifosx/*.yaml | grep -v '#' | sed 's/.*image: *//' | sort -u
+```
+
+Two pins are not `image:` lines and are easy to overlook:
+
+- the **Pentaho plugin zip**, fetched by the `fetch-reporting-plugin` initContainer in `fineract-server-deployment.yaml`
+- the shared **PostgreSQL** version, in `src/deployer/helm/infra/values.yaml`
+
+## 3. Rebuild the images Gazelle builds itself
+
+Three modules publish no container image, so Gazelle builds them from source: the **Workflow Engine**, the **Credit Bureau** and **Loan Assessment**. A new MifosX release does not rebuild them — you do.
+
+Always use the repo's builder rather than raw `docker buildx`, so the build stays reproducible:
+
+```bash
+docker login
+git clone https://github.com/openMF/mifos-workflow.git
+src/utils/build-and-import-image.sh \
+    -n <namespace>/mifos-workflow -t <tag> \
+    -c mifos-workflow -f mifos-workflow/Dockerfile \
+    --platform linux/amd64,linux/arm64 --push
+```
+
+Repeat for `mifos-x-credit-bureau-plugin` and `reactive-loan-module`. `--platform linux/amd64,linux/arm64` is what keeps Apple Silicon and Raspberry Pi working and requires `--push`; see [BUILDING-IMAGES.md](BUILDING-IMAGES.md). Then update the pins from step 2 to the tags you pushed.
+
+If a module fails to build against the new Fineract, fix it **upstream** rather than in a fork — that is what keeps the next upgrade cheap.
+
+## 4. Redeploy
+
+```bash
+./run.sh -m deploy -a mifosx
+```
+
+The deploy warns if any image in the manifests cannot be found in a registry, which catches a pin you bumped but never published. The warning is advisory and does not stop the deploy.
+
+If the upgrade added a module with its own ingress, add the hostname to `MIFOSXHOSTS` in `src/environmentSetup/environmentSetup.sh` and re-run `sudo ./setup-env.sh -u $USER`, otherwise the URL will not resolve.
+
+## 5. Verify
+
+Check the pods and ingresses first:
+
+```bash
+kubectl -n mifosx get pods      # every pod 1/1
+kubectl -n mifosx get ingress   # one host per exposed module
+```
+
+Note that the deploy only waits on Fineract's tenant APIs, so a module can be broken while the deploy still reports success. Then exercise each module end to end:
+
+```bash
+./src/utils/demo-workflow.sh          # onboards a client and activates it in Fineract
+./src/utils/demo-credit-bureau.sh     # registers a bureau and pulls a mock report
+./src/utils/demo-message-gateway.sh   # sends a message through the Dummy provider
+./src/utils/demo-loan-module.sh       # creates a loan and waits for the risk row
+```
+
+Each script fails loudly if MifosX is not deployed. If one fails after an upgrade, that module is the regression — the scripts are the fastest way to find which.
+
+Confirm reporting separately, since it is staged into the Fineract pod rather than run as its own service:
+
+```bash
+kubectl -n mifosx logs deploy/fineract-server -c fetch-reporting-plugin | tail -5
+```
+
+## 6. Raise the PR
+
+Include the before and after versions, and say which images you rebuilt and where you pushed them. Update [MIFOSX.md](MIFOSX.md) if the upgrade changed how a component is used, and add an entry to [RELEASE-NOTES.md](RELEASE-NOTES.md).
+
+---
+
+## Things that have bitten us before
+
+- **A module image built for one architecture only.** It deploys fine on the machine that built it and fails on Apple Silicon or a Pi. Always build multi-arch.
+- **A pin bumped but never pushed.** The pods sit in `ImagePullBackOff` and the deploy times out on the tenant wait with an unhelpful message. The image check at deploy time is there to catch this earlier.
+- **The Pentaho plugin drifting from Fineract.** The plugin is released separately, so a Fineract bump can leave reporting on an incompatible plugin. Reporting failures usually surface as a 403 from `runreports`, not as a startup error.
+- **Assuming the deploy verifies the modules.** It does not — it waits on Fineract only. Run the demo scripts.

--- a/src/deployer/manifests/mifosx/VERSIONS.md
+++ b/src/deployer/manifests/mifosx/VERSIONS.md
@@ -1,0 +1,50 @@
+# MifosX — Pinned Image Versions
+
+Single source of truth for the container images used by the MifosX deployment in Mifos Gazelle. **No `:latest` tags.** When adopting a new MifosX release, bump the pins here and in the referenced manifests together — see [UPGRADE-RUNBOOK.md](../../../../docs/UPGRADE-RUNBOOK.md).
+
+Gazelle currently tracks the MifosX **25.12.25** release line.
+
+## Application images
+
+| Component | Image | Tag | Manifest |
+|---|---|---|---|
+| Fineract (core) | `openmf/fineract` | `1.14.0` | `fineract-server-deployment.yaml` |
+| Web App | `openmf/web-app` | `dev-10d24b8` | `web-app-deployment.yaml` |
+| Workflow Engine | `kanishksingh23/mifos-workflow` | `21082026` | `mifos-workflow-deployment.yaml` |
+| Credit Bureau | `kanishksingh23/mifos-credit-bureau` | `21082026` | `credit-bureau-deployment.yaml` |
+| SMS & Messaging | `openmf/message-gateway` | `dev-51abedb` | `message-gateway-deployment.yaml` |
+| Loan Assessment | `kanishksingh23/mifos-x-reactive-loan-module` | `09082026` | `loan-module-deployment.yaml` |
+
+Three of these are **built from source and pinned to a personal DockerHub namespace**, because neither the workflow engine, the credit bureau nor the loan module publishes a container image. They should move to `openmf` images once those are published. `docs/MIFOSX.md` covers the build and publish commands.
+
+The web app is pinned to a `dev-` tag rather than the `1.12` release image because that release image is amd64-only, which breaks Gazelle's ARM64 targets. `dev-10d24b8` is the nearest multi-architecture build.
+
+## Helper images used by initContainers
+
+| Image | Used by | Purpose |
+|---|---|---|
+| `alpine:3.20` | `fineract-server` → `fetch-reporting-plugin` | Downloads and stages the Pentaho plugin and fonts |
+| `postgres:16-alpine` | `fineract-server` → `enable-loan-events` | Enables the Fineract external events the loan module consumes |
+| `postgres:16-alpine` | `credit-bureau` → `ensure-creditbureau-db` | Creates the `creditbureau` database if absent |
+| `postgres:16-alpine` | `message-gateway` → `ensure-messagegateway-db` | Creates the `messagegateway` database if absent |
+| `postgres:16-alpine` | `loan-module` → `ensure-loanrisk-db` | Creates the `loanrisk` database if absent |
+| `curlimages/curl:8.10.1` | `credit-bureau` → `wait-for-fineract` | Blocks until the Fineract API answers |
+| `busybox:1.36` | `mifos-workflow` → `wait-postgres`, `wait-fineract` | Blocks until PostgreSQL and Fineract are reachable |
+
+## Non-image artefacts
+
+| Artefact | Version | Where it is pinned |
+|---|---|---|
+| Pentaho reporting plugin | `MifosReportingPlugin-1.14.0` | downloaded from SourceForge by the `fetch-reporting-plugin` initContainer in `fineract-server-deployment.yaml` |
+
+This one is not a container image, so it does not appear in any `image:` line — it is a zip fetched at pod startup. Bump it in the initContainer script when the plugin releases a version matching the Fineract in use.
+
+## Shared infrastructure
+
+Deployed by the `infra` chart, not by the MifosX manifests, and shared with the other DPGs.
+
+| Component | Image | Tag | Pinned in |
+|---|---|---|---|
+| PostgreSQL | `bitnamilegacy/postgresql` | `16.6.0` | `src/deployer/helm/infra/values.yaml` |
+
+Every MifosX component stores its data here: Fineract's per-tenant databases plus `mifos_flowable`, `creditbureau`, `messagegateway` and `loanrisk`.


### PR DESCRIPTION
## Summary

Nothing is recorded about which image versions make up the MifosX deployment or what to do
when a new MifosX release arrives.

- **`src/deployer/manifests/mifosx/VERSIONS.md`** is now the single source of truth
  for the pins: the six application images, the helper images the initContainers
  use, the Pentaho plugin, and the shared PostgreSQL from the infra chart. Every row
  names the manifest it is pinned in. No `latest` tags.
- **`docs/UPGRADE-RUNBOOK.md`** is the checklist for adopting a future release: read
  the MifosX release notes, move `VERSIONS.md` and the manifest pins together,
  rebuild the three modules Gazelle builds from source, redeploy, verify, raise the PR.
- **`docs/MIFOSX.md`** now links both from its Version Pins section, which is what
  that section was always meant to reference, the links were left out only because
  neither file existed yet.
 - All four `demo.sh` scripts were verified against this branch and passed: a client
onboarded to Active by the Workflow Engine, a mock credit report, an SMS reaching
DELIVERED through the Dummy provider, and a loan assessment row written via Kafka.


## Note

- **This PR also corrects six stale claims in `docs/MIFOSX.md`.** It already edits
  that file to restore the two links, so the fixes ride along rather than needing a
  ticket of their own. The one worth reading is the message gateway: the document
  said the gateway "accepts and records requests but cannot deliver", which is wrong
  twice over: without a provider bridge, `POST /sms` returns a 500, and with one the
  built-in Dummy provider does simulate delivery. Registering a bridge is the step
  that makes the module usable, and it appeared nowhere. The others are drift: a
  `{ ... }` placeholder where a runnable request belonged, two of four module
  databases listed, "three modules" where there are five, and a `/etc/hosts` note
  naming two of four module hostnames.
